### PR TITLE
chore(release): bump workspace version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,17 @@ resolver = "2"
 
 # Shared package metadata, inherited by member crates via `<key>.workspace = true`.
 [workspace.package]
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Diego Beltran Fernandez Prada <diego.fernandez@bahiasoftware.es>", "Victor Soñora Pombo", "Sergio Figueiras Gomez", "Miguel Boubeta Martinez", "Galicia Supercomputing Center (CESGA)"]
 license = "European Union Public Licence (EUPL), version 1.2 or – as soon they will be approved by the European Commission – subsequent versions of the EUPL."
 
 [workspace.dependencies]
-polypus-circuit    = { path = "crates/polypus-circuit", version = "0.4.0" }
-polypus-physics    = { path = "crates/polypus-physics", version = "0.4.0" }
-polypus-sim        = { path = "crates/polypus-sim", version = "0.4.0" }
-polypus-optimizers = { path = "crates/polypus-optimizers", version = "0.4.0" }
-polypus-logger     = { path = "crates/polypus-logger", version = "0.4.0" }
+polypus-circuit    = { path = "crates/polypus-circuit", version = "0.6.0" }
+polypus-physics    = { path = "crates/polypus-physics", version = "0.6.0" }
+polypus-sim        = { path = "crates/polypus-sim", version = "0.6.0" }
+polypus-optimizers = { path = "crates/polypus-optimizers", version = "0.6.0" }
+polypus-logger     = { path = "crates/polypus-logger", version = "0.6.0" }
 
 # Shared external dependencies pinned once for the whole workspace.
 # `log` is the logging facade every crate emits through; the concrete sink lives

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is built for researchers and engineers who need to:
 - swap between a local simulator, CESGA's CUNQA platform, or CESGA's QMIO real QPU without touching algorithm code,
 - keep a Python-friendly API while getting Rust-level performance on the hot paths (parameter binding, batched simulation).
 
-> **Status:** Polypus is under active development (current version: `0.4.0`) and is not yet published on PyPI. Install from source — see [Installation](#installation).
+> **Status:** Polypus is under active development (current version: `0.6.0`) and is not yet published on PyPI. Install from source — see [Installation](#installation).
 
 ## Key Features
 
@@ -325,7 +325,7 @@ If Polypus is useful in your research, please cite it:
   title   = {{Polypus: A Distributed Quantum Computing Library}},
   year    = {2026},
   url     = {https://github.com/Bahia-Software/polypus},
-  version = {0.4.0}
+  version = {0.6.0}
 }
 ```
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,7 +4,7 @@
 # (deny/warn/allow) are set in CI (`-- -D warnings`) and, optionally, in the
 # `[workspace.lints]` table of the root Cargo.toml (see AI_GUIDELINES §7).
 
-# Polypus is pre-1.0 (0.4.0) and under active development: don't hold back lints
+# Polypus is pre-1.0 (0.6.0) and under active development: don't hold back lints
 # just to preserve a frozen public API.
 avoid-breaking-exported-api = false
 


### PR DESCRIPTION
Cargo.toml, README, and clippy.toml still referenced 0.4.0 despite v0.6.0 being the current tagged release.