### PR TITLE
fix(circuit): reject non-finite gate parameters (#38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ logs/
 
 CLAUDE.md
 AI_GUIDELINES.md
-.claude/*
+.claude/

--- a/crates/polypus-circuit/src/circuit.rs
+++ b/crates/polypus-circuit/src/circuit.rs
@@ -503,7 +503,7 @@ impl ConcreteCircuit {
     /// was assembled manually.
     pub fn to_qasm2(&self) -> String {
         qasm::write_qasm2(self.num_qubits, self.num_clbits(), &self.gates, &[]).expect(
-            "ConcreteCircuit contains an unbound Param; use ParameterizedCircuit::assign_parameters",
+            "ConcreteCircuit contains an unbound Param or a non-finite fixed angle; use ParameterizedCircuit::assign_parameters",
         )
     }
 
@@ -524,7 +524,7 @@ impl ConcreteCircuit {
     /// was assembled manually.
     pub fn to_qir(&self) -> String {
         qir::write_qir(self.num_qubits, self.num_clbits(), &self.gates, &[]).expect(
-            "ConcreteCircuit contains an unbound Param; use ParameterizedCircuit::assign_parameters",
+            "ConcreteCircuit contains an unbound Param or a non-finite fixed angle; use ParameterizedCircuit::assign_parameters",
         )
     }
 

--- a/crates/polypus-circuit/src/circuit.rs
+++ b/crates/polypus-circuit/src/circuit.rs
@@ -110,6 +110,19 @@ impl ParameterizedCircuit {
         }
     }
 
+    /// Reject a `Fixed` angle that is not finite (`NaN` or infinity) at
+    /// construction time. `Param` angles are unchecked here — their values are
+    /// only known at binding time, where [`GateParam::resolve`] enforces the
+    /// same rule.
+    fn check_finite(param: &GateParam) -> Result<(), CircuitError> {
+        if let GateParam::Fixed(v) = param {
+            if !v.is_finite() {
+                return Err(CircuitError::NonFiniteParam);
+            }
+        }
+        Ok(())
+    }
+
     /// Fallible version of [`push`](Self::push): append a raw
     /// [`GateInstruction`], validating qubit indices and keeping `num_params`
     /// in sync. Use this from host languages (e.g. Python bindings) where
@@ -128,6 +141,7 @@ impl ParameterizedCircuit {
             | GateInstruction::Ry { qubit, theta }
             | GateInstruction::Rz { qubit, theta } => {
                 self.check_qubit(*qubit)?;
+                Self::check_finite(theta)?;
                 let theta = *theta;
                 self.track_param(&theta);
             }
@@ -136,11 +150,13 @@ impl ParameterizedCircuit {
             }
             GateInstruction::Rzz { q0, q1, theta } | GateInstruction::Rxx { q0, q1, theta } => {
                 self.check_pair(*q0, *q1)?;
+                Self::check_finite(theta)?;
                 let theta = *theta;
                 self.track_param(&theta);
             }
             GateInstruction::Cp { q0, q1, theta } => {
                 self.check_pair(*q0, *q1)?;
+                Self::check_finite(theta)?;
                 let theta = *theta;
                 self.track_param(&theta);
             }
@@ -151,6 +167,9 @@ impl ParameterizedCircuit {
                 lam,
             } => {
                 self.check_qubit(*qubit)?;
+                Self::check_finite(theta)?;
+                Self::check_finite(phi)?;
+                Self::check_finite(lam)?;
                 let (theta, phi, lam) = (*theta, *phi, *lam);
                 self.track_param(&theta);
                 self.track_param(&phi);
@@ -175,9 +194,9 @@ impl ParameterizedCircuit {
     ///
     /// # Panics
     ///
-    /// Panics on out-of-range qubit indices or a two-qubit gate whose qubits
-    /// coincide (see type-level docs). For a fallible variant, use
-    /// [`try_push`](Self::try_push).
+    /// Panics on out-of-range qubit indices, a two-qubit gate whose qubits
+    /// coincide (see type-level docs), or a non-finite fixed angle (`NaN` or
+    /// infinity). For a fallible variant, use [`try_push`](Self::try_push).
     pub fn push(mut self, gate: GateInstruction) -> Self {
         if let Err(e) = self.try_push(gate) {
             panic!("{e}");

--- a/crates/polypus-circuit/src/circuit.rs
+++ b/crates/polypus-circuit/src/circuit.rs
@@ -495,10 +495,12 @@ impl ConcreteCircuit {
     ///
     /// # Panics
     ///
-    /// Panics if a gate contains an unbound [`GateParam::Param`]. This cannot
-    /// happen for circuits produced by
-    /// [`ParameterizedCircuit::assign_parameters`]; it is only possible when
-    /// the `gates` field was assembled manually.
+    /// Panics if a gate parameter cannot be resolved: either an unbound
+    /// [`GateParam::Param`], or a [`GateParam::Fixed`] holding a non-finite
+    /// value (`NaN` or infinity). Neither can happen for circuits produced by
+    /// [`ParameterizedCircuit::assign_parameters`] (which rejects non-finite
+    /// values at binding time); both are only possible when the `gates` field
+    /// was assembled manually.
     pub fn to_qasm2(&self) -> String {
         qasm::write_qasm2(self.num_qubits, self.num_clbits(), &self.gates, &[]).expect(
             "ConcreteCircuit contains an unbound Param; use ParameterizedCircuit::assign_parameters",
@@ -514,10 +516,12 @@ impl ConcreteCircuit {
     ///
     /// # Panics
     ///
-    /// Panics if a gate contains an unbound [`GateParam::Param`]. This cannot
-    /// happen for circuits produced by
-    /// [`ParameterizedCircuit::assign_parameters`]; it is only possible when
-    /// the `gates` field was assembled manually.
+    /// Panics if a gate parameter cannot be resolved: either an unbound
+    /// [`GateParam::Param`], or a [`GateParam::Fixed`] holding a non-finite
+    /// value (`NaN` or infinity). Neither can happen for circuits produced by
+    /// [`ParameterizedCircuit::assign_parameters`] (which rejects non-finite
+    /// values at binding time); both are only possible when the `gates` field
+    /// was assembled manually.
     pub fn to_qir(&self) -> String {
         qir::write_qir(self.num_qubits, self.num_clbits(), &self.gates, &[]).expect(
             "ConcreteCircuit contains an unbound Param; use ParameterizedCircuit::assign_parameters",

--- a/crates/polypus-circuit/src/error.rs
+++ b/crates/polypus-circuit/src/error.rs
@@ -14,6 +14,12 @@ pub enum CircuitError {
     /// the provided parameter values. This can only happen when the circuit
     /// was assembled manually (the fluent builder keeps `num_params` in sync).
     ParamIndexOutOfBounds { index: usize, num_params: usize },
+    /// A gate parameter resolved to a non-finite value (`NaN` or infinity),
+    /// which is not a valid rotation angle. Rejected both at construction (a
+    /// `Fixed` angle) and at binding time (a caller-supplied value bound to a
+    /// `Param`), matching the native simulator's reference behaviour
+    /// (contract C-2).
+    NonFiniteParam,
     /// A gate addresses a qubit index `>= num_qubits`.
     QubitOutOfRange { qubit: usize, num_qubits: usize },
     /// A two-qubit gate was given the same qubit twice.
@@ -44,6 +50,10 @@ impl fmt::Display for CircuitError {
             CircuitError::ParamIndexOutOfBounds { index, num_params } => write!(
                 f,
                 "gate references parameter index {index}, but only {num_params} parameter value(s) are available"
+            ),
+            CircuitError::NonFiniteParam => write!(
+                f,
+                "gate parameter resolved to a non-finite value (NaN or infinity)"
             ),
             CircuitError::QubitOutOfRange { qubit, num_qubits } => write!(
                 f,

--- a/crates/polypus-circuit/src/gate.rs
+++ b/crates/polypus-circuit/src/gate.rs
@@ -33,18 +33,23 @@ impl From<f64> for GateParam {
 
 impl GateParam {
     /// Resolve to a concrete value, looking up `Param` indices in `params`.
+    ///
+    /// Rejects a non-finite result — whether from a `Fixed` angle or from a
+    /// caller-supplied value bound to a `Param` — with
+    /// [`CircuitError::NonFiniteParam`], since `NaN`/infinity is not a valid
+    /// rotation angle (mirrors the simulator, contract C-2).
     pub(crate) fn resolve(&self, params: &[f64]) -> Result<f64, CircuitError> {
-        match *self {
-            GateParam::Fixed(v) => Ok(v),
-            GateParam::Param(i) => {
-                params
-                    .get(i)
-                    .copied()
-                    .ok_or(CircuitError::ParamIndexOutOfBounds {
-                        index: i,
-                        num_params: params.len(),
-                    })
-            }
+        let value = match *self {
+            GateParam::Fixed(v) => v,
+            GateParam::Param(i) => *params.get(i).ok_or(CircuitError::ParamIndexOutOfBounds {
+                index: i,
+                num_params: params.len(),
+            })?,
+        };
+        if value.is_finite() {
+            Ok(value)
+        } else {
+            Err(CircuitError::NonFiniteParam)
         }
     }
 }
@@ -214,13 +219,26 @@ mod tests {
 
     #[test]
     fn test_resolve_special_values() {
+        // A `Fixed` non-finite angle is rejected directly.
+        assert_eq!(
+            GateParam::Fixed(f64::NAN).resolve(&[]),
+            Err(CircuitError::NonFiniteParam)
+        );
+        assert_eq!(
+            GateParam::Fixed(f64::INFINITY).resolve(&[]),
+            Err(CircuitError::NonFiniteParam)
+        );
+
+        // A caller-supplied non-finite value bound to a `Param` is also rejected.
         let params = vec![f64::INFINITY, f64::NAN];
-
-        let inf = GateParam::Param(0).resolve(&params).unwrap();
-        let nan = GateParam::Param(1).resolve(&params).unwrap();
-
-        assert!(inf.is_infinite());
-        assert!(nan.is_nan());
+        assert_eq!(
+            GateParam::Param(0).resolve(&params),
+            Err(CircuitError::NonFiniteParam)
+        );
+        assert_eq!(
+            GateParam::Param(1).resolve(&params),
+            Err(CircuitError::NonFiniteParam)
+        );
     }
 
     #[test]

--- a/crates/polypus-circuit/src/qasm_import.rs
+++ b/crates/polypus-circuit/src/qasm_import.rs
@@ -561,7 +561,15 @@ impl Parser {
             let mut values = Vec::new();
             if self.peek() != Some(&Tok::RParen) {
                 loop {
-                    values.push(self.expr()?);
+                    let line = self.line();
+                    let value = self.expr()?;
+                    if !value.is_finite() {
+                        return Err(err(
+                            line,
+                            "parameter expression evaluated to a non-finite value (NaN or infinity)",
+                        ));
+                    }
+                    values.push(value);
                     match self.next("',' or ')'")? {
                         (Tok::Comma, _) => continue,
                         (Tok::RParen, _) => break,
@@ -800,8 +808,13 @@ impl Parser {
                     v *= self.factor()?;
                 }
                 Some(Tok::Slash) => {
+                    let line = self.line();
                     self.pos += 1;
-                    v /= self.factor()?;
+                    let divisor = self.factor()?;
+                    if divisor == 0.0 {
+                        return Err(err(line, "division by zero in parameter expression"));
+                    }
+                    v /= divisor;
                 }
                 _ => return Ok(v),
             }

--- a/crates/polypus-circuit/tests/circuit.rs
+++ b/crates/polypus-circuit/tests/circuit.rs
@@ -127,6 +127,28 @@ fn test_parameterized_circuit_assign_parameters_param_index_out_of_bounds() {
 }
 
 #[test]
+fn test_parameterized_circuit_assign_parameters_rejects_non_finite() {
+    let qc = ParameterizedCircuit::new(2)
+        .rx(0, Param(0))
+        .u(1, Param(1), Param(2), Param(3));
+    assert_eq!(qc.num_params, 4);
+
+    // A caller-supplied non-finite value bound to a `Param` is rejected.
+    assert_eq!(
+        qc.assign_parameters(&[f64::NAN, 0.1, 0.2, 0.3]),
+        Err(CircuitError::NonFiniteParam)
+    );
+    assert_eq!(
+        qc.assign_parameters(&[0.1, f64::INFINITY, 0.2, 0.3]),
+        Err(CircuitError::NonFiniteParam)
+    );
+    assert_eq!(
+        qc.assign_parameters(&[0.1, 0.2, 0.3, f64::NEG_INFINITY]),
+        Err(CircuitError::NonFiniteParam)
+    );
+}
+
+#[test]
 fn test_parameterized_circuit_num_clbits_no_measurements() {
     let qc = ParameterizedCircuit::new(2);
 
@@ -395,6 +417,101 @@ fn test_parameterized_circuit_push_out_of_range() {
 #[should_panic]
 fn test_parameterized_circuit_push_same_qubits() {
     let _qc = ParameterizedCircuit::new(2).push(GateInstruction::Cx(0, 0));
+}
+
+/// Mirror of `polypus-sim`'s `non_finite_angle_is_rejected`
+/// (crates/polypus-sim/tests/gate_matrices.rs): the circuit layer rejects a
+/// non-finite fixed angle with its own error type, matching the simulator's
+/// reference behaviour (contract C-2).
+#[test]
+fn non_finite_angle_is_rejected() {
+    let mut qc = ParameterizedCircuit::new(1);
+    let err = qc
+        .try_push(GateInstruction::Rx {
+            qubit: 0,
+            theta: GateParam::Fixed(f64::NAN),
+        })
+        .unwrap_err();
+    assert_eq!(err, CircuitError::NonFiniteParam);
+}
+
+#[test]
+fn test_parameterized_circuit_try_push_rejects_non_finite() {
+    let mut qc = ParameterizedCircuit::new(1);
+
+    // Single-angle gate: infinity is rejected as well as NaN.
+    assert_eq!(
+        qc.try_push(GateInstruction::Rx {
+            qubit: 0,
+            theta: GateParam::Fixed(f64::INFINITY),
+        }),
+        Err(CircuitError::NonFiniteParam)
+    );
+
+    // Multi-angle U gate: a non-finite value in any of the three slots is
+    // rejected (NaN in phi, then -inf in theta).
+    assert_eq!(
+        qc.try_push(GateInstruction::U {
+            qubit: 0,
+            theta: GateParam::Fixed(1.0),
+            phi: GateParam::Fixed(f64::NAN),
+            lam: GateParam::Fixed(0.5),
+        }),
+        Err(CircuitError::NonFiniteParam)
+    );
+    assert_eq!(
+        qc.try_push(GateInstruction::U {
+            qubit: 0,
+            theta: GateParam::Fixed(f64::NEG_INFINITY),
+            phi: GateParam::Fixed(1.0),
+            lam: GateParam::Fixed(0.5),
+        }),
+        Err(CircuitError::NonFiniteParam)
+    );
+
+    // A finite `Param` reference is unaffected — construction-time validation
+    // only inspects `Fixed` angles.
+    assert_eq!(
+        qc.try_push(GateInstruction::Rx {
+            qubit: 0,
+            theta: GateParam::Param(0),
+        }),
+        Ok(())
+    );
+
+    // Only the valid gate made it into the circuit.
+    assert_eq!(qc.gates.len(), 1);
+}
+
+/// Regression for issue #38 (acceptance criterion): a non-finite angle must
+/// never reach the QASM exporter as a literal `NaN`/`inf` string. Both a bound
+/// free parameter and a hand-assembled fixed angle are rejected at export.
+#[test]
+fn test_export_rejects_non_finite_angle() {
+    // Route 1: a free parameter bound to a non-finite value.
+    let parameterized = ParameterizedCircuit::new(1).rx(0, Param(0));
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert_eq!(
+            parameterized.to_qasm2_with_params(&[bad]),
+            Err(CircuitError::NonFiniteParam)
+        );
+    }
+
+    // Route 2: a circuit assembled by hand with a fixed non-finite angle,
+    // bypassing the builder's construction-time guard — the exporter itself
+    // still refuses it, so no `NaN`/`inf` literal is ever serialised.
+    let hand_assembled = ParameterizedCircuit {
+        num_qubits: 1,
+        num_params: 0,
+        gates: vec![GateInstruction::Rx {
+            qubit: 0,
+            theta: GateParam::Fixed(f64::INFINITY),
+        }],
+    };
+    assert_eq!(
+        hand_assembled.to_qasm2_with_params(&[]),
+        Err(CircuitError::NonFiniteParam)
+    );
 }
 
 // ConcreteCircuit

--- a/crates/polypus-circuit/tests/circuit_qasm.rs
+++ b/crates/polypus-circuit/tests/circuit_qasm.rs
@@ -293,6 +293,21 @@ fn concrete_circuit_panics_on_unbound_param() {
     let _ = qc.to_qasm2();
 }
 
+#[test]
+#[should_panic(expected = "non-finite")]
+fn concrete_circuit_panics_on_non_finite_fixed_angle() {
+    // A hand-assembled ConcreteCircuit bypasses the builder's validation; the
+    // exporter still refuses a non-finite fixed angle rather than serialising it.
+    let qc = ConcreteCircuit {
+        num_qubits: 1,
+        gates: vec![GateInstruction::Rx {
+            qubit: 0,
+            theta: GateParam::Fixed(f64::NAN),
+        }],
+    };
+    let _ = qc.to_qasm2();
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Real-world case: QAOA MaxCut on 4 qubits (ring graph), p = 1
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/polypus-circuit/tests/circuit_qir.rs
+++ b/crates/polypus-circuit/tests/circuit_qir.rs
@@ -5,7 +5,9 @@
 //! The optional `qir_base_profile_module_is_valid_llvm` test additionally
 //! parses the output with `llvm-as` when it is available on the host.
 
-use polypus_circuit::{CircuitError, GateInstruction, Param, ParameterizedCircuit};
+use polypus_circuit::{
+    CircuitError, ConcreteCircuit, GateInstruction, GateParam, Param, ParameterizedCircuit,
+};
 
 /// Collect just the `call void @...` instruction lines (without the leading
 /// indentation), in order — handy for asserting on exact gate sequences.
@@ -241,6 +243,21 @@ fn concrete_circuit_to_qir_matches_parameterized() {
     let pc = ParameterizedCircuit::new(1).rx(0, 0.5).measure(0, 0);
     let concrete = pc.assign_parameters(&[]).unwrap();
     assert_eq!(concrete.to_qir(), pc.to_qir_with_params(&[]).unwrap());
+}
+
+#[test]
+#[should_panic(expected = "non-finite")]
+fn concrete_circuit_to_qir_panics_on_non_finite_fixed_angle() {
+    // A hand-assembled ConcreteCircuit bypasses the builder's validation; the
+    // QIR exporter still refuses a non-finite fixed angle rather than emitting it.
+    let qc = ConcreteCircuit {
+        num_qubits: 1,
+        gates: vec![GateInstruction::Rx {
+            qubit: 0,
+            theta: GateParam::Fixed(f64::INFINITY),
+        }],
+    };
+    let _ = qc.to_qir();
 }
 
 #[test]

--- a/crates/polypus-circuit/tests/error.rs
+++ b/crates/polypus-circuit/tests/error.rs
@@ -53,6 +53,16 @@ fn test_circuit_error_display_identical_qubits() {
 }
 
 #[test]
+fn test_circuit_error_display_non_finite_param() {
+    let err = CircuitError::NonFiniteParam;
+
+    let msg = format!("{err}");
+
+    assert!(msg.contains("non-finite"));
+    assert!(msg.contains("NaN or infinity"));
+}
+
+#[test]
 fn test_circuit_error_display_parse() {
     let err = CircuitError::Parse {
         line: 10,

--- a/crates/polypus-circuit/tests/qasm_import.rs
+++ b/crates/polypus-circuit/tests/qasm_import.rs
@@ -352,6 +352,23 @@ fn rejects_reset_and_if() {
 }
 
 #[test]
+fn rejects_division_by_zero_in_parameter() {
+    let src = "OPENQASM 2.0;\nqreg q[1];\nrx(1/0) q[0];\n";
+    assert_parse_err(src, "division by zero", 3);
+}
+
+#[test]
+fn rejects_non_finite_parameter_expression() {
+    // ln(0) = -inf: caught by the general finiteness guard.
+    let src = "OPENQASM 2.0;\nqreg q[1];\nrx(ln(0)) q[0];\n";
+    assert_parse_err(src, "non-finite", 3);
+
+    // 0^-1 = inf via powf: same guard, different route.
+    let src = "OPENQASM 2.0;\nqreg q[1];\nrx(0^-1) q[0];\n";
+    assert_parse_err(src, "non-finite", 3);
+}
+
+#[test]
 fn rejects_truncated_input() {
     let src = "OPENQASM 2.0;\nqreg q[1];\nh q[0]";
     assert!(matches!(

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -115,6 +115,12 @@ Corollaries:
   reproduces the same instruction sequence and parameters as `c`.
 - Adding a gate is a **four-place change** plus a row in the equivalence test;
   a PR adding it in fewer than four places must be rejected.
+- **Non-finite parameters are rejected uniformly.** A `NaN` or infinite angle
+  is never a valid parameter value: circuit construction and parameter binding
+  reject it (`CircuitError::NonFiniteParam`), the OpenQASM importer rejects it
+  at parse time (`CircuitError::Parse`), the QASM and QIR exporters refuse to
+  serialise it, and the simulator rejects it (`SimError::NonFiniteAmplitude`).
+  No producer may emit, and no consumer may accept, a non-finite parameter.
 
 *Known breaks (audit C2, C3): `cp` is missing from the importer, and its QIR
 decomposition is not unitarily equivalent.*


### PR DESCRIPTION
## Summary

`GateParam` accepted `NaN`/`±inf` with zero validation, so the QASM exporter
could emit invalid OpenQASM (e.g. `rx(NaN) q[0];`) and the QASM constant-
expression parser silently produced `inf` on division by zero. The native
simulator already rejects non-finite angles, so the circuit layer was
inconsistent with its own reference implementation.

- `GateParam::resolve` now rejects a non-finite result for both `Fixed` and
  `Param` arms with the new `CircuitError::NonFiniteParam`, closing the
  `assign_parameters` and QASM/QIR exporter holes in one place (both funnel
  through `resolve`).
- `try_push` checks `.is_finite()` on `Fixed` angles for every angle-bearing
  gate, failing fast at construction time.
- The QASM importer's expression parser adds an explicit division-by-zero
  check and a general non-finite guard on parsed parameter expressions,
  both surfaced as `CircuitError::Parse` with the source line.
- `ConcreteCircuit::to_qasm2`/`to_qir`'s existing `.expect()` panic (only
  reachable via manual, unsupported `ConcreteCircuit` assembly) now also
  covers and documents the non-finite case, instead of misreporting it as an
  unbound `Param`.
- `docs/CONTRACTS.md` (C-2) gains a corollary documenting uniform rejection
  of non-finite parameters across exporter, importer and simulator.

Closes #38.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers --all-features`
- [x] New tests: `try_push`/`assign_parameters` rejection (NaN/inf), QASM
      import rejection (division by zero, `ln(0)`, `0^-1`), exporter
      regression test asserting no `NaN`/`inf` literal can ever be
      serialized, `Display` test for `CircuitError::NonFiniteParam`, and
      `should_panic` coverage for the hand-assembled `ConcreteCircuit` edge
      case in both QASM and QIR export.