### PR TITLE
fix(bindings): expose real seeding + run/train manifest (closes #34, C-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ bash install.sh --no-tests
 import polypus
 
 bell = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
-counts = polypus.run_quantum_circuit(bell, shots=1000, infrastructure="local")
-print(counts)  # e.g. {'00': 512, '11': 488}
+result = polypus.run_quantum_circuit(bell, shots=1000, infrastructure="local")
+print(result.counts[0])  # e.g. {'00': 512, '11': 488}
 ```
 
 See [Usage](#usage) for Qiskit circuits, multi-QPU distribution, and variational training.
@@ -140,6 +140,8 @@ Set `n_qpus > 1` to split the shots across available QPUs and reduce execution t
 result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10)
 ```
 
+Both calls return a `RunResult`: `result.counts` holds the measurement payload — a `list[dict[str, int]]` for a single QPU, or a single merged `dict[str, int]` when `n_qpus > 1`. The manifest fields `result.id`, `result.seed`, `result.backend` and `result.infrastructure` record the run for logging and replay (`seed` is the effective RNG seed on the native `"polypus"` backend, `None` otherwise).
+
 ### Training Variational Circuits
 
 Polypus optimizes variational quantum circuits via `polypus.train()`. The optimizer is selected by passing a method object as the second argument. Polypus distributes the population individuals across the available QPUs automatically.
@@ -157,13 +159,14 @@ The common parameters for all methods are:
 | `nodes` | Number of nodes (CUNQA only) |
 | `cores_per_qpu` | Cores per QPU (CUNQA only) |
 | `id` | Experiment identifier for logging |
+| `seed` | Optional RNG seed for a reproducible run (default: drawn from OS entropy) |
 
 If CUNQA is not available, set `infrastructure="local"`.
 
 #### Differential Evolution
 
 ```python
-result_params = polypus.train(
+result = polypus.train(
     qc,
     polypus.DE(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, tolerance=TOL),
     shots=N_SHOTS,
@@ -177,10 +180,22 @@ result_params = polypus.train(
 )
 ```
 
+`train()` (and `qml.train()`) return a `TrainResult` carrying the full optimization outcome, not just the tuned parameters:
+
+```python
+print(result.best_params)     # list[float] — the optimized parameters
+print(result.best_fitness)    # float — cost/fitness at those parameters
+print(result.iterations_run)  # int — iterations actually run (early-stopping aware)
+print(result.converged)       # bool — whether the convergence criterion was met
+print(result.seed)            # int — the effective RNG seed; pass it back as seed=... to reproduce the run
+```
+
+Pin reproducibility with the `seed` keyword (`polypus.train(..., seed=42)`) or on the optimizer itself (`polypus.DE(..., seed=42)`); with no seed, one is drawn from OS entropy and reported back in `result.seed`.
+
 #### Particle Swarm Optimization
 
 ```python
-result_params = polypus.train(
+result = polypus.train(
     qc,
     polypus.PSO(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE,
                 bounds=(0.0, np.pi), tolerance=TOL),
@@ -200,7 +215,7 @@ result_params = polypus.train(
 `QNG` requires a `variance_function` callable that estimates the diagonal quantum Fisher information matrix element for each parameter. Default hyperparameters: `learning_rate=0.1`, `finite_difference_step=0.1`, `tikhonov_reg=0.05`.
 
 ```python
-result_params = polypus.train(
+result = polypus.train(
     qc,
     polypus.QNG(variance_fn, max_iters=MAX_GENERATIONS, bounds=(0.0, np.pi),
                 learning_rate=0.1, finite_difference_step=0.1, tikhonov_reg=0.05),
@@ -228,7 +243,7 @@ import polypus
 
 # Fully bound circuit → run directly
 bell = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
-counts = polypus.run_quantum_circuit(bell, shots=1000, infrastructure="local")
+result = polypus.run_quantum_circuit(bell, shots=1000, infrastructure="local")
 
 # Parameterized ansatz → train (binding happens in Rust, GIL-free)
 qaoa = (polypus.Circuit(4)
@@ -238,7 +253,7 @@ qaoa = (polypus.Circuit(4)
         .rx(0, polypus.Param(1)).rx(1, polypus.Param(1))
         .rx(2, polypus.Param(1)).rx(3, polypus.Param(1))
         .measure_all())
-params = polypus.train(qaoa, polypus.DE(generations=100, population_size=50),
+result = polypus.train(qaoa, polypus.DE(generations=100, population_size=50),
                        shots=1024, n_qpus=1, dimensions=2,
                        expectation_function=my_cost, infrastructure="local",
                        nodes=1, cores_per_qpu=1, id="qaoa")

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -247,7 +247,10 @@ def _hamming_cost_bitstring(bitstring: str) -> float:
 
 def _hamming_cost_counts(result) -> float:
     """SciPy objective: expected fraction of 1s from run_quantum_circuit output."""
-    counts = result[0] if isinstance(result, list) else result
+    # run_quantum_circuit returns a RunResult wrapping the counts payload
+    # (contract C-7): a list for a single QPU, a merged dict for n_qpus > 1.
+    payload = result.counts
+    counts = payload[0] if isinstance(payload, list) else payload
     total = sum(counts.values())
     return sum((bs.count("1") / len(bs)) * c for bs, c in counts.items()) / total
 

--- a/crates/polypus/src/bindings/de.rs
+++ b/crates/polypus/src/bindings/de.rs
@@ -9,17 +9,24 @@ pub struct DE {
     pub population_size: u32,
     #[pyo3(get, set)]
     pub tolerance: f64,
+    /// Optional RNG seed pinned on the optimizer object. Consumed by
+    /// `train`/`qml.train` per the precedence rule (contract C-7): the explicit
+    /// `seed` kwarg passed to the call wins; this field is the fallback; a fresh
+    /// OS-entropy value is used when neither is set. `None` by default.
+    #[pyo3(get, set)]
+    pub seed: Option<u64>,
 }
 
 #[pymethods]
 impl DE {
     #[new]
-    #[pyo3(signature = (generations = 100, population_size = 50, tolerance = 0.01))]
-    pub fn new(generations: u32, population_size: u32, tolerance: f64) -> Self {
+    #[pyo3(signature = (generations = 100, population_size = 50, tolerance = 0.01, seed = None))]
+    pub fn new(generations: u32, population_size: u32, tolerance: f64, seed: Option<u64>) -> Self {
         DE {
             generations,
             population_size,
             tolerance,
+            seed,
         }
     }
 }

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -18,6 +18,7 @@ use qng::{PyVarianceOracle, QNG};
 
 use crate::algorithms::{AlgorithmArgs, AlgorithmSingleRun, AlgorithmTrait, DistributeByShotsRun};
 use crate::evaluation::{CircuitSource, EvaluationOracle, QmlOracle, VqcOracle};
+use crate::infrastructure::execution_config::random_seed;
 #[cfg(feature = "qmio")]
 use crate::infrastructure::execution_config::QmioProgramFormat;
 use crate::infrastructure::{
@@ -29,20 +30,148 @@ use polypus_optimizers::{
 };
 use std::sync::Arc;
 
-/// Convert an [`OptimizationOutcome`] into the value the Python `train` /
-/// `qml_train` entry points return: the flat list of best parameters
-/// (`list[float]`).
+/// Result of [`run_quantum_circuit`]: the measurement counts plus the run
+/// manifest that lets a run be logged and replayed (contract C-7).
 ///
-/// The optimizers now return a richer native struct, but the public Python
-/// contract is still just the best-parameter vector, so the extra fields
-/// (fitness, iteration count, convergence flag) are intentionally dropped at
-/// this binding boundary.
-fn outcome_to_pyobject(py: Python<'_>, outcome: OptimizationOutcome) -> PyObject {
-    outcome
-        .best_params
-        .into_pyobject(py)
-        .expect("Error converting best_params to PyObject")
-        .unbind()
+/// `counts` is the exact payload the runner produced before this wrapper
+/// existed — a `list[dict[str, int]]` for a single-QPU run
+/// ([`AlgorithmSingleRun`](crate::algorithms::AlgorithmSingleRun)), or a single
+/// merged `dict[str, int]` for a distributed (`n_qpus > 1`) run
+/// ([`DistributeByShotsRun`](crate::algorithms::DistributeByShotsRun)); the
+/// per-dict format is contract C-3. The manifest fields make a native run
+/// reproducible: feeding the reported [`seed`](Self::seed) back into
+/// `run_quantum_circuit(..., backend="polypus")` reproduces the counts
+/// byte-for-byte. `seed` is `None` for non-native backends, which Polypus does
+/// not seed.
+#[pyclass(frozen)]
+pub struct RunResult {
+    /// Measurement counts. Shape depends on `n_qpus` (see the type docs).
+    #[pyo3(get)]
+    pub counts: PyObject,
+    /// Run identifier used for logging, temp files and SLURM job names.
+    #[pyo3(get)]
+    pub id: String,
+    /// Effective RNG seed used by the native backend's shot sampling
+    /// (user-supplied or OS-entropy). `None` for non-native backends.
+    #[pyo3(get)]
+    pub seed: Option<u64>,
+    /// Device selected within the infrastructure (`"aer"`, `"polypus"`, …).
+    #[pyo3(get)]
+    pub backend: String,
+    /// Execution infrastructure label (`"local"`, `"cunqa"`, `"qmio"`).
+    #[pyo3(get)]
+    pub infrastructure: String,
+}
+
+#[pymethods]
+impl RunResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "RunResult(id={:?}, seed={:?}, backend={:?}, infrastructure={:?})",
+            self.id, self.seed, self.backend, self.infrastructure
+        )
+    }
+}
+
+/// Result of [`train`] / [`qml_train`]: the full [`OptimizationOutcome`] plus
+/// the effective RNG seed used, so a training run can be reported and reproduced
+/// (contract C-7).
+///
+/// Replaces the former bare `list[float]` return, which discarded the fitness,
+/// iteration count and convergence flag. `best_params` remains available as a
+/// field; the previously dropped [`OptimizationOutcome`] fields are now exposed
+/// alongside it, and `seed` records the value that drove the optimizer.
+#[pyclass(frozen)]
+pub struct TrainResult {
+    /// Best parameter vector found.
+    #[pyo3(get)]
+    pub best_params: Vec<f64>,
+    /// Fitness of [`best_params`](Self::best_params) (higher is better).
+    #[pyo3(get)]
+    pub best_fitness: f64,
+    /// Generations/iterations actually executed (below the budget when an
+    /// early-stopping criterion fired).
+    #[pyo3(get)]
+    pub iterations_run: usize,
+    /// Whether the optimizer's convergence criterion was satisfied.
+    #[pyo3(get)]
+    pub converged: bool,
+    /// Effective RNG seed that drove the optimizer (and, on the native backend,
+    /// shot sampling): the explicit `seed` kwarg, else the optimizer object's
+    /// `seed`, else a fresh OS-entropy value (contract C-7).
+    #[pyo3(get)]
+    pub seed: u64,
+}
+
+#[pymethods]
+impl TrainResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "TrainResult(best_fitness={}, iterations_run={}, converged={}, seed={}, best_params={:?})",
+            self.best_fitness, self.iterations_run, self.converged, self.seed, self.best_params
+        )
+    }
+}
+
+/// Wrap an [`OptimizationOutcome`] and the effective `seed` into the
+/// [`TrainResult`] that `train` / `qml_train` now return.
+///
+/// This is the current public Python contract for those entry points (contract
+/// C-7): the whole outcome — `best_params`, `best_fitness`, `iterations_run`,
+/// `converged` — plus the `seed`, rather than the bare best-parameter list the
+/// former `outcome_to_pyobject` produced.
+fn outcome_to_train_result(
+    py: Python<'_>,
+    outcome: OptimizationOutcome,
+    seed: u64,
+) -> PyResult<PyObject> {
+    Py::new(
+        py,
+        TrainResult {
+            best_params: outcome.best_params,
+            best_fitness: outcome.best_fitness,
+            iterations_run: outcome.iterations_run,
+            converged: outcome.converged,
+            seed,
+        },
+    )
+    .map(|result| result.into_any())
+}
+
+/// Whether this `infrastructure` + `backend` combination actually runs on the
+/// native pure-Rust statevector backend — the only backend whose shot sampling
+/// Polypus seeds. It is reached exclusively via `infrastructure="local"` +
+/// `backend="polypus"`; every other combination runs Aer, CUNQA or QMIO, none
+/// of which consume `ExecutionConfig::seed`, so an explicit seed there would be
+/// silently ineffective (see [`run_quantum_circuit`]).
+fn uses_native_backend(infrastructure: &str, backend: &str) -> bool {
+    infrastructure == "local" && is_native_backend(backend)
+}
+
+/// Resolve the optimizer seed for `train` / `qml_train` (contract C-7).
+///
+/// Precedence: the explicit `seed` kwarg wins when provided; otherwise the
+/// `seed` field pinned on the `DE`/`PSO`/`QNG` instance; otherwise a fresh
+/// OS-entropy value. The chosen value both drives the optimizer and is reported
+/// back in the [`TrainResult`], so the run can be replayed.
+fn resolve_optimizer_seed(kwarg_seed: Option<u64>, method_seed: Option<u64>) -> u64 {
+    kwarg_seed.or(method_seed).unwrap_or_else(random_seed)
+}
+
+/// Read the `seed` field pinned on the optimizer object passed as `method`,
+/// whichever of `DE`/`PSO`/`QNG` it is (`None` if it is none of them — the type
+/// error is surfaced later by the dispatch that actually runs the optimizer).
+fn method_seed(method: &Bound<'_, PyAny>) -> Option<u64> {
+    if let Ok(de) = method.extract::<PyRef<DE>>() {
+        return de.seed;
+    }
+    if let Ok(pso) = method.extract::<PyRef<PSO>>() {
+        return pso.seed;
+    }
+    if let Ok(qng) = method.extract::<PyRef<QNG>>() {
+        return qng.seed;
+    }
+    None
 }
 
 /// Map the public `infrastructure` + `backend` strings and provider parameters
@@ -199,7 +328,18 @@ fn extract_bound_circuit(qc: &Bound<'_, PyAny>) -> PyResult<BoundCircuit> {
 /// `qc` may be a Qiskit `QuantumCircuit`, a `polypus.Circuit` (fully bound),
 /// or an OpenQASM 2.0 string. `backend` selects the local device: `"aer"`
 /// (default) or the pure-Rust `"polypus"` statevector simulator.
-#[pyfunction(signature=(qc, shots, infrastructure, n_qpus=1, sim_method="automatic", noise_model=None, backend="aer"))]
+///
+/// `seed` controls the native backend's shot sampling (contract C-7): with
+/// `backend="polypus"` an explicit `seed` reproduces the counts byte-for-byte,
+/// and omitting it draws a fresh OS-entropy seed so repeated runs give genuinely
+/// independent noise. Passing a `seed` with any other backend raises
+/// `ValueError` rather than silently ignoring it, since only the native backend
+/// is seeded here. Returns a [`RunResult`] carrying the counts plus a manifest
+/// (`id`, effective `seed`, `backend`, `infrastructure`) for logging and replay.
+#[pyfunction(signature=(qc, shots, infrastructure, n_qpus=1, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
+// Rich FFI entry point mirroring a many-kwarg Python API; same rationale and
+// convention as `train`/`qml_train` below.
+#[allow(clippy::too_many_arguments)]
 pub fn run_quantum_circuit<'py>(
     qc: Bound<'py, PyAny>,
     shots: u32,
@@ -208,12 +348,13 @@ pub fn run_quantum_circuit<'py>(
     sim_method: &str,
     noise_model: Option<Bound<'py, PyAny>>,
     backend: &str,
+    seed: Option<u64>,
 ) -> PyResult<pyo3::PyObject> {
     // Entry-point trace carrying the full circuit `Debug` repr on every call:
     // large and high-volume, so it stays at `debug` rather than the default log.
     log::debug!(
         "run_quantum_circuit called with qc: {qc:?}, shots: {shots}, \
-         infrastructure: {infrastructure}, n_qpus: {n_qpus}, backend: {backend}"
+         infrastructure: {infrastructure}, n_qpus: {n_qpus}, backend: {backend}, seed: {seed:?}"
     );
     validate_shots_and_qpus(shots, n_qpus)?;
     let bound_qc = extract_bound_circuit(&qc)?;
@@ -236,6 +377,23 @@ pub fn run_quantum_circuit<'py>(
             ));
         }
     }
+    // Resolve the shot-sampling seed. Only the native statevector backend is
+    // seeded by Polypus; for any other backend an explicit seed would be
+    // silently ineffective, so reject it rather than give false confidence in
+    // reproducibility. When native, `None` means "draw a fresh OS-entropy seed",
+    // resolved here so the effective value can be reported in the manifest.
+    let effective_seed: Option<u64> = if uses_native_backend(&infrastructure, backend) {
+        Some(seed.unwrap_or_else(random_seed))
+    } else if seed.is_some() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "seed is only supported for the native statevector backend \
+             (infrastructure=\"local\", backend=\"polypus\"); backend=\"{backend}\" on \
+             infrastructure=\"{infrastructure}\" does not support seeding"
+        )));
+    } else {
+        None
+    };
+
     let id = format!("run_{}_{}", n_qpus, infrastructure);
     let backend_config = build_backend_config(
         &infrastructure,
@@ -246,12 +404,13 @@ pub fn run_quantum_circuit<'py>(
         2,
     )?;
     let config = ExecutionConfig {
-        id,
+        id: id.clone(),
         shots,
         n_qpus,
-        infrastructure,
+        infrastructure: infrastructure.clone(),
         backend_config,
         opt_level: OptLevel::default(),
+        seed: effective_seed,
     };
     let args = AlgorithmArgs {
         qcs: vec![bound_qc],
@@ -265,12 +424,33 @@ pub fn run_quantum_circuit<'py>(
             Box::new(DistributeByShotsRun)
         };
 
-    Ok(algorithm.run(args))
+    // Keep the original counts payload intact and wrap it with the run manifest.
+    let counts = algorithm.run(args);
+    Python::with_gil(|py| {
+        Py::new(
+            py,
+            RunResult {
+                counts,
+                id,
+                seed: effective_seed,
+                backend: backend.to_string(),
+                infrastructure,
+            },
+        )
+        .map(|result| result.into_any())
+    })
 }
 
 /// Unified entry point: train a variational quantum circuit with a chosen optimizer.
 ///
 /// `method` must be an instance of `DE`, `PSO`, or `QNG`.
+///
+/// `seed` makes the optimizer reproducible (contract C-7): precedence is the
+/// explicit `seed` kwarg, then the optimizer object's `seed` field, then a fresh
+/// OS-entropy value. On the native backend the same seed also drives shot
+/// sampling, so a native-backend run reproduces exactly. Returns a
+/// [`TrainResult`] exposing `best_params`, `best_fitness`, `iterations_run`,
+/// `converged` and the effective `seed`.
 ///
 /// Example:
 ///
@@ -282,7 +462,7 @@ pub fn run_quantum_circuit<'py>(
 ///         infrastructure="local", nodes=1, cores_per_qpu=2, id="run1"
 ///     )
 /// ```
-#[pyfunction(signature = (qc, method, shots, n_qpus, dimensions, expectation_function, infrastructure, nodes, cores_per_qpu, id, sim_method="automatic", noise_model=None, backend="aer"))]
+#[pyfunction(signature = (qc, method, shots, n_qpus, dimensions, expectation_function, infrastructure, nodes, cores_per_qpu, id, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn train<'py>(
     qc: Bound<'py, PyAny>,
@@ -298,8 +478,16 @@ pub fn train<'py>(
     sim_method: &str,
     noise_model: Option<Bound<'py, PyAny>>,
     backend: &str,
+    seed: Option<u64>,
 ) -> PyResult<PyObject> {
     validate_shots_and_qpus(shots, n_qpus)?;
+    // Resolve the seed that drives the optimizer's RNG (contract C-7): explicit
+    // kwarg > optimizer object's `seed` field > fresh OS entropy. Unlike
+    // `run_quantum_circuit`, a seed is always meaningful here — it seeds the
+    // optimizer regardless of backend — and it is also threaded into
+    // `ExecutionConfig::seed` so the native backend's shot sampling becomes
+    // deterministic too, making a native-backend training run fully reproducible.
+    let effective_seed = resolve_optimizer_seed(seed, method_seed(&method));
     // Native circuits know their parameter count — catch a mismatch with the
     // requested optimisation dimensions before any QPU work starts.
     let circuit_source = extract_circuit_source(&qc);
@@ -345,6 +533,9 @@ pub fn train<'py>(
         infrastructure: infrastructure.clone(),
         backend_config,
         opt_level: OptLevel::default(),
+        // Consumed only by the native backend; ignored by Aer/CUNQA/QMIO. Set
+        // unconditionally so a native-backend training run reproduces exactly.
+        seed: Some(effective_seed),
     });
     let backend = Infrastructure::create_backend(&config);
     let oracle: Box<dyn EvaluationOracle> = Box::new(VqcOracle {
@@ -361,12 +552,12 @@ pub fn train<'py>(
             generations: de.generations,
             dimensions,
             tolerance: de.tolerance,
-            seed: None,
+            seed: Some(effective_seed),
         };
-        return AlgorithmDifferentialEvolution
+        let outcome = AlgorithmDifferentialEvolution
             .optimize(args)
-            .map(|outcome| outcome_to_pyobject(method.py(), outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        return outcome_to_train_result(method.py(), outcome, effective_seed);
     }
 
     if let Ok(pso) = method.extract::<PyRef<PSO>>() {
@@ -380,12 +571,12 @@ pub fn train<'py>(
             cognitive_weight: pso.cognitive_weight,
             social_weight: pso.social_weight,
             tolerance: pso.tolerance,
-            seed: None,
+            seed: Some(effective_seed),
         };
-        return AlgorithmPSO
+        let outcome = AlgorithmPSO
             .optimize(args)
-            .map(|outcome| outcome_to_pyobject(method.py(), outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        return outcome_to_train_result(method.py(), outcome, effective_seed);
     }
 
     if let Ok(qng) = method.extract::<PyRef<QNG>>() {
@@ -400,12 +591,12 @@ pub fn train<'py>(
                 variance_function: qng.variance_function.clone_ref(method.py()),
             }),
             tikhonov_reg: qng.tikhonov_reg,
-            seed: None,
+            seed: Some(effective_seed),
         };
-        return AlgorithmQNG
+        let outcome = AlgorithmQNG
             .optimize(args)
-            .map(|outcome| outcome_to_pyobject(method.py(), outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        return outcome_to_train_result(method.py(), outcome, effective_seed);
     }
 
     Err(pyo3::exceptions::PyTypeError::new_err(
@@ -425,6 +616,12 @@ pub fn train<'py>(
 ///    circuits, runs them, and averages the expectation values into a single
 ///    fitness value.
 ///
+/// `seed` follows the same precedence as [`train`] and makes the optimizer's
+/// search reproducible; it returns a [`TrainResult`]. Note that qml.train runs
+/// on the Qiskit/Aer path (the native backend is rejected), and Aer's own shot
+/// sampling is not seeded by Polypus, so full end-to-end reproducibility holds
+/// only for a deterministic oracle (contract C-7).
+///
 /// Example:
 ///
 /// ```ignore
@@ -436,7 +633,7 @@ pub fn train<'py>(
 ///         infrastructure="local", nodes=1, cores_per_qpu=2, id="qml_run",
 ///     )
 /// ```
-#[pyfunction(name = "train", signature = (feature_map, ansatz, x_train, method, shots, n_qpus, dimensions, expectation_function, infrastructure, nodes, cores_per_qpu, id, sim_method="automatic", noise_model=None, backend="aer"))]
+#[pyfunction(name = "train", signature = (feature_map, ansatz, x_train, method, shots, n_qpus, dimensions, expectation_function, infrastructure, nodes, cores_per_qpu, id, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn qml_train<'py>(
     feature_map: Bound<'py, PyAny>,
@@ -454,8 +651,14 @@ pub fn qml_train<'py>(
     sim_method: &str,
     noise_model: Option<Bound<'py, PyAny>>,
     backend: &str,
+    seed: Option<u64>,
 ) -> PyResult<PyObject> {
     validate_shots_and_qpus(shots, n_qpus)?;
+    // Same seed precedence as `train` (contract C-7): kwarg > optimizer field >
+    // OS entropy. qml.train always runs on a Qiskit/Aer path (native rejected
+    // below), so this seed governs the optimizer's RNG; Aer's own shot sampling
+    // is not seeded by Polypus.
+    let effective_seed = resolve_optimizer_seed(seed, method_seed(&method));
     // QML composes Qiskit feature maps and ansätze, so it is inherently a
     // Qiskit path; the native statevector backend cannot consume a Qiskit
     // `QuantumCircuit`. Accept `backend` for API symmetry but reject native.
@@ -523,6 +726,9 @@ pub fn qml_train<'py>(
         infrastructure: infrastructure.clone(),
         backend_config,
         opt_level: OptLevel::default(),
+        // Consumed only by the native backend; ignored by Aer/CUNQA/QMIO. Set
+        // unconditionally so a native-backend training run reproduces exactly.
+        seed: Some(effective_seed),
     });
     let backend = Infrastructure::create_backend(&config);
     let oracle: Box<dyn EvaluationOracle> = Box::new(QmlOracle {
@@ -539,12 +745,12 @@ pub fn qml_train<'py>(
             generations: de.generations,
             dimensions,
             tolerance: de.tolerance,
-            seed: None,
+            seed: Some(effective_seed),
         };
-        return AlgorithmDifferentialEvolution
+        let outcome = AlgorithmDifferentialEvolution
             .optimize(args)
-            .map(|outcome| outcome_to_pyobject(py, outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        return outcome_to_train_result(py, outcome, effective_seed);
     }
 
     if let Ok(pso) = method.extract::<PyRef<PSO>>() {
@@ -558,12 +764,12 @@ pub fn qml_train<'py>(
             cognitive_weight: pso.cognitive_weight,
             social_weight: pso.social_weight,
             tolerance: pso.tolerance,
-            seed: None,
+            seed: Some(effective_seed),
         };
-        return AlgorithmPSO
+        let outcome = AlgorithmPSO
             .optimize(args)
-            .map(|outcome| outcome_to_pyobject(py, outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        return outcome_to_train_result(py, outcome, effective_seed);
     }
 
     if let Ok(qng) = method.extract::<PyRef<QNG>>() {
@@ -578,12 +784,12 @@ pub fn qml_train<'py>(
                 variance_function: qng.variance_function.clone_ref(py),
             }),
             tikhonov_reg: qng.tikhonov_reg,
-            seed: None,
+            seed: Some(effective_seed),
         };
-        return AlgorithmQNG
+        let outcome = AlgorithmQNG
             .optimize(args)
-            .map(|outcome| outcome_to_pyobject(py, outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        return outcome_to_train_result(py, outcome, effective_seed);
     }
 
     Err(pyo3::exceptions::PyTypeError::new_err(
@@ -598,6 +804,8 @@ pub fn polypus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<QNG>()?;
     m.add_class::<Circuit>()?;
     m.add_class::<Param>()?;
+    m.add_class::<RunResult>()?;
+    m.add_class::<TrainResult>()?;
     m.add_function(wrap_pyfunction!(train, m)?)?;
     m.add_function(wrap_pyfunction!(run_quantum_circuit, m)?)?;
     m.add_function(wrap_pyfunction!(statevector, m)?)?;
@@ -613,4 +821,212 @@ pub fn polypus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     sys.getattr("modules")?.set_item("polypus.qml", &qml)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::PyString;
+    use std::collections::HashMap;
+
+    /// 3-qubit uniform superposition as OpenQASM 2.0. Its eight equally likely
+    /// outcomes make "counts differ across unseeded runs" non-flaky (a 2-outcome
+    /// Bell state collides far too often to assert inequality reliably).
+    fn uniform3_qasm() -> String {
+        polypus_circuit::ParameterizedCircuit::new(3)
+            .h(0)
+            .h(1)
+            .h(2)
+            .measure_all()
+            .assign_parameters(&[])
+            .expect("no free parameters")
+            .to_qasm2()
+    }
+
+    /// Drive `run_quantum_circuit` on the native backend and return the effective
+    /// seed reported in the manifest plus the wrapped counts payload.
+    fn native_run(
+        py: Python<'_>,
+        qasm: &str,
+        seed: Option<u64>,
+    ) -> (Option<u64>, Vec<HashMap<String, u64>>) {
+        let qc = PyString::new(py, qasm).into_any();
+        let result = run_quantum_circuit(
+            qc,
+            500,
+            "local".to_string(),
+            1,
+            "automatic",
+            None,
+            "polypus",
+            seed,
+        )
+        .expect("native run_quantum_circuit succeeds");
+        let bound = result.bind(py);
+        let reported = bound
+            .getattr("seed")
+            .unwrap()
+            .extract::<Option<u64>>()
+            .unwrap();
+        let counts = bound
+            .getattr("counts")
+            .unwrap()
+            .extract::<Vec<HashMap<String, u64>>>()
+            .unwrap();
+        (reported, counts)
+    }
+
+    /// Acceptance criterion (defect #1) through the public entry point: an
+    /// explicit seed round-trips into the manifest and reproduces the counts.
+    #[test]
+    fn native_seed_round_trips_and_reproduces_counts() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let qasm = uniform3_qasm();
+            let (s1, c1) = native_run(py, &qasm, Some(42));
+            let (s2, c2) = native_run(py, &qasm, Some(42));
+            assert_eq!(s1, Some(42));
+            assert_eq!(s2, Some(42));
+            assert_eq!(c1, c2, "same seed must reproduce counts");
+        });
+    }
+
+    /// Acceptance criterion (defect #1), negative half: with no seed, each run
+    /// draws a fresh entropy seed (reported in the manifest) and the counts
+    /// differ across calls.
+    #[test]
+    fn native_omitted_seed_is_entropy_and_differs() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let qasm = uniform3_qasm();
+            let (s1, c1) = native_run(py, &qasm, None);
+            let (s2, c2) = native_run(py, &qasm, None);
+            assert!(
+                s1.is_some() && s2.is_some(),
+                "an entropy seed must be reported"
+            );
+            assert_ne!(s1, s2, "each unseeded run must draw a fresh seed");
+            assert_ne!(c1, c2, "unseeded runs must produce independent noise");
+        });
+    }
+
+    /// The manifest carries the full run metadata for logging/replay.
+    #[test]
+    fn native_manifest_reports_run_metadata() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let qc = PyString::new(py, &uniform3_qasm()).into_any();
+            let result = run_quantum_circuit(
+                qc,
+                100,
+                "local".to_string(),
+                1,
+                "automatic",
+                None,
+                "polypus",
+                Some(7),
+            )
+            .expect("native run succeeds");
+            let bound = result.bind(py);
+            let get = |name: &str| bound.getattr(name).unwrap().extract::<String>().unwrap();
+            assert_eq!(get("backend"), "polypus");
+            assert_eq!(get("infrastructure"), "local");
+            assert_eq!(get("id"), "run_1_local");
+            assert_eq!(
+                bound
+                    .getattr("seed")
+                    .unwrap()
+                    .extract::<Option<u64>>()
+                    .unwrap(),
+                Some(7)
+            );
+        });
+    }
+
+    /// A seed passed with any non-native backend is rejected, never silently
+    /// dropped — Polypus only seeds the native statevector backend.
+    #[test]
+    fn seed_rejected_for_non_native_backends() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let qasm = uniform3_qasm();
+            for (infra, backend) in [("local", "aer"), ("cunqa", "aer"), ("qmio", "aer")] {
+                let qc = PyString::new(py, &qasm).into_any();
+                let result = run_quantum_circuit(
+                    qc,
+                    100,
+                    infra.to_string(),
+                    1,
+                    "automatic",
+                    None,
+                    backend,
+                    Some(3),
+                );
+                assert!(
+                    result.is_err(),
+                    "an explicit seed must be rejected for infrastructure={infra}, backend={backend}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn resolve_optimizer_seed_follows_precedence() {
+        // Explicit kwarg wins over the optimizer field...
+        assert_eq!(resolve_optimizer_seed(Some(7), Some(9)), 7);
+        // ...the optimizer field is the fallback...
+        assert_eq!(resolve_optimizer_seed(None, Some(9)), 9);
+        // ...and with neither set, a fresh entropy seed is drawn each time.
+        assert_ne!(
+            resolve_optimizer_seed(None, None),
+            resolve_optimizer_seed(None, None)
+        );
+    }
+
+    /// The seed the binding resolves must actually make the optimizer
+    /// reproducible (same seed ⇒ identical outcome) and its entropy fallback must
+    /// vary (no seed ⇒ different outcomes) — the `train`/`qml.train` acceptance
+    /// criterion, exercised at the binding's seed-resolution boundary. `train()`
+    /// itself needs a Python oracle + `polypus_python`, which the
+    /// Python-runtime-free Rust suite forbids, so the optimizer is driven
+    /// directly with a pure-Rust oracle (mirroring
+    /// `optimizers.rs::de_is_deterministic_for_a_fixed_seed`, one layer up).
+    #[test]
+    fn resolved_seed_drives_the_optimizer_deterministically() {
+        use polypus_optimizers::{
+            AlgorithmDifferentialEvolution, AlgorithmDifferentialEvolutionArgs, EvaluationOracle,
+            Optimizer,
+        };
+
+        struct Quadratic;
+        impl EvaluationOracle for Quadratic {
+            fn evaluate_batch(&self, candidates: &[Vec<f64>]) -> Vec<f64> {
+                candidates
+                    .iter()
+                    .map(|c| -c.iter().map(|x| (x - 0.7).powi(2)).sum::<f64>())
+                    .collect()
+            }
+        }
+
+        let run = |kwarg: Option<u64>, field: Option<u64>| {
+            let seed = resolve_optimizer_seed(kwarg, field);
+            AlgorithmDifferentialEvolution
+                .optimize(AlgorithmDifferentialEvolutionArgs {
+                    oracle: Box::new(Quadratic),
+                    population_size: 20,
+                    generations: 40,
+                    dimensions: 3,
+                    tolerance: 1e-9,
+                    seed: Some(seed),
+                })
+                .expect("valid DE args optimize successfully")
+        };
+
+        // Same explicit seed ⇒ identical outcome (params, fitness, iters, converged).
+        assert_eq!(run(Some(123), None), run(Some(123), None));
+        // A method-field seed reproduces just as well.
+        assert_eq!(run(None, Some(55)), run(None, Some(55)));
+        // Omitted seed ⇒ (almost surely) different outcomes.
+        assert_ne!(run(None, None), run(None, None));
+    }
 }

--- a/crates/polypus/src/bindings/pso.rs
+++ b/crates/polypus/src/bindings/pso.rs
@@ -18,12 +18,21 @@ pub struct PSO {
     pub social_weight: f64,
     #[pyo3(get, set)]
     pub tolerance: f64,
+    /// Optional RNG seed pinned on the optimizer object. Consumed by
+    /// `train`/`qml.train` per the precedence rule (contract C-7): the explicit
+    /// `seed` kwarg passed to the call wins; this field is the fallback; a fresh
+    /// OS-entropy value is used when neither is set. `None` by default.
+    #[pyo3(get, set)]
+    pub seed: Option<u64>,
 }
 
 #[pymethods]
 impl PSO {
     #[new]
-    #[pyo3(signature = (generations = 100, population_size = 50, bounds = (-std::f64::consts::PI, std::f64::consts::PI), inertia_weight = 0.5, cognitive_weight = 1.0, social_weight = 1.0, tolerance = 0.01))]
+    #[pyo3(signature = (generations = 100, population_size = 50, bounds = (-std::f64::consts::PI, std::f64::consts::PI), inertia_weight = 0.5, cognitive_weight = 1.0, social_weight = 1.0, tolerance = 0.01, seed = None))]
+    // Constructor mirrors PSO's full hyper-parameter set as Python kwargs; the
+    // added `seed` pushes it one past the lint threshold.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         generations: u32,
         population_size: u32,
@@ -32,6 +41,7 @@ impl PSO {
         cognitive_weight: f64,
         social_weight: f64,
         tolerance: f64,
+        seed: Option<u64>,
     ) -> Self {
         PSO {
             generations,
@@ -41,6 +51,7 @@ impl PSO {
             cognitive_weight,
             social_weight,
             tolerance,
+            seed,
         }
     }
 }

--- a/crates/polypus/src/bindings/qng.rs
+++ b/crates/polypus/src/bindings/qng.rs
@@ -17,12 +17,18 @@ pub struct QNG {
     pub tikhonov_reg: f64,
     #[pyo3(get, set)]
     pub variance_function: Py<PyAny>,
+    /// Optional RNG seed pinned on the optimizer object. Consumed by
+    /// `train`/`qml.train` per the precedence rule (contract C-7): the explicit
+    /// `seed` kwarg passed to the call wins; this field is the fallback; a fresh
+    /// OS-entropy value is used when neither is set. `None` by default.
+    #[pyo3(get, set)]
+    pub seed: Option<u64>,
 }
 
 #[pymethods]
 impl QNG {
     #[new]
-    #[pyo3(signature = (variance_function, max_iters = 100, bounds = (-std::f64::consts::PI, std::f64::consts::PI), learning_rate = 0.1, finite_difference_step = 0.1, tikhonov_reg = 0.05))]
+    #[pyo3(signature = (variance_function, max_iters = 100, bounds = (-std::f64::consts::PI, std::f64::consts::PI), learning_rate = 0.1, finite_difference_step = 0.1, tikhonov_reg = 0.05, seed = None))]
     pub fn new(
         variance_function: Py<PyAny>,
         max_iters: u32,
@@ -30,6 +36,7 @@ impl QNG {
         learning_rate: f64,
         finite_difference_step: f64,
         tikhonov_reg: f64,
+        seed: Option<u64>,
     ) -> Self {
         QNG {
             variance_function,
@@ -38,6 +45,7 @@ impl QNG {
             learning_rate,
             finite_difference_step,
             tikhonov_reg,
+            seed,
         }
     }
 }

--- a/crates/polypus/src/infrastructure/execution_config.rs
+++ b/crates/polypus/src/infrastructure/execution_config.rs
@@ -35,6 +35,28 @@ pub struct ExecutionConfig {
     /// [`IdentityTranspiler`](crate::infrastructure::IdentityTranspiler) it has
     /// no effect on results.
     pub opt_level: OptLevel,
+    /// Explicit RNG seed for shot sampling.
+    ///
+    /// Only the native statevector backend
+    /// ([`NativeStatevectorBackend`](crate::infrastructure::NativeStatevectorBackend))
+    /// consumes this: it seeds the per-circuit sampling stream, making counts
+    /// reproducible. The Python-facing layer resolves it to `Some` whenever the
+    /// native backend runs (user-supplied value or a fresh OS-entropy draw), so
+    /// the effective seed can be reported back in the run manifest (contract
+    /// C-7). Every other backend ignores it; `None` means "no explicit seed"
+    /// and the native backend falls back to a fresh OS-entropy draw. Decoupled
+    /// from [`id`](Self::id), which is only a logging/temp-file/SLURM label.
+    pub seed: Option<u64>,
+}
+
+/// Draw a fresh 64-bit seed from OS entropy.
+///
+/// Used as the default when no explicit seed is supplied, so an omitted seed
+/// produces genuine (independent) shot noise across runs rather than repeating a
+/// value derived from the run [`id`](ExecutionConfig::id).
+pub(crate) fn random_seed() -> u64 {
+    use rand::RngCore;
+    rand::rngs::OsRng.next_u64()
 }
 
 /// Provider-specific configuration.

--- a/crates/polypus/src/infrastructure/mod.rs
+++ b/crates/polypus/src/infrastructure/mod.rs
@@ -72,7 +72,13 @@ impl Infrastructure {
                 backend.clone(),
                 sim_method.clone(),
             )),
-            BackendConfig::LocalNative => Arc::new(NativeStatevectorBackend::new(&config.id)),
+            BackendConfig::LocalNative => Arc::new(NativeStatevectorBackend::new(
+                // The Python-facing layer resolves a concrete seed whenever the
+                // native backend runs; the entropy fallback here only guards a
+                // directly-built config that left `seed` unset (e.g. tests), so
+                // an omitted seed still yields independent noise, never a panic.
+                config.seed.unwrap_or_else(execution_config::random_seed),
+            )),
             #[cfg(feature = "qmio")]
             BackendConfig::Qmio {
                 endpoint,

--- a/crates/polypus/src/infrastructure/native.rs
+++ b/crates/polypus/src/infrastructure/native.rs
@@ -12,16 +12,19 @@ use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Tr
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use polypus_circuit::{ConcreteCircuit, ParameterizedCircuit};
 use polypus_sim::StatevectorSimulator;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Local, noiseless statevector backend backed by `polypus-sim`.
 ///
-/// Sampling is seeded deterministically from the run `id` plus a per-circuit
-/// counter, so repeated runs with the same `id` reproduce the same counts while
-/// distinct circuits in a batch still get independent shot noise.
+/// Sampling is seeded from an explicit base seed plus a per-circuit counter, so
+/// two backends built with the same seed reproduce the same counts while
+/// distinct circuits in a batch still get independent shot noise. The seed is
+/// supplied by the caller (`ExecutionConfig::seed`, resolved at the
+/// Python-facing boundary from a user value or an OS-entropy draw) and is
+/// **fully decoupled from the run `id`**: an omitted seed yields genuine,
+/// independent noise across runs instead of the `id`-derived repetition that was
+/// previously mistaken for shot noise.
 ///
 /// The backend *composes* a [`Transpiler`] (the rewriting *strategy*) and runs
 /// it on every native circuit before simulating, passing the per-run
@@ -36,24 +39,22 @@ pub struct NativeStatevectorBackend {
 }
 
 impl NativeStatevectorBackend {
-    /// Create a backend whose sampling stream is derived from `id`, using the
+    /// Create a backend whose sampling stream starts from `seed`, using the
     /// no-op [`IdentityTranspiler`] (behavior identical to having no transpiler).
-    pub fn new(id: &str) -> Self {
-        Self::with_transpiler(id, Box::new(IdentityTranspiler))
+    pub fn new(seed: u64) -> Self {
+        Self::with_transpiler(seed, Box::new(IdentityTranspiler))
     }
 
     /// Create a backend with a custom transpilation *strategy* injected by
-    /// composition. The sampling stream is still derived from `id`.
+    /// composition. The sampling stream starts from `seed`.
     ///
     /// This is the extension point for hardware-aware rewriting: pass any
     /// `Box<dyn Transpiler>` without changing the backend or any algorithm code.
-    pub fn with_transpiler(id: &str, transpiler: Box<dyn Transpiler>) -> Self {
-        let mut hasher = DefaultHasher::new();
-        id.hash(&mut hasher);
+    pub fn with_transpiler(seed: u64, transpiler: Box<dyn Transpiler>) -> Self {
         NativeStatevectorBackend {
             simulator: StatevectorSimulator::new(),
             transpiler,
-            base_seed: hasher.finish(),
+            base_seed: seed,
             counter: AtomicU64::new(0),
         }
     }
@@ -157,7 +158,27 @@ mod tests {
             infrastructure: "local".to_string(),
             backend_config: crate::infrastructure::BackendConfig::LocalNative,
             opt_level,
+            // No explicit seed: exercises the OS-entropy fallback path in
+            // `Infrastructure::create_backend`. Tests that build the backend
+            // directly pass their seed to `new`/`with_transpiler`, so this field
+            // is unused by them.
+            seed: None,
         }
+    }
+
+    /// 3-qubit uniform superposition (H on every qubit) with a full read-out.
+    /// Its counts spread over eight bitstrings, so two independent samplings
+    /// differ with overwhelming probability — the circuit used to assert that
+    /// distinct/omitted seeds produce distinct counts without statistical
+    /// flakiness (a 2-outcome Bell state would collide far too often).
+    fn uniform3() -> ConcreteCircuit {
+        ParameterizedCircuit::new(3)
+            .h(0)
+            .h(1)
+            .h(2)
+            .measure_all()
+            .assign_parameters(&[])
+            .unwrap()
     }
 
     /// Records the last [`OptLevel`] it was asked to honor, proving the level set
@@ -190,7 +211,7 @@ mod tests {
 
     #[test]
     fn bell_counts_only_correlated_outcomes() {
-        let backend = NativeStatevectorBackend::new("test");
+        let backend = NativeStatevectorBackend::new(0);
         let counts = backend.simulate_one(
             &BoundCircuit::Native(bell()),
             2000,
@@ -210,9 +231,9 @@ mod tests {
     #[test]
     fn identity_default_matches_explicit_identity() {
         let opts = TranspileOptions::default();
-        let default_backend = NativeStatevectorBackend::new("bell");
+        let default_backend = NativeStatevectorBackend::new(0);
         let explicit_backend =
-            NativeStatevectorBackend::with_transpiler("bell", Box::new(IdentityTranspiler));
+            NativeStatevectorBackend::with_transpiler(0, Box::new(IdentityTranspiler));
         let circuit = BoundCircuit::Native(bell());
         assert_eq!(
             default_backend.simulate_one(&circuit, 1000, 42, &opts),
@@ -228,7 +249,7 @@ mod tests {
             .assign_parameters(&[])
             .unwrap()
             .to_qasm2();
-        let backend = NativeStatevectorBackend::new("t");
+        let backend = NativeStatevectorBackend::new(0);
         let counts = backend.simulate_one(
             &BoundCircuit::Qasm2(qasm),
             128,
@@ -243,7 +264,7 @@ mod tests {
     /// for the same circuit and seed under the identity transpiler.
     #[test]
     fn qasm2_path_matches_native_path() {
-        let backend = NativeStatevectorBackend::new("eq");
+        let backend = NativeStatevectorBackend::new(0);
         let opts = TranspileOptions::default();
         let native = backend.simulate_one(&BoundCircuit::Native(bell()), 1000, 5, &opts);
         let qasm = backend.simulate_one(&BoundCircuit::Qasm2(bell().to_qasm2()), 1000, 5, &opts);
@@ -269,7 +290,7 @@ mod tests {
     fn opt_level_reaches_transpiler() {
         let seen = Arc::new(AtomicU8::new(0xFF));
         let backend = NativeStatevectorBackend::with_transpiler(
-            "lvl",
+            0,
             Box::new(RecordingTranspiler {
                 seen: Arc::clone(&seen),
             }),
@@ -285,7 +306,7 @@ mod tests {
     /// the injection point, not observed as wrong results.
     #[test]
     fn injected_strategy_runs_through_run_circuits() {
-        let backend = NativeStatevectorBackend::with_transpiler("inj", Box::new(BarrierTranspiler));
+        let backend = NativeStatevectorBackend::with_transpiler(0, Box::new(BarrierTranspiler));
         let cfg = config_with(OptLevel::default());
         let counts = backend.run_circuits(&[BoundCircuit::Native(bell())], &cfg);
         assert_eq!(counts.len(), 1);
@@ -296,12 +317,47 @@ mod tests {
         }
     }
 
+    /// Acceptance criterion (defect #1), positive half: the *same explicit
+    /// seed* reproduces byte-identical counts across two independent backends,
+    /// regardless of the run `id` (which no longer feeds the RNG).
     #[test]
-    fn seeding_is_reproducible_per_id() {
+    fn same_seed_reproduces_counts() {
         let cfg = config_with(OptLevel::default());
-        let a = NativeStatevectorBackend::new(&cfg.id);
-        let b = NativeStatevectorBackend::new(&cfg.id);
-        let batch = vec![BoundCircuit::Native(bell())];
+        let a = NativeStatevectorBackend::new(2024);
+        let b = NativeStatevectorBackend::new(2024);
+        let batch = vec![BoundCircuit::Native(uniform3())];
         assert_eq!(a.run_circuits(&batch, &cfg), b.run_circuits(&batch, &cfg));
+    }
+
+    /// Distinct seeds produce distinct counts: the seed genuinely drives the
+    /// sampling stream (guards against the seed being ignored).
+    #[test]
+    fn distinct_seeds_produce_distinct_counts() {
+        let cfg = config_with(OptLevel::default());
+        let a = NativeStatevectorBackend::new(1);
+        let b = NativeStatevectorBackend::new(2);
+        let batch = vec![BoundCircuit::Native(uniform3())];
+        assert_ne!(a.run_circuits(&batch, &cfg), b.run_circuits(&batch, &cfg));
+    }
+
+    /// Acceptance criterion (defect #1), negative half: with **no explicit
+    /// seed**, two runs sharing the *same `id`* must NOT reproduce each other —
+    /// the shot noise is real noise, not an artefact of hashing the `id`.
+    /// `create_backend` draws a fresh OS-entropy seed for each `LocalNative`
+    /// backend when `config.seed` is `None`. Asserting inequality of the full
+    /// eight-outcome counts dict (not a single statistic) keeps this
+    /// non-flaky. This is the exact inversion of the removed
+    /// `seeding_is_reproducible_per_id`, which encoded the bug.
+    #[test]
+    fn omitted_seed_differs_across_calls_for_same_id() {
+        use crate::infrastructure::Infrastructure;
+        let cfg = config_with(OptLevel::default()); // id "abc", seed: None
+        let batch = vec![BoundCircuit::Native(uniform3())];
+        let a = Infrastructure::create_backend(&cfg).run_circuits(&batch, &cfg);
+        let b = Infrastructure::create_backend(&cfg).run_circuits(&batch, &cfg);
+        assert_ne!(
+            a, b,
+            "no-seed runs with the same id must produce independent noise"
+        );
     }
 }

--- a/crates/polypus/src/infrastructure/qmio.rs
+++ b/crates/polypus/src/infrastructure/qmio.rs
@@ -1045,6 +1045,8 @@ mod tests {
                 res_format: "binary_count".to_string(),
             },
             opt_level: crate::infrastructure::OptLevel::default(),
+            // QMIO does not consume the sampling seed (real QPU / server-side).
+            seed: None,
         };
 
         let counts = backend.run_circuits(&[BoundCircuit::Native(bell())], &config);
@@ -1086,6 +1088,8 @@ mod tests {
                 res_format: "binary_count".to_string(),
             },
             opt_level: crate::infrastructure::OptLevel::default(),
+            // QMIO does not consume the sampling seed (real QPU / server-side).
+            seed: None,
         };
         let counts = backend.run_circuits(&[BoundCircuit::Native(bell())], &config);
         assert_eq!(counts.len(), 1);

--- a/crates/polypus/src/lib.rs
+++ b/crates/polypus/src/lib.rs
@@ -25,13 +25,19 @@
 //! result = polypus.run_quantum_circuit(qc, shots=1000, infrastructure="local", n_qpus=10)
 //! ```
 //!
+//! Both calls return a `RunResult`: `result.counts` holds the payload (a
+//! `list[dict]` for a single QPU, a merged `dict` for `n_qpus > 1`), plus
+//! `result.id` / `result.seed` / `result.backend` / `result.infrastructure`
+//! for logging and replay (`seed` is the effective RNG seed on the native
+//! backend, `None` otherwise).
+//!
 //! ## Training a variational circuit
 //! Pass a method object as the second argument to `train()`. The optimizer-specific
 //! parameters are encapsulated in the method object; execution parameters are shared.
 //!
 //! ```python
 //! # Differential Evolution
-//! result_params = polypus.train(
+//! result = polypus.train(
 //!     qc, polypus.DE(generations=100, population_size=50, tolerance=0.01),
 //!     shots=N_SHOTS, n_qpus=N_QPUS, dimensions=2*layers,
 //!     expectation_function=bitstring_to_obj,
@@ -39,7 +45,7 @@
 //! )
 //!
 //! # Particle Swarm Optimization
-//! result_params = polypus.train(
+//! result = polypus.train(
 //!     qc, polypus.PSO(generations=100, population_size=50, bounds=(0.0, 3.14)),
 //!     shots=N_SHOTS, n_qpus=N_QPUS, dimensions=2*layers,
 //!     expectation_function=bitstring_to_obj,
@@ -47,13 +53,19 @@
 //! )
 //!
 //! # Quantum Natural Gradient
-//! result_params = polypus.train(
+//! result = polypus.train(
 //!     qc, polypus.QNG(variance_fn, max_iters=100, learning_rate=0.1),
 //!     shots=N_SHOTS, n_qpus=N_QPUS, dimensions=2*layers,
 //!     expectation_function=bitstring_to_obj,
 //!     infrastructure="local", nodes=1, cores_per_qpu=2, id="run1"
 //! )
 //! ```
+//!
+//! `train()` returns a `TrainResult` exposing `result.best_params`
+//! (`list[float]`) plus `result.best_fitness`, `result.iterations_run`,
+//! `result.converged`, and the effective `result.seed` — the full optimization
+//! outcome, not just the parameters. Pass `seed=...` (or set it on the
+//! optimizer, e.g. `polypus.DE(..., seed=42)`) to reproduce a run.
 //!
 //! # Authors
 //! Diego Beltrán Fernández Prada (<diego.fernandez@bahiasoftware.es>), Víctor Sóñora Pombo, Sergio Figueiras Gómez, Miguel Boubeta Martínez, Galicia Supercomputing Center (CESGA)

--- a/crates/polypus/tests/running_quantum_circuits_local.rs
+++ b/crates/polypus/tests/running_quantum_circuits_local.rs
@@ -122,6 +122,9 @@ fn native_bell_args(shots: u32, n_qpus: u32, id: &str) -> AlgorithmArgs {
             infrastructure: "local".to_string(),
             backend_config: BackendConfig::LocalNative,
             opt_level: OptLevel::default(),
+            // Fixed seed: these tests assert only shot conservation, and a fixed
+            // seed keeps the native backend's sampling deterministic across runs.
+            seed: Some(7),
         },
         qcs: vec![BoundCircuit::Native(bell)],
     }

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -26,6 +26,7 @@ Rules of the road:
 | C-4 | Terminal measurement placement | rejection tests (sim + QIR) | ⏳ to add | measurement semantics (C5) |
 | C-5 | Optimizer ↔ oracle | invariant test, multi-seed | ✅ present | DE `best_fitness` mismatch (C4) |
 | C-6 | Version coherence | `hygiene.yml` version step | ✅ present | tag/Cargo diverged at 0.6.0 |
+| C-7 | Seeding & run manifest | `tests/python/test_seed_reproducibility.py` + bindings/native Rust tests | ✅ present | repeated runs byte-identical / `train` seed hardcoded `None` (#34) |
 
 ⏳ contracts are specified but not yet mechanically enforced; treat them as
 review-enforced until the test lands. Each known break has a public issue
@@ -137,6 +138,12 @@ test (to be added; see `bug_repro.rs` from the audit for the seed).
 - If several `measure` instructions write the same classical bit, the **last
   measurement wins** (OpenQASM 2.0 register semantics).
 
+The per-circuit dict format above is unchanged by C-7: `run_quantum_circuit`
+now returns that payload as the `counts` attribute of a `RunResult` wrapper
+(`list[dict]` for a single-QPU run, a merged `dict` for `n_qpus > 1`), so
+callers read `result.counts` rather than the bare value. The dict shape,
+bit order and shot-conservation rule are exactly as specified here.
+
 **Enforcing test:** shot-conservation assertion in the orchestration tests
 (`crates/polypus/tests/running_quantum_circuits_local.rs`, plus the Python
 public-API case in `tests/python/test_local_run.py`; audit C6) and
@@ -187,3 +194,62 @@ coherence check is enforced from 0.7.0 onwards; aligning the workspace version
 is the first release action.*
 
 **Enforcing check:** version-coherence step in `.github/workflows/hygiene.yml`.
+
+---
+
+## C-7 · Seeding & run manifest (Python entry points)
+
+This contract governs the outer Rust↔Python boundary of the three public entry
+points `polypus.run_quantum_circuit`, `polypus.train` and `polypus.qml.train`:
+their `seed` kwarg and their return shape. (It is distinct from C-1, which
+freezes the *internal* `run_qcs` seam to the `polypus_python` package.)
+
+### The `seed` kwarg
+
+- **`run_quantum_circuit(..., seed: int | None = None)`** seeds shot sampling,
+  which **only the native statevector backend** performs in-process:
+  - With the native backend (`infrastructure="local"`, `backend="polypus"`): an
+    explicit `seed` is used directly and reproduces the counts byte-for-byte
+    across calls; `seed=None` draws a fresh seed from OS entropy, so repeated
+    calls produce **independent** noise (never the run-`id`-derived repetition
+    that motivated this contract). The run `id` is decoupled from the RNG — it
+    is only a logging/temp-file/SLURM label.
+  - With any other backend (`backend="aer"`, or `infrastructure` `"cunqa"` /
+    `"qmio"`): passing an explicit `seed` raises `ValueError`. Polypus does not
+    seed these paths (Aer's own `seed_simulator` is not wired), so silently
+    accepting a seed would give false confidence in reproducibility. `seed=None`
+    behaves exactly as before.
+- **`train(..., seed=None)` / `qml.train(..., seed=None)`** seed the optimizer's
+  RNG and are **always accepted**, for every backend, because the seed's primary
+  job (making population init / mutation deterministic, inside the pure-Rust
+  `polypus-optimizers`) is independent of which backend evaluates the oracle.
+  Precedence: the explicit `seed` kwarg wins; otherwise the `seed` field pinned
+  on the `DE`/`PSO`/`QNG` instance; otherwise a fresh OS-entropy value. On the
+  native backend the resolved seed *also* seeds shot sampling, so a
+  native-backend training run is reproducible end-to-end; `qml.train` is
+  Qiskit/Aer-only (native rejected) and Aer shot noise is unseeded, so its
+  reproducibility guarantee covers the optimizer trajectory given a deterministic
+  oracle, not Aer's sampling.
+
+### The run manifest (return shapes)
+
+- `run_quantum_circuit` returns a **`RunResult`** exposing:
+  `counts` (the C-3 payload — `list[dict]` for one QPU, merged `dict` for
+  `n_qpus > 1`), `id` (str), `seed` (`int | None`; the effective seed used, or
+  `None` for a non-native backend), `backend` (str), `infrastructure` (str).
+- `train` / `qml.train` return a **`TrainResult`** exposing the full
+  optimization outcome — `best_params` (`list[float]`), `best_fitness` (float),
+  `iterations_run` (int), `converged` (bool) — plus `seed` (int, the effective
+  seed used). This replaces the former bare `list[float]`, which discarded
+  fitness, iteration count and the convergence flag.
+
+The effective `seed` on both result types is what lets a caller log a run and
+replay it exactly.
+
+**Enforcing test:** `tests/python/test_seed_reproducibility.py` (public-API
+end-to-end: native reproducibility, entropy variation, the non-native
+rejection, and the returned manifest/outcome fields), plus the Rust tests in
+`crates/polypus/src/bindings/mod.rs` (native seed round-trip through
+`run_quantum_circuit`, the rejection path, and the seed-resolution precedence /
+optimizer determinism) and `crates/polypus/src/infrastructure/native.rs`
+(same-seed reproduces / omitted-seed differs at the backend level).

--- a/examples/infraestructures.py
+++ b/examples/infraestructures.py
@@ -104,10 +104,10 @@ fixed_circuit = build_qaoa([0.8], [0.4])
 
 counts_aer = polypus.run_quantum_circuit(
     fixed_circuit, shots=SHOTS, infrastructure="local", backend="aer"
-)[0]
+).counts[0]
 counts_native = polypus.run_quantum_circuit(
     fixed_circuit, shots=SHOTS, infrastructure="local", backend="polypus"
-)[0]
+).counts[0]
 
 tvd = total_variation(counts_aer, counts_native, SHOTS)
 print(f"\nTotal-variation distance (Aer vs polypus): {tvd:.4f}")
@@ -186,14 +186,16 @@ train_kw = dict(
 
 def time_train(backend):
     t0 = time.perf_counter()
-    params = polypus.train(
+    result = polypus.train(
         ansatz,
         polypus.DE(generations=15, population_size=20, tolerance=1e-6),
         id=f"qaoa_{backend}",
         backend=backend,
         **train_kw,
     )
-    return params, time.perf_counter() - t0
+    # train now returns a TrainResult (contract C-7); the tuned angles are in
+    # .best_params, alongside .best_fitness / .iterations_run / .converged / .seed.
+    return result.best_params, time.perf_counter() - t0
 
 
 def evaluate_solution(params, backend):
@@ -206,7 +208,7 @@ def evaluate_solution(params, backend):
     bound = ansatz.to_qasm2(list(params))
     counts = polypus.run_quantum_circuit(
         bound, shots=SHOTS, infrastructure="local", backend=backend
-    )[0]
+    ).counts[0]
     mean_cut = sum(maxcut_value(k) * v for k, v in counts.items()) / SHOTS
     best_cut = max(maxcut_value(k) for k in counts)
     return mean_cut, best_cut

--- a/examples/max_cut_qaoa.py
+++ b/examples/max_cut_qaoa.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
             nodes=NUM_NODES,
             cores_per_qpu=CORES_PER_QPU,
             id=id,
-            sim_method=de_sim_method)
+            sim_method=de_sim_method).best_params
         elapsed = time.time() - tic
 
         counts, best_bitstring, cut, approximation_ratio = final_evaluation(
@@ -344,7 +344,7 @@ if __name__ == "__main__":
             infrastructure=infrastructure,
             nodes=NUM_NODES,
             cores_per_qpu=CORES_PER_QPU,
-            id=id)
+            id=id).best_params
         elapsed = time.time() - tic
 
         counts, best_bitstring, cut, approximation_ratio = final_evaluation(
@@ -378,7 +378,7 @@ if __name__ == "__main__":
             infrastructure=infrastructure,
             nodes=NUM_NODES,
             cores_per_qpu=CORES_PER_QPU,
-            id=id)
+            id=id).best_params
         elapsed = time.time() - tic
 
         # Final evaluation uses the QNG circuit (alternating parameterisation)

--- a/tests/python/test_backend_selection.py
+++ b/tests/python/test_backend_selection.py
@@ -28,13 +28,16 @@ class TestRunQuantumCircuitBackends:
         result = polypus.run_quantum_circuit(
             qc, shots=2000, infrastructure="local", backend="polypus"
         )
-        assert isinstance(result, list) and len(result) == 1
-        counts = result[0]
+        assert isinstance(result.counts, list) and len(result.counts) == 1
+        counts = result.counts[0]
         assert sum(counts.values()) == 2000
         assert set(counts.keys()) <= {"00", "11"}
         # A fair Bell state: both outcomes appear, roughly balanced.
         assert "00" in counts and "11" in counts
         assert abs(counts["00"] / 2000 - 0.5) < 0.1
+        # The native backend is seeded: the manifest reports the effective seed.
+        assert result.backend == "polypus"
+        assert isinstance(result.seed, int)
 
     def test_native_backend_accepts_qasm_string(self):
         import polypus
@@ -44,7 +47,7 @@ class TestRunQuantumCircuitBackends:
             qasm, shots=256, infrastructure="local", backend="polypus"
         )
         # X|0> = |1>: every shot reads "1".
-        assert result[0] == {"1": 256}
+        assert result.counts[0] == {"1": 256}
 
     def test_default_backend_is_aer(self):
         import polypus
@@ -52,7 +55,7 @@ class TestRunQuantumCircuitBackends:
         # No `backend` kwarg → Aer. Native Bell circuit still works end-to-end.
         qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
         result = polypus.run_quantum_circuit(qc, shots=1000, infrastructure="local")
-        counts = result[0]
+        counts = result.counts[0]
         assert sum(counts.values()) == 1000
         assert set(counts.keys()) <= {"00", "11"}
 
@@ -158,10 +161,10 @@ class TestNativeVsAerEquivalence:
         shots = 8000
         aer = polypus.run_quantum_circuit(
             build(), shots=shots, infrastructure="local", backend="aer"
-        )[0]
+        ).counts[0]
         native = polypus.run_quantum_circuit(
             build(), shots=shots, infrastructure="local", backend="polypus"
-        )[0]
+        ).counts[0]
 
         # Same bitstring format (3-bit keys) and close probabilities.
         assert all(len(k) == 3 for k in native)
@@ -207,7 +210,7 @@ class TestTrainNativeBackend:
             backend="polypus",
             **_TRAIN_KW,
         )
-        theta = result[0]
+        theta = result.best_params[0]
         p1 = math.sin(theta / 2) ** 2
         assert p1 > 0.9, f"native backend did not converge: θ={theta:.3f}, p1={p1:.3f}"
 

--- a/tests/python/test_local_run.py
+++ b/tests/python/test_local_run.py
@@ -14,64 +14,75 @@ pytestmark = pytest.mark.integration
 
 
 class TestRunQuantumCircuitSingleQpu:
-    """n_qpus=1 goes through AlgorithmSingleRun which returns the raw runner
-    output: a list with one counts dict."""
+    """n_qpus=1 goes through AlgorithmSingleRun. The counts payload (a list with
+    one counts dict) is exposed as ``RunResult.counts`` (contract C-7)."""
 
     def test_returns_list(self, bell_circuit):
         import polypus
         result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
-        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        assert isinstance(result.counts, list), f"Expected list, got {type(result.counts)}"
 
     def test_returns_one_element(self, bell_circuit):
         import polypus
         result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
-        assert len(result) == 1
+        assert len(result.counts) == 1
 
     def test_element_is_dict(self, bell_circuit):
         import polypus
         result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
-        assert isinstance(result[0], dict)
+        assert isinstance(result.counts[0], dict)
 
     def test_only_bell_states(self, bell_circuit):
         """A Bell circuit can only produce '00' or '11'."""
         import polypus
         result = polypus.run_quantum_circuit(bell_circuit, shots=1000, infrastructure="local")
-        assert set(result[0].keys()).issubset({"00", "11"}), (
-            f"Unexpected bitstrings in Bell result: {result[0].keys()}"
+        assert set(result.counts[0].keys()).issubset({"00", "11"}), (
+            f"Unexpected bitstrings in Bell result: {result.counts[0].keys()}"
         )
 
     def test_total_shots(self, bell_circuit):
         import polypus
         shots = 512
         result = polypus.run_quantum_circuit(bell_circuit, shots=shots, infrastructure="local")
-        assert sum(result[0].values()) == shots
+        assert sum(result.counts[0].values()) == shots
 
     def test_both_bell_states_observed(self, bell_circuit):
         """With 1000 shots both '00' and '11' should appear."""
         import polypus
         result = polypus.run_quantum_circuit(bell_circuit, shots=1000, infrastructure="local")
-        counts = result[0]
+        counts = result.counts[0]
         assert "00" in counts and "11" in counts
+
+    def test_manifest_defaults_for_aer(self, bell_circuit):
+        """The manifest records the run metadata; the default Aer backend is not
+        seeded, so the reported seed is None (contract C-7)."""
+        import polypus
+        result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
+        assert result.backend == "aer"
+        assert result.infrastructure == "local"
+        assert result.seed is None
 
 
 class TestRunQuantumCircuitMultipleQpus:
-    """n_qpus>1 goes through DistributeByShotsRun which merges partial results
-    into a single counts dict."""
+    """n_qpus>1 goes through DistributeByShotsRun, which merges partial results
+    into a single counts dict, exposed as ``RunResult.counts``."""
 
     def test_distributed_returns_dict(self, bell_circuit):
         import polypus
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=400, infrastructure="local", n_qpus=4
         )
-        assert isinstance(result, dict), f"Expected merged dict for n_qpus>1, got {type(result)}"
+        assert isinstance(result.counts, dict), (
+            f"Expected merged dict for n_qpus>1, got {type(result.counts)}"
+        )
 
     def test_distributed_only_bell_states(self, bell_circuit):
         import polypus
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=400, infrastructure="local", n_qpus=4
         )
-        assert set(result.keys()).issubset({"00", "11"}), (
-            f"Unexpected bitstrings in distributed Bell result: {result.keys()}"
+        assert set(result.counts.keys()).issubset({"00", "11"}), (
+            f"Unexpected bitstrings in distributed Bell result: {result.counts.keys()}"
         )
 
     def test_distributed_total_shots(self, bell_circuit):
@@ -80,7 +91,7 @@ class TestRunQuantumCircuitMultipleQpus:
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=shots, infrastructure="local", n_qpus=4
         )
-        assert sum(result.values()) == shots
+        assert sum(result.counts.values()) == shots
 
     def test_distributed_total_shots_not_divisible(self, bell_circuit):
         """Contract C-3: shots % n_qpus != 0 must still conserve the total.
@@ -90,7 +101,7 @@ class TestRunQuantumCircuitMultipleQpus:
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=shots, infrastructure="local", n_qpus=3
         )
-        assert sum(result.values()) == shots
+        assert sum(result.counts.values()) == shots
 
     def test_distributed_total_shots_fewer_than_qpus(self, bell_circuit):
         """Contract C-3 degenerate case: shots < n_qpus. 5 shots on 8 QPUs must
@@ -100,4 +111,4 @@ class TestRunQuantumCircuitMultipleQpus:
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=shots, infrastructure="local", n_qpus=8
         )
-        assert sum(result.values()) == shots
+        assert sum(result.counts.values()) == shots

--- a/tests/python/test_native_circuit.py
+++ b/tests/python/test_native_circuit.py
@@ -136,8 +136,8 @@ class TestRunNativeCircuit:
         result = polypus.run_quantum_circuit(
             native_bell_circuit, shots=1000, infrastructure="local"
         )
-        assert isinstance(result, list) and len(result) == 1
-        counts = result[0]
+        assert isinstance(result.counts, list) and len(result.counts) == 1
+        counts = result.counts[0]
         assert set(counts.keys()).issubset({"00", "11"})
         assert sum(counts.values()) == 1000
 
@@ -146,15 +146,15 @@ class TestRunNativeCircuit:
         result = polypus.run_quantum_circuit(
             native_bell_circuit, shots=400, infrastructure="local", n_qpus=4
         )
-        assert isinstance(result, dict)
-        assert set(result.keys()).issubset({"00", "11"})
-        assert sum(result.values()) == 400
+        assert isinstance(result.counts, dict)
+        assert set(result.counts.keys()).issubset({"00", "11"})
+        assert sum(result.counts.values()) == 400
 
     def test_qasm_string_input(self, native_bell_circuit):
         import polypus
         qasm = native_bell_circuit.to_qasm2()
         result = polypus.run_quantum_circuit(qasm, shots=500, infrastructure="local")
-        counts = result[0]
+        counts = result.counts[0]
         assert set(counts.keys()).issubset({"00", "11"})
         assert sum(counts.values()) == 500
 
@@ -170,10 +170,10 @@ class TestRunNativeCircuit:
         shots = 4000
         native = polypus.run_quantum_circuit(
             native_bell_circuit, shots=shots, infrastructure="local"
-        )[0]
+        ).counts[0]
         qiskit = polypus.run_quantum_circuit(
             bell_circuit, shots=shots, infrastructure="local"
-        )[0]
+        ).counts[0]
         for key in ("00", "11"):
             p_native = native.get(key, 0) / shots
             p_qiskit = qiskit.get(key, 0) / shots
@@ -216,8 +216,8 @@ class TestTrainNativeCircuit:
             id="test_native_de",
             **_TRAIN_KW,
         )
-        assert isinstance(result, list) and len(result) == 1
-        assert all(isinstance(v, float) for v in result)
+        assert isinstance(result.best_params, list) and len(result.best_params) == 1
+        assert all(isinstance(v, float) for v in result.best_params)
 
     def test_train_pso(self, native_parametrized_circuit, simple_expectation_fn):
         import polypus
@@ -228,7 +228,7 @@ class TestTrainNativeCircuit:
             id="test_native_pso",
             **_TRAIN_KW,
         )
-        assert isinstance(result, list) and len(result) == 1
+        assert isinstance(result.best_params, list) and len(result.best_params) == 1
 
     def test_train_qng(self, native_parametrized_circuit, simple_expectation_fn, simple_variance_fn):
         import polypus
@@ -239,7 +239,7 @@ class TestTrainNativeCircuit:
             id="test_native_qng",
             **_TRAIN_KW,
         )
-        assert isinstance(result, list) and len(result) == 1
+        assert isinstance(result.best_params, list) and len(result.best_params) == 1
 
     def test_dimension_mismatch_raises_before_training(self, native_parametrized_circuit, simple_expectation_fn):
         import polypus
@@ -267,12 +267,12 @@ class TestTrainNativeCircuit:
             native_parametrized_circuit, method(),
             expectation_function=simple_expectation_fn,
             id="test_native_conv", **kwargs,
-        )[0]
+        ).best_params[0]
         theta_qiskit = polypus.train(
             parametrized_circuit, method(),
             expectation_function=simple_expectation_fn,
             id="test_qiskit_conv", **kwargs,
-        )[0]
+        ).best_params[0]
 
         # Both must approach θ = π (probability of |1⟩ maximised).
         p1 = math.sin(theta_native / 2) ** 2

--- a/tests/python/test_qasm_import.py
+++ b/tests/python/test_qasm_import.py
@@ -95,7 +95,7 @@ class TestRunImportedCircuit:
         result = polypus.run_quantum_circuit(
             imported, shots=1000, infrastructure="local"
         )
-        counts = result[0]
+        counts = result.counts[0]
         assert set(counts.keys()).issubset({"00", "11"})
         assert sum(counts.values()) == 1000
         assert abs(counts.get("00", 0) - 500) < 150

--- a/tests/python/test_seed_reproducibility.py
+++ b/tests/python/test_seed_reproducibility.py
@@ -1,0 +1,256 @@
+"""
+Seed reproducibility & run manifest — public-API end-to-end tests (contract C-7).
+
+These exercise issue #34's acceptance criteria from Python:
+
+* ``run_quantum_circuit(..., seed=...)`` on the native backend: same seed ⇒
+  identical counts; no seed ⇒ different counts; the effective seed and manifest
+  are returned; a seed with any non-native backend is rejected.
+* ``train`` / ``qml.train`` seed: same seed ⇒ identical outcome; no seed ⇒
+  different outcome; the outcome now exposes fitness / iterations / convergence
+  / seed, and the ``DE``/``PSO``/``QNG`` ``seed`` field feeds the precedence.
+
+The native backend is fully seeded by Polypus, so its reproducibility tests need
+no mocking. ``qml.train`` runs on Qiskit/Aer (native rejected) and Aer's own shot
+sampling is not seeded by Polypus, so that test mocks ``polypus_python.run_qcs``
+to make the oracle deterministic and isolate the optimizer RNG the seed controls.
+"""
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run_quantum_circuit — native backend is seeded; other backends reject a seed
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _uniform3():
+    """3-qubit uniform superposition: eight outcomes, so two independent
+    samplings differ with overwhelming probability (non-flaky inequality)."""
+    import polypus
+
+    return polypus.Circuit(3).h(0).h(1).h(2).measure_all()
+
+
+@pytest.mark.integration
+class TestRunQuantumCircuitSeed:
+    def test_same_seed_reproduces_counts(self):
+        import polypus
+
+        qc = _uniform3()
+        r1 = polypus.run_quantum_circuit(
+            qc, shots=2000, infrastructure="local", backend="polypus", seed=42
+        )
+        r2 = polypus.run_quantum_circuit(
+            qc, shots=2000, infrastructure="local", backend="polypus", seed=42
+        )
+        assert r1.seed == 42 and r2.seed == 42
+        assert r1.counts == r2.counts
+
+    def test_no_seed_differs_across_calls(self):
+        import polypus
+
+        qc = _uniform3()
+        r1 = polypus.run_quantum_circuit(
+            qc, shots=2000, infrastructure="local", backend="polypus"
+        )
+        r2 = polypus.run_quantum_circuit(
+            qc, shots=2000, infrastructure="local", backend="polypus"
+        )
+        # An entropy seed is generated, reported, and fresh on every call.
+        assert isinstance(r1.seed, int) and isinstance(r2.seed, int)
+        assert r1.seed != r2.seed
+        assert r1.counts != r2.counts
+
+    def test_manifest_fields(self):
+        import polypus
+
+        qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
+        r = polypus.run_quantum_circuit(
+            qc, shots=100, infrastructure="local", backend="polypus", seed=7
+        )
+        assert r.seed == 7
+        assert r.backend == "polypus"
+        assert r.infrastructure == "local"
+        assert r.id == "run_1_local"
+        assert isinstance(r.counts, list) and len(r.counts) == 1
+
+    def test_seed_rejected_for_aer(self):
+        import polypus
+
+        qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
+        with pytest.raises(ValueError, match="seed is only supported"):
+            polypus.run_quantum_circuit(
+                qc, shots=100, infrastructure="local", backend="aer", seed=1
+            )
+
+    def test_seed_rejected_for_qmio(self):
+        import polypus
+
+        qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
+        with pytest.raises(ValueError, match="seed is only supported"):
+            polypus.run_quantum_circuit(
+                qc, shots=100, infrastructure="qmio", seed=1
+            )
+
+    def test_aer_without_seed_reports_none(self):
+        import polypus
+
+        qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
+        r = polypus.run_quantum_circuit(qc, shots=100, infrastructure="local", backend="aer")
+        assert r.seed is None
+        assert r.backend == "aer"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DE / PSO / QNG `seed` field (no backend needed)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestOptimizerSeedField:
+    def test_defaults_to_none(self):
+        import polypus
+
+        assert polypus.DE().seed is None
+        assert polypus.PSO().seed is None
+        assert polypus.QNG(lambda theta, a: 0.5).seed is None
+
+    def test_getter_setter_roundtrip(self):
+        import polypus
+
+        de = polypus.DE(seed=5)
+        assert de.seed == 5
+        de.seed = 8
+        assert de.seed == 8
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# train — native backend is fully reproducible from a single seed
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _all_ones(bitstring):
+    return float(all(b == "1" for b in bitstring))
+
+
+@pytest.mark.integration
+@pytest.mark.vqc
+class TestTrainSeed:
+    @staticmethod
+    def _train(seed=None, method=None, ident="train_seed"):
+        import polypus
+
+        qc = polypus.Circuit(1).ry(0, polypus.Param(0)).measure_all()
+        return polypus.train(
+            qc,
+            method or polypus.DE(generations=5, population_size=8, tolerance=1e-12),
+            shots=256,
+            n_qpus=1,
+            dimensions=1,
+            expectation_function=_all_ones,
+            infrastructure="local",
+            nodes=1,
+            cores_per_qpu=1,
+            id=ident,
+            backend="polypus",
+            seed=seed,
+        )
+
+    def test_same_seed_reproduces_outcome(self):
+        r1 = self._train(seed=2024)
+        r2 = self._train(seed=2024)
+        assert r1.seed == 2024 and r2.seed == 2024
+        assert r1.best_params == r2.best_params
+        assert r1.best_fitness == r2.best_fitness
+        assert r1.iterations_run == r2.iterations_run
+        assert r1.converged == r2.converged
+        # The full outcome is exposed now, not just the parameters (C-7).
+        assert isinstance(r1.best_fitness, float)
+        assert isinstance(r1.iterations_run, int)
+        assert isinstance(r1.converged, bool)
+
+    def test_no_seed_differs_across_calls(self):
+        r1 = self._train(seed=None, ident="train_seed_none")
+        r2 = self._train(seed=None, ident="train_seed_none")
+        assert r1.seed != r2.seed
+        assert r1.best_params != r2.best_params
+
+    def test_optimizer_field_seed_is_used(self):
+        import polypus
+
+        # No kwarg seed → the seed pinned on the optimizer object drives the run.
+        m1 = polypus.DE(generations=5, population_size=8, tolerance=1e-12, seed=99)
+        m2 = polypus.DE(generations=5, population_size=8, tolerance=1e-12, seed=99)
+        r1 = self._train(seed=None, method=m1, ident="train_field_seed")
+        r2 = self._train(seed=None, method=m2, ident="train_field_seed")
+        assert r1.seed == 99 and r2.seed == 99
+        assert r1.best_params == r2.best_params
+
+    def test_kwarg_seed_overrides_field(self):
+        import polypus
+
+        # The explicit kwarg wins over the optimizer object's field.
+        m = polypus.DE(generations=5, population_size=8, tolerance=1e-12, seed=1)
+        r = self._train(seed=777, method=m, ident="train_override")
+        assert r.seed == 777
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# qml.train — optimizer RNG is seeded; Aer sampling isn't, so mock the backend
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.vqc
+class TestQmlTrainSeed:
+    @staticmethod
+    def _patch_deterministic_backend(monkeypatch):
+        import polypus_python
+
+        # Fixed counts regardless of the circuit ⇒ a deterministic oracle, so the
+        # only remaining randomness is the optimizer RNG that qml.train's seed
+        # controls (Aer's own shot sampling is not seeded by Polypus; C-7).
+        def fake_run_qcs(infrastructure, **kwargs):
+            return [{"1": kwargs["shots"]} for _ in kwargs["qcs"]]
+
+        monkeypatch.setattr(polypus_python, "run_qcs", fake_run_qcs)
+
+    @staticmethod
+    def _qml_train(seed):
+        import numpy as np
+        import polypus
+        from qiskit.circuit.library import real_amplitudes, zz_feature_map
+
+        feature_map = zz_feature_map(feature_dimension=2, reps=1)
+        ansatz = real_amplitudes(num_qubits=2, reps=1)
+        x_train = np.zeros((2, 2))
+        return polypus.qml.train(
+            feature_map,
+            ansatz,
+            x_train,
+            polypus.DE(generations=3, population_size=6, tolerance=1e-12),
+            shots=64,
+            n_qpus=1,
+            dimensions=len(ansatz.parameters),
+            expectation_function=lambda b: sum(int(c) for c in b) / len(b),
+            infrastructure="local",
+            nodes=1,
+            cores_per_qpu=1,
+            id="qml_seed",
+            seed=seed,
+        )
+
+    def test_same_seed_reproduces_outcome(self, monkeypatch):
+        self._patch_deterministic_backend(monkeypatch)
+        r1 = self._qml_train(123)
+        r2 = self._qml_train(123)
+        assert r1.seed == 123 and r2.seed == 123
+        assert r1.best_params == r2.best_params
+        assert r1.best_fitness == r2.best_fitness
+
+    def test_no_seed_differs_across_calls(self, monkeypatch):
+        self._patch_deterministic_backend(monkeypatch)
+        r1 = self._qml_train(None)
+        r2 = self._qml_train(None)
+        assert r1.seed != r2.seed
+        assert r1.best_params != r2.best_params

--- a/tests/python/test_vqc.py
+++ b/tests/python/test_vqc.py
@@ -42,7 +42,15 @@ class TestTrainDE:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_de",
         )
-        assert isinstance(result, list), f"Expected list of parameters, got {type(result)}"
+        assert isinstance(result.best_params, list), (
+            f"Expected list of parameters, got {type(result.best_params)}"
+        )
+        # The richer result also carries fitness / iterations / convergence /
+        # seed (contract C-7), not just the parameters.
+        assert isinstance(result.best_fitness, float)
+        assert isinstance(result.iterations_run, int)
+        assert isinstance(result.converged, bool)
+        assert isinstance(result.seed, int)
 
     def test_train_result_length(self, parametrized_circuit, simple_expectation_fn):
         import polypus
@@ -58,7 +66,7 @@ class TestTrainDE:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_de_len",
         )
-        assert len(result) == _DIMENSIONS
+        assert len(result.best_params) == _DIMENSIONS
 
     def test_train_result_contains_floats(self, parametrized_circuit, simple_expectation_fn):
         import polypus
@@ -74,7 +82,7 @@ class TestTrainDE:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_de_floats",
         )
-        for val in result:
+        for val in result.best_params:
             assert isinstance(val, float), f"Expected float parameter, got {type(val)}"
 
 
@@ -93,7 +101,7 @@ class TestTrainPSO:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_pso",
         )
-        assert isinstance(result, list)
+        assert isinstance(result.best_params, list)
 
     def test_train_result_length(self, parametrized_circuit, simple_expectation_fn):
         import polypus
@@ -109,7 +117,7 @@ class TestTrainPSO:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_pso_len",
         )
-        assert len(result) == _DIMENSIONS
+        assert len(result.best_params) == _DIMENSIONS
 
 
 class TestTrainQNG:
@@ -134,7 +142,7 @@ class TestTrainQNG:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_qng",
         )
-        assert isinstance(result, list)
+        assert isinstance(result.best_params, list)
 
     def test_train_result_length(
         self, parametrized_circuit, simple_expectation_fn, simple_variance_fn
@@ -156,7 +164,7 @@ class TestTrainQNG:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_qng_len",
         )
-        assert len(result) == _DIMENSIONS
+        assert len(result.best_params) == _DIMENSIONS
 
 
 class TestTrainInvalidMethod:


### PR DESCRIPTION
Closes #34.

## Problem
Two defects at the Rust↔Python seam:
1. `run_quantum_circuit` derived the native backend's RNG seed from the hardcoded
   run `id`, so **repeated identical calls returned byte-identical counts** — the
   "shot noise" wasn't noise, making aggregated repeats statistically invalid.
2. `train`/`qml.train` hardcoded `seed: None` (training was **impossible to
   reproduce** from Python) and discarded the `OptimizationOutcome`, returning
   only the parameter list.

## Changes
- **Seeding.** New `seed=` kwarg on `run_quantum_circuit`, `train`, `qml.train`,
  and a `seed` field on `DE`/`PSO`/`QNG`.
  - `run_quantum_circuit`: seeds the native (`polypus`) backend — same seed
    reproduces counts, omitted seed draws OS entropy. `id` is fully decoupled
    from the RNG. A seed with any non-native backend raises `ValueError` (never
    silently ignored — Aer/CUNQA/QMIO aren't seeded by Polypus).
  - `train`/`qml.train`: seeds the optimizer RNG (precedence: kwarg > optimizer
    field > OS entropy). On the native backend the same seed also drives shot
    sampling, so a native-backend run reproduces end-to-end.
- **Run manifest (⚠️ breaking return shape).**
  - `run_quantum_circuit` → `RunResult` (`counts`, `id`, `seed`, `backend`,
    `infrastructure`).
  - `train`/`qml.train` → `TrainResult` (`best_params`, `best_fitness`,
    `iterations_run`, `converged`, `seed`).
  - The effective seed is returned so a run can be logged and replayed.
- **Contract C-7** added to `docs/CONTRACTS.md` (seed semantics per backend +
  manifest shapes), plus a note on C-3.

## Migration
- `result[0]` → `result.counts[0]`
- `params = train(...)` → `result = train(...); result.best_params`

All in-tree consumers (tests, benchmarks, examples, README, crate docs) are
already updated.

## Testing
- Rust: native seed round-trip through `run_quantum_circuit`, non-native
  rejection, seed-precedence + optimizer determinism; rewrote the old
  `seeding_is_reproducible_per_id` (which encoded the bug) into same-seed /
  distinct-seed / omitted-seed cases.
- Python: new `tests/python/test_seed_reproducibility.py` (14 tests) covering the
  acceptance criteria end-to-end.
- Green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets
  -D warnings` (+ `--features qmio`), `cargo test --workspace`, pure crates
  `--all-features`, `pytest tests/python` (110).

## Notes
- `qml.train` runs on Aer only (native rejected); Aer's shot sampling isn't
  seeded by Polypus, so its reproducibility guarantee covers the optimizer
  trajectory given a deterministic oracle.
- Commits: `75228e8` (implementation) · `df4d71e` (docs).