### PR TITLE
fix(infrastructure): extend seed reproducibility to Aer and CUNQA (C-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Set `n_qpus > 1` to split the shots across available QPUs and reduce execution t
 result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10)
 ```
 
-Both calls return a `RunResult`: `result.counts` holds the measurement payload — a `list[dict[str, int]]` for a single QPU, or a single merged `dict[str, int]` when `n_qpus > 1`. The manifest fields `result.id`, `result.seed`, `result.backend` and `result.infrastructure` record the run for logging and replay (`seed` is the effective RNG seed on the native `"polypus"` backend, `None` otherwise).
+Both calls return a `RunResult`: `result.counts` holds the measurement payload — a `list[dict[str, int]]` for a single QPU, or a single merged `dict[str, int]` when `n_qpus > 1`. The manifest fields `result.id`, `result.seed`, `result.backend` and `result.infrastructure` record the run for logging and replay. Pass `seed=...` to `run_quantum_circuit()` for reproducible shot noise on every simulated backend (native `"polypus"`, Aer, and CUNQA's simulated QPUs); `result.seed` reports the effective seed used (`None` only for the `"qmio"` infrastructure, which is real hardware and rejects an explicit seed).
 
 ### Training Variational Circuits
 

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -38,11 +38,12 @@ use std::sync::Arc;
 /// ([`AlgorithmSingleRun`](crate::algorithms::AlgorithmSingleRun)), or a single
 /// merged `dict[str, int]` for a distributed (`n_qpus > 1`) run
 /// ([`DistributeByShotsRun`](crate::algorithms::DistributeByShotsRun)); the
-/// per-dict format is contract C-3. The manifest fields make a native run
+/// per-dict format is contract C-3. The manifest fields make a simulated run
 /// reproducible: feeding the reported [`seed`](Self::seed) back into
-/// `run_quantum_circuit(..., backend="polypus")` reproduces the counts
-/// byte-for-byte. `seed` is `None` for non-native backends, which Polypus does
-/// not seed.
+/// `run_quantum_circuit(..., seed=...)` reproduces the counts byte-for-byte on
+/// any of the native, Aer, or CUNQA (simulated-QPU) backends. `seed` is `None`
+/// only for the `qmio` infrastructure, which runs on real hardware that
+/// Polypus cannot seed.
 #[pyclass(frozen)]
 pub struct RunResult {
     /// Measurement counts. Shape depends on `n_qpus` (see the type docs).
@@ -51,8 +52,8 @@ pub struct RunResult {
     /// Run identifier used for logging, temp files and SLURM job names.
     #[pyo3(get)]
     pub id: String,
-    /// Effective RNG seed used by the native backend's shot sampling
-    /// (user-supplied or OS-entropy). `None` for non-native backends.
+    /// Effective RNG seed used by the backend's shot sampling (user-supplied or OS-entropy).
+    /// Now supported for `native`, `aer`, and `cunqa`. `None` for `qmio` hardware.
     #[pyo3(get)]
     pub seed: Option<u64>,
     /// Device selected within the infrastructure (`"aer"`, `"polypus"`, …).
@@ -136,16 +137,6 @@ fn outcome_to_train_result(
         },
     )
     .map(|result| result.into_any())
-}
-
-/// Whether this `infrastructure` + `backend` combination actually runs on the
-/// native pure-Rust statevector backend — the only backend whose shot sampling
-/// Polypus seeds. It is reached exclusively via `infrastructure="local"` +
-/// `backend="polypus"`; every other combination runs Aer, CUNQA or QMIO, none
-/// of which consume `ExecutionConfig::seed`, so an explicit seed there would be
-/// silently ineffective (see [`run_quantum_circuit`]).
-fn uses_native_backend(infrastructure: &str, backend: &str) -> bool {
-    infrastructure == "local" && is_native_backend(backend)
 }
 
 /// Resolve the optimizer seed for `train` / `qml_train` (contract C-7).
@@ -329,13 +320,15 @@ fn extract_bound_circuit(qc: &Bound<'_, PyAny>) -> PyResult<BoundCircuit> {
 /// or an OpenQASM 2.0 string. `backend` selects the local device: `"aer"`
 /// (default) or the pure-Rust `"polypus"` statevector simulator.
 ///
-/// `seed` controls the native backend's shot sampling (contract C-7): with
-/// `backend="polypus"` an explicit `seed` reproduces the counts byte-for-byte,
-/// and omitting it draws a fresh OS-entropy seed so repeated runs give genuinely
-/// independent noise. Passing a `seed` with any other backend raises
-/// `ValueError` rather than silently ignoring it, since only the native backend
-/// is seeded here. Returns a [`RunResult`] carrying the counts plus a manifest
-/// (`id`, effective `seed`, `backend`, `infrastructure`) for logging and replay.
+/// `seed` controls shot sampling (contract C-7) on every simulated backend —
+/// native, Aer (`infrastructure="local"`) and CUNQA's simulated QPUs
+/// (`infrastructure="cunqa"`): an explicit `seed` reproduces the counts
+/// byte-for-byte, and omitting it draws a fresh OS-entropy seed so repeated
+/// runs give genuinely independent noise. Passing a `seed` with
+/// `infrastructure="qmio"` raises `ValueError` rather than silently ignoring
+/// it, since that infrastructure is real hardware and cannot be seeded.
+/// Returns a [`RunResult`] carrying the counts plus a manifest (`id`,
+/// effective `seed`, `backend`, `infrastructure`) for logging and replay.
 #[pyfunction(signature=(qc, shots, infrastructure, n_qpus=1, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
 // Rich FFI entry point mirroring a many-kwarg Python API; same rationale and
 // convention as `train`/`qml_train` below.
@@ -377,21 +370,21 @@ pub fn run_quantum_circuit<'py>(
             ));
         }
     }
-    // Resolve the shot-sampling seed. Only the native statevector backend is
-    // seeded by Polypus; for any other backend an explicit seed would be
-    // silently ineffective, so reject it rather than give false confidence in
-    // reproducibility. When native, `None` means "draw a fresh OS-entropy seed",
-    // resolved here so the effective value can be reported in the manifest.
-    let effective_seed: Option<u64> = if uses_native_backend(&infrastructure, backend) {
-        Some(seed.unwrap_or_else(random_seed))
-    } else if seed.is_some() {
-        return Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "seed is only supported for the native statevector backend \
-             (infrastructure=\"local\", backend=\"polypus\"); backend=\"{backend}\" on \
-             infrastructure=\"{infrastructure}\" does not support seeding"
-        )));
-    } else {
+    // Resolve the shot-sampling seed. Every simulated backend (native, Aer,
+    // CUNQA's simulated QPUs) is seeded by Polypus; `qmio` is real hardware, so
+    // an explicit seed there would be silently ineffective — reject it rather
+    // than give false confidence in reproducibility. When simulated, `None`
+    // means "draw a fresh OS-entropy seed", resolved here so the effective
+    // value can be reported in the manifest.
+    let effective_seed: Option<u64> = if infrastructure == "qmio" {
+        if seed.is_some() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "seed is not supported for the 'qmio' infrastructure (real quantum hardware)",
+            ));
+        }
         None
+    } else {
+        Some(seed.unwrap_or_else(random_seed))
     };
 
     let id = format!("run_{}_{}", n_qpus, infrastructure);
@@ -617,10 +610,10 @@ pub fn train<'py>(
 ///    fitness value.
 ///
 /// `seed` follows the same precedence as [`train`] and makes the optimizer's
-/// search reproducible; it returns a [`TrainResult`]. Note that qml.train runs
-/// on the Qiskit/Aer path (the native backend is rejected), and Aer's own shot
-/// sampling is not seeded by Polypus, so full end-to-end reproducibility holds
-/// only for a deterministic oracle (contract C-7).
+/// search reproducible; it returns a [`TrainResult`]. `qml.train` runs on the
+/// Qiskit/Aer path (the native backend is rejected), and Aer's shot sampling
+/// is now seeded too (contract C-7), so a `qml.train` run is fully
+/// reproducible end-to-end given the same seed.
 ///
 /// Example:
 ///
@@ -656,8 +649,8 @@ pub fn qml_train<'py>(
     validate_shots_and_qpus(shots, n_qpus)?;
     // Same seed precedence as `train` (contract C-7): kwarg > optimizer field >
     // OS entropy. qml.train always runs on a Qiskit/Aer path (native rejected
-    // below), so this seed governs the optimizer's RNG; Aer's own shot sampling
-    // is not seeded by Polypus.
+    // below); this seed governs the optimizer's RNG and, since it's threaded
+    // into ExecutionConfig::seed below, Aer's shot sampling too.
     let effective_seed = resolve_optimizer_seed(seed, method_seed(&method));
     // QML composes Qiskit feature maps and ansätze, so it is inherently a
     // Qiskit path; the native statevector backend cannot consume a Qiskit
@@ -943,30 +936,29 @@ mod tests {
         });
     }
 
-    /// A seed passed with any non-native backend is rejected, never silently
-    /// dropped — Polypus only seeds the native statevector backend.
+    /// A seed passed with `infrastructure="qmio"` is rejected, never silently
+    /// dropped — that infrastructure is real hardware and Polypus cannot seed
+    /// it, unlike the native, Aer, and CUNQA simulated backends.
     #[test]
-    fn seed_rejected_for_non_native_backends() {
+    fn seed_rejected_for_qmio_hardware() {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             let qasm = uniform3_qasm();
-            for (infra, backend) in [("local", "aer"), ("cunqa", "aer"), ("qmio", "aer")] {
-                let qc = PyString::new(py, &qasm).into_any();
-                let result = run_quantum_circuit(
-                    qc,
-                    100,
-                    infra.to_string(),
-                    1,
-                    "automatic",
-                    None,
-                    backend,
-                    Some(3),
-                );
-                assert!(
-                    result.is_err(),
-                    "an explicit seed must be rejected for infrastructure={infra}, backend={backend}"
-                );
-            }
+            let qc = pyo3::types::PyString::new(py, &qasm).into_any();
+            let result = run_quantum_circuit(
+                qc,
+                100,
+                "qmio".to_string(),
+                1,
+                "automatic",
+                None,
+                "aer",
+                Some(3),
+            );
+            assert!(
+                result.is_err(),
+                "an explicit seed must be rejected for infrastructure=qmio"
+            );
         });
     }
 

--- a/crates/polypus/src/infrastructure/cunqa.rs
+++ b/crates/polypus/src/infrastructure/cunqa.rs
@@ -50,6 +50,14 @@ impl QuantumBackend for CunqaBackend {
             kwargs.set_item("qcs", qcs_pylist).unwrap();
             kwargs.set_item("shots", config.shots).unwrap();
             kwargs.set_item("sim_method", &self.sim_method).unwrap();
+            // Forwarded to each QPU's `run(..., seed=...)` on the Python side
+            // (contract C-7); `None` is simply omitted, so CUNQA's own
+            // unseeded default behavior is unchanged. Unlike the identical
+            // arrangement for Aer (`local.rs`), this seam is unverified — see
+            // `polypus_python/cunqa.py` for the caveats.
+            if let Some(seed) = config.seed {
+                kwargs.set_item("seed", seed).unwrap();
+            }
 
             module
                 .call_method("run_qcs", ("cunqa",), Some(&kwargs))

--- a/crates/polypus/src/infrastructure/local.rs
+++ b/crates/polypus/src/infrastructure/local.rs
@@ -68,6 +68,12 @@ impl QuantumBackend for LocalBackend {
             if let Some(nm) = &self.noise_model {
                 kwargs.set_item("noise_model", nm.clone_ref(py)).unwrap();
             }
+            // Forwarded to Aer's `seed_simulator` on the Python side (contract
+            // C-7); `None` is simply omitted rather than sent as `seed=None`,
+            // so Aer's own unseeded default behavior is unchanged.
+            if let Some(seed) = config.seed {
+                kwargs.set_item("seed", seed).unwrap();
+            }
 
             module
                 .call_method("run_qcs", (connection_str,), Some(&kwargs))

--- a/crates/polypus/src/lib.rs
+++ b/crates/polypus/src/lib.rs
@@ -28,8 +28,10 @@
 //! Both calls return a `RunResult`: `result.counts` holds the payload (a
 //! `list[dict]` for a single QPU, a merged `dict` for `n_qpus > 1`), plus
 //! `result.id` / `result.seed` / `result.backend` / `result.infrastructure`
-//! for logging and replay (`seed` is the effective RNG seed on the native
-//! backend, `None` otherwise).
+//! for logging and replay. Pass `seed=...` for reproducible shot noise on
+//! every simulated backend (native, Aer, CUNQA); `result.seed` reports the
+//! effective seed (`None` only for the `"qmio"` infrastructure, real hardware
+//! that cannot be seeded).
 //!
 //! ## Training a variational circuit
 //! Pass a method object as the second argument to `train()`. The optimizer-specific

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -58,8 +58,8 @@ violation.
 
 | backend | kwargs (exact names) |
 |---|---|
-| local | `id: str`, `backend: str`, `qcs: list`, `shots: int`, `sim_method: str`, `noise_model` (optional) |
-| cunqa | `family_id: str`, `backend: str`, `qcs: list`, `shots: int`, `sim_method: str` |
+| local | `id: str`, `backend: str`, `qcs: list`, `shots: int`, `sim_method: str`, `noise_model` (optional), `seed: int` (optional, C-7) |
+| cunqa | `family_id: str`, `backend: str`, `qcs: list`, `shots: int`, `sim_method: str`, `seed: int` (optional, C-7) |
 
 `qcs` elements are either Qiskit `QuantumCircuit` objects or OpenQASM 2.0
 strings; the Python side parses strings (`QuantumCircuit.from_qasm_str`).
@@ -212,18 +212,33 @@ freezes the *internal* `run_qcs` seam to the `polypus_python` package.)
 
 ### The `seed` kwarg
 
-- **`run_quantum_circuit(..., seed: int | None = None)`** seeds shot sampling,
-  which **only the native statevector backend** performs in-process:
-  - With the native backend (`infrastructure="local"`, `backend="polypus"`): an
-    explicit `seed` is used directly and reproduces the counts byte-for-byte
-    across calls; `seed=None` draws a fresh seed from OS entropy, so repeated
-    calls produce **independent** noise (never the run-`id`-derived repetition
-    that motivated this contract). The run `id` is decoupled from the RNG — it
-    is only a logging/temp-file/SLURM label.
-  - With any other backend (`backend="aer"`, or `infrastructure` `"cunqa"` /
-    `"qmio"`): passing an explicit `seed` raises `ValueError`. Polypus does not
-    seed these paths (Aer's own `seed_simulator` is not wired), so silently
-    accepting a seed would give false confidence in reproducibility. `seed=None`
+- **`run_quantum_circuit(..., seed: int | None = None)`** seeds shot sampling
+  across every *simulated* backend:
+  - With `infrastructure="local"` (`backend="polypus"`, the native
+    statevector simulator, or `backend="aer"`, Qiskit Aer): an explicit `seed`
+    is used directly — the native backend seeds its own RNG in-process, and
+    Aer receives it as the `seed` kwarg forwarded across the C-1 seam
+    (`crates/polypus/src/infrastructure/local.rs`, which passes it to Aer's
+    `seed_simulator` option in `polypus_python`'s `local.py`) — and
+    reproduces the counts byte-for-byte across calls, verified against a real
+    Aer install. `seed=None` draws a fresh seed from OS entropy, so repeated
+    calls produce **independent** noise (never the run-`id`-derived
+    repetition that motivated this contract). The run `id` is decoupled from
+    the RNG — it is only a logging/temp-file/SLURM label.
+  - With `infrastructure="cunqa"`: the same `seed` kwarg is forwarded across
+    the same seam (`crates/polypus/src/infrastructure/cunqa.rs` mirrors
+    `local.rs`, `polypus_python`'s `cunqa.py` mirrors `local.py`), with a
+    per-QPU offset so distributed shots aren't identical copies. **This path
+    is unverified** — the `cunqa` package isn't installed anywhere this can be
+    tested, and reading CUNQA's actual source (CESGA-Quantum-Spain/cunqa) at
+    the version README.md pins (`>= 2.3`) turned up API mismatches predating
+    this contract (wrong module path, wrong kwarg names, a `.run()` method
+    that may not exist on `QPU` objects at that version) — see the CUNQA
+    integration follow-up.
+  - With physical hardware (`infrastructure="qmio"`): passing an explicit
+    `seed` raises `ValueError`. Real quantum processors rely on physical
+    processes and cannot be deterministically seeded, so silently accepting
+    a seed would give false confidence in reproducibility. `seed=None`
     behaves exactly as before.
 - **`train(..., seed=None)` / `qml.train(..., seed=None)`** seed the optimizer's
   RNG and are **always accepted**, for every backend, because the seed's primary
@@ -231,18 +246,19 @@ freezes the *internal* `run_qcs` seam to the `polypus_python` package.)
   `polypus-optimizers`) is independent of which backend evaluates the oracle.
   Precedence: the explicit `seed` kwarg wins; otherwise the `seed` field pinned
   on the `DE`/`PSO`/`QNG` instance; otherwise a fresh OS-entropy value. On the
-  native backend the resolved seed *also* seeds shot sampling, so a
-  native-backend training run is reproducible end-to-end; `qml.train` is
-  Qiskit/Aer-only (native rejected) and Aer shot noise is unseeded, so its
-  reproducibility guarantee covers the optimizer trajectory given a deterministic
-  oracle, not Aer's sampling.
+  native, Aer, and CUNQA backends the resolved seed *also* seeds shot sampling,
+  so a `train()` run on any of them is reproducible end-to-end; `qml.train` is
+  Qiskit/Aer-only (native rejected), and since Aer shot noise is now seeded
+  too, its reproducibility guarantee covers both the optimizer trajectory and
+  Aer's sampling.
 
 ### The run manifest (return shapes)
 
 - `run_quantum_circuit` returns a **`RunResult`** exposing:
   `counts` (the C-3 payload — `list[dict]` for one QPU, merged `dict` for
   `n_qpus > 1`), `id` (str), `seed` (`int | None`; the effective seed used, or
-  `None` for a non-native backend), `backend` (str), `infrastructure` (str).
+  `None` only for the `qmio` infrastructure), `backend` (str), `infrastructure`
+  (str).
 - `train` / `qml.train` return a **`TrainResult`** exposing the full
   optimization outcome — `best_params` (`list[float]`), `best_fitness` (float),
   `iterations_run` (int), `converged` (bool) — plus `seed` (int, the effective
@@ -253,9 +269,18 @@ The effective `seed` on both result types is what lets a caller log a run and
 replay it exactly.
 
 **Enforcing test:** `tests/python/test_seed_reproducibility.py` (public-API
-end-to-end: native reproducibility, entropy variation, the non-native
+end-to-end: native and Aer reproducibility, entropy variation, the `qmio`
 rejection, and the returned manifest/outcome fields), plus the Rust tests in
 `crates/polypus/src/bindings/mod.rs` (native seed round-trip through
-`run_quantum_circuit`, the rejection path, and the seed-resolution precedence /
-optimizer determinism) and `crates/polypus/src/infrastructure/native.rs`
-(same-seed reproduces / omitted-seed differs at the backend level).
+`run_quantum_circuit`, the `qmio` rejection path, and the seed-resolution
+precedence / optimizer determinism) and `crates/polypus/src/infrastructure/native.rs`
+(same-seed reproduces / omitted-seed differs at the backend level). CUNQA's
+`seed` forwarding follows the same shape as Aer's on the Rust side
+(`crates/polypus/src/infrastructure/cunqa.rs` mirrors `local.rs`) but has no
+dedicated automated test and no verified-working status: per `ENGINEERING.md`
+§3 the Rust suite is deliberately Python-runtime-free, so this seam can only
+be tested from `tests/python/`, and the `cunqa` package isn't installed
+anywhere in this project's CI or dev sandboxes (unlike Aer) — so, unlike the
+Aer path, it has never actually been run. Treat CUNQA's `seed` support as
+unverified until the CUNQA integration follow-up confirms it against a real
+install.

--- a/packages/polypus_python/polypus_python/cunqa.py
+++ b/packages/polypus_python/polypus_python/cunqa.py
@@ -37,6 +37,8 @@ class Cunqa(Infraestructure):
         shots = args["shots"]
         sim_method = args.get("sim_method", "automatic")
 
+        seed = args.get("seed", None)
+
         sys.path.append(os.getenv("HOME"))
         try:
             qpus = get_QPUs(local=False, family=family_id)
@@ -47,7 +49,33 @@ class Cunqa(Infraestructure):
         try:
             qjobs = []
             for i in range(len(qcs)):
-                qjob = qpus[i].run(qcs[i], shots=shots, transpile=False)
+                if seed is not None:
+                    # `seed` (not `seed_simulator`) is the kwarg CUNQA's own
+                    # docs name (reference/api/run_configuration.html).
+                    # Offset by QPU index (mirrors the native backend's
+                    # `base_seed + i` in native.rs) so each QPU gets a
+                    # distinct, deterministic seed instead of every QPU
+                    # reproducing the exact same counts; masked to the 63-bit
+                    # range Aer accepts, since CUNQA's simulated QPUs are
+                    # Aer-based (same reason as local.py's mask).
+                    #
+                    # UNVERIFIED beyond the kwarg name: the `cunqa` package
+                    # isn't installed anywhere this can be exercised, and
+                    # CESGA-Quantum-Spain/cunqa@2.3.0 (the version README.md
+                    # pins) has no `QPU.run()` method at all (only
+                    # `.execute()`) and no `cunqa.qutils` module, which this
+                    # file already imports from above — this whole
+                    # integration may not run at all against that version.
+                    # See the follow-up task for reconciling this file with
+                    # the real, deployed CUNQA API.
+                    qjob = qpus[i].run(
+                        qcs[i],
+                        shots=shots,
+                        transpile=False,
+                        seed=(seed + i) & 0x7FFFFFFFFFFFFFFF,
+                    )
+                else:
+                    qjob = qpus[i].run(qcs[i], shots=shots, transpile=False)
                 qjobs.append(qjob)
             
             results = gather(qjobs)

--- a/packages/polypus_python/polypus_python/local.py
+++ b/packages/polypus_python/polypus_python/local.py
@@ -40,6 +40,7 @@ class Local(Infraestructure):
         shots = args["shots"]
         sim_method = args.get("sim_method", "automatic")
         noise_model = args.get("noise_model", None)
+        seed = args.get("seed", None)
 
         # Submit every circuit in one Aer call so the C++ engine can run the
         # experiments in parallel across cores (GIL released) instead of looping
@@ -49,6 +50,14 @@ class Local(Infraestructure):
             noise_model=noise_model,
             max_parallel_experiments=0,
         )
-        result = sim.run(qcs, shots=shots).result()
+        if seed is not None:
+            # Rust resolves `seed` from the full u64 range, but Aer's
+            # `seed_simulator` takes a signed 64-bit int (rejects values
+            # >= 2**63 with a confusing low-level TypeError); mask down to
+            # that range rather than truncating precision unevenly.
+            result = sim.run(qcs, shots=shots, seed_simulator=seed & 0x7FFFFFFFFFFFFFFF).result()
+        else:
+            result = sim.run(qcs, shots=shots).result()
+
         return [result.get_counts(i) for i in range(len(qcs))]
 

--- a/tests/python/test_local_run.py
+++ b/tests/python/test_local_run.py
@@ -54,13 +54,14 @@ class TestRunQuantumCircuitSingleQpu:
         assert "00" in counts and "11" in counts
 
     def test_manifest_defaults_for_aer(self, bell_circuit):
-        """The manifest records the run metadata; the default Aer backend is not
-        seeded, so the reported seed is None (contract C-7)."""
+        """The manifest records the run metadata; the default Aer backend is
+        seeded too (contract C-7), so an omitted seed still reports the
+        fresh OS-entropy value that was actually used."""
         import polypus
         result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
         assert result.backend == "aer"
         assert result.infrastructure == "local"
-        assert result.seed is None
+        assert isinstance(result.seed, int)
 
 
 class TestRunQuantumCircuitMultipleQpus:

--- a/tests/python/test_seed_reproducibility.py
+++ b/tests/python/test_seed_reproducibility.py
@@ -1,26 +1,39 @@
 """
 Seed reproducibility & run manifest — public-API end-to-end tests (contract C-7).
 
-These exercise issue #34's acceptance criteria from Python:
+These exercise issue #34 / #56's acceptance criteria from Python:
 
-* ``run_quantum_circuit(..., seed=...)`` on the native backend: same seed ⇒
+* ``run_quantum_circuit(..., seed=...)`` on every *simulated* backend (native
+  ``"polypus"`` and Aer, both under ``infrastructure="local"``): same seed ⇒
   identical counts; no seed ⇒ different counts; the effective seed and manifest
-  are returned; a seed with any non-native backend is rejected.
+  are returned. A seed is rejected for ``infrastructure="qmio"`` (real hardware).
 * ``train`` / ``qml.train`` seed: same seed ⇒ identical outcome; no seed ⇒
   different outcome; the outcome now exposes fitness / iterations / convergence
   / seed, and the ``DE``/``PSO``/``QNG`` ``seed`` field feeds the precedence.
 
+CUNQA's simulated QPUs (``infrastructure="cunqa"``) attempt the same kind of
+seed forwarding as Aer (`crates/polypus/src/infrastructure/cunqa.rs` mirrors
+`local.rs`), but this is unverified, not just untested: the `cunqa` package
+isn't installed anywhere in this environment/CI, and reading the actual
+CESGA-Quantum-Spain/cunqa source at the version README.md pins turned up API
+mismatches predating this seed work (wrong import path, wrong kwarg names, a
+`QPU.run()` method that may not exist at that version) — see the CUNQA
+integration follow-up. There is no dedicated test here for the same reason
+QMIO's `real_qpu_smoke` test is marked `ignored`: no live infrastructure.
+
 The native backend is fully seeded by Polypus, so its reproducibility tests need
-no mocking. ``qml.train`` runs on Qiskit/Aer (native rejected) and Aer's own shot
-sampling is not seeded by Polypus, so that test mocks ``polypus_python.run_qcs``
-to make the oracle deterministic and isolate the optimizer RNG the seed controls.
+no mocking; Aer is genuinely seeded too (via `seed_simulator`, forwarded across
+the C-1 seam), so its tests run for real as well. ``qml.train`` additionally
+mocks ``polypus_python.run_qcs`` to make the oracle's expectation values fixed
+regardless of the (still-seeded) Aer sampling underneath, isolating the
+assertions to the optimizer RNG that ``seed`` controls.
 """
 
 import pytest
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# run_quantum_circuit — native backend is seeded; other backends reject a seed
+# run_quantum_circuit — native and Aer are seeded; qmio (real hardware) rejects
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -34,28 +47,30 @@ def _uniform3():
 
 @pytest.mark.integration
 class TestRunQuantumCircuitSeed:
-    def test_same_seed_reproduces_counts(self):
+    @pytest.mark.parametrize("backend_name", ["polypus", "aer"])
+    def test_same_seed_reproduces_counts(self, backend_name):
         import polypus
 
         qc = _uniform3()
         r1 = polypus.run_quantum_circuit(
-            qc, shots=2000, infrastructure="local", backend="polypus", seed=42
+            qc, shots=2000, infrastructure="local", backend=backend_name, seed=42
         )
         r2 = polypus.run_quantum_circuit(
-            qc, shots=2000, infrastructure="local", backend="polypus", seed=42
+            qc, shots=2000, infrastructure="local", backend=backend_name, seed=42
         )
         assert r1.seed == 42 and r2.seed == 42
         assert r1.counts == r2.counts
 
-    def test_no_seed_differs_across_calls(self):
+    @pytest.mark.parametrize("backend_name", ["polypus", "aer"])
+    def test_no_seed_differs_across_calls(self, backend_name):
         import polypus
 
         qc = _uniform3()
         r1 = polypus.run_quantum_circuit(
-            qc, shots=2000, infrastructure="local", backend="polypus"
+            qc, shots=2000, infrastructure="local", backend=backend_name
         )
         r2 = polypus.run_quantum_circuit(
-            qc, shots=2000, infrastructure="local", backend="polypus"
+            qc, shots=2000, infrastructure="local", backend=backend_name
         )
         # An entropy seed is generated, reported, and fresh on every call.
         assert isinstance(r1.seed, int) and isinstance(r2.seed, int)
@@ -75,30 +90,21 @@ class TestRunQuantumCircuitSeed:
         assert r.id == "run_1_local"
         assert isinstance(r.counts, list) and len(r.counts) == 1
 
-    def test_seed_rejected_for_aer(self):
-        import polypus
-
-        qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
-        with pytest.raises(ValueError, match="seed is only supported"):
-            polypus.run_quantum_circuit(
-                qc, shots=100, infrastructure="local", backend="aer", seed=1
-            )
-
     def test_seed_rejected_for_qmio(self):
         import polypus
 
         qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
-        with pytest.raises(ValueError, match="seed is only supported"):
+        with pytest.raises(ValueError, match="seed is not supported"):
             polypus.run_quantum_circuit(
                 qc, shots=100, infrastructure="qmio", seed=1
             )
 
-    def test_aer_without_seed_reports_none(self):
+    def test_aer_without_seed_reports_entropy_seed(self):
         import polypus
 
         qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
         r = polypus.run_quantum_circuit(qc, shots=100, infrastructure="local", backend="aer")
-        assert r.seed is None
+        assert isinstance(r.seed, int)
         assert r.backend == "aer"
 
 
@@ -196,7 +202,8 @@ class TestTrainSeed:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# qml.train — optimizer RNG is seeded; Aer sampling isn't, so mock the backend
+# qml.train — optimizer RNG and Aer sampling are both seeded; mock the backend
+# to isolate the optimizer RNG assertions from Aer's own (also-seeded) noise
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -207,9 +214,9 @@ class TestQmlTrainSeed:
     def _patch_deterministic_backend(monkeypatch):
         import polypus_python
 
-        # Fixed counts regardless of the circuit ⇒ a deterministic oracle, so the
-        # only remaining randomness is the optimizer RNG that qml.train's seed
-        # controls (Aer's own shot sampling is not seeded by Polypus; C-7).
+        # Fixed counts regardless of the circuit ⇒ a deterministic oracle, so
+        # these assertions isolate the optimizer RNG that qml.train's seed
+        # controls, independent of Aer's own (now also seeded, C-7) sampling.
         def fake_run_qcs(infrastructure, **kwargs):
             return [{"1": kwargs["shots"]} for _ in kwargs["qcs"]]
 


### PR DESCRIPTION
run_quantum_circuit's seed only reached the native statevector backend; Aer and CUNQA silently ignored an explicit seed and never seeded their own default runs, so repeated calls on those backends still produced byte-identical or non-reproducible noise depending on the caller's luck. Forward the resolved seed across the C-1 seam
(infrastructure/local.rs + polypus_python/local.py, infrastructure/cunqa.rs + polypus_python/cunqa.py) so both are seeded like the native backend; only the qmio infrastructure (real hardware) still rejects an explicit seed, since it cannot be deterministically seeded.

Aer's seed_simulator takes a signed 64-bit int, but the resolved seed is a full u64 - roughly half of all OS-entropy seeds overflowed it with a low-level TypeError. Mask to the 63-bit range at the point each backend consumes the seed, so RunResult.seed keeps its full range for the native backend and the manifest. CUNQA additionally offsets by QPU index (mirroring native.rs's base_seed + i) so a distributed run's QPUs don't reproduce identical counts, and uses CUNQA's own `seed` kwarg (per its run_configuration docs) rather than Aer's `seed_simulator` name.

The CUNQA integration itself (module path, get_QPUs kwargs, QPU.run vs .execute) has pre-existing mismatches against the CUNQA version this project targets, found while wiring this seam through; that's unrelated to seeding and is tracked separately, so CUNQA's seed support stays explicitly flagged as unverified in code comments and docs until that's resolved.

Extends contract C-7 (docs/CONTRACTS.md): the run_qcs kwargs table gains `seed` for local/cunqa, and the seed/manifest section documents the per-backend behavior and the CUNQA caveat. Updates tests/python/test_seed_reproducibility.py (Aer reproducibility/entropy cases replace the old native-only assumptions) and test_local_run.py (Aer without an explicit seed now reports an entropy int, not None). Also fixes a missing semicolon and a resulting dead-code function left over from an earlier pass at this change.