### PR TITLE
fix(bindings): make FFI-reachable paths panic-free with typed errors

### DIFF
--- a/crates/polypus/src/algorithms/mod.rs
+++ b/crates/polypus/src/algorithms/mod.rs
@@ -11,13 +11,12 @@ pub use polypus_optimizers::{
 };
 
 use crate::infrastructure::{BoundCircuit, ExecutionConfig};
-use std::fmt;
 
 /// Trait for all quantum algorithms in Polypus.
 /// Each algorithm should implement this trait for its argument and output types.
 pub trait AlgorithmTrait {
     type Args;
-    type AlgorithmReturnType: fmt::Display;
+    type AlgorithmReturnType;
 
     /// Run the algorithm with the given arguments.
     fn run(&self, args: Self::Args) -> Self::AlgorithmReturnType;

--- a/crates/polypus/src/algorithms/orchestration/distribute_by_shots.rs
+++ b/crates/polypus/src/algorithms/orchestration/distribute_by_shots.rs
@@ -10,10 +10,10 @@ pub struct DistributeByShotsRun;
 
 impl AlgorithmTrait for DistributeByShotsRun {
     type Args = AlgorithmArgs;
-    type AlgorithmReturnType = pyo3::PyObject;
+    type AlgorithmReturnType = PyResult<pyo3::PyObject>;
 
-    fn run(&self, mut args: AlgorithmArgs) -> pyo3::PyObject {
-        let backend = Infrastructure::create_backend(&args.config);
+    fn run(&self, mut args: AlgorithmArgs) -> PyResult<pyo3::PyObject> {
+        let backend = Infrastructure::create_backend(&args.config)?;
 
         // Distribute shots across QPUs, conserving the total (contract C-3): the
         // remainder `shots % n_qpus` is spread one extra shot per QPU over the
@@ -46,14 +46,14 @@ impl AlgorithmTrait for DistributeByShotsRun {
         if remainder > 0 {
             let qcs: Vec<_> = (0..remainder).map(|_| args.qcs[0].duplicate()).collect();
             args.config.shots = base + 1;
-            counts_vec.extend(backend.run_circuits(&qcs, &args.config));
+            counts_vec.extend(backend.run_circuits(&qcs, &args.config)?);
         }
         if base > 0 {
             let qcs: Vec<_> = (0..n_qpus - remainder)
                 .map(|_| args.qcs[0].duplicate())
                 .collect();
             args.config.shots = base;
-            counts_vec.extend(backend.run_circuits(&qcs, &args.config));
+            counts_vec.extend(backend.run_circuits(&qcs, &args.config)?);
         }
 
         // Merge counts from all QPUs into a single dict
@@ -63,16 +63,16 @@ impl AlgorithmTrait for DistributeByShotsRun {
                 *total.entry(k).or_insert(0) += v;
             }
         }
-        let merged_pyobj = Python::with_gil(|py| {
+        let merged_pyobj = Python::with_gil(|py| -> PyResult<pyo3::PyObject> {
             let py_dict = PyDict::new(py);
             for (k, v) in total {
-                py_dict.set_item(k, v).unwrap();
+                py_dict.set_item(k, v)?;
             }
-            py_dict.into()
-        });
+            Ok(py_dict.into())
+        })?;
 
         backend.close();
-        merged_pyobj
+        Ok(merged_pyobj)
     }
 
     fn name(&self) -> String {

--- a/crates/polypus/src/algorithms/orchestration/single_run.rs
+++ b/crates/polypus/src/algorithms/orchestration/single_run.rs
@@ -7,20 +7,16 @@ pub struct AlgorithmSingleRun;
 
 impl AlgorithmTrait for AlgorithmSingleRun {
     type Args = AlgorithmArgs;
-    type AlgorithmReturnType = pyo3::PyObject;
+    type AlgorithmReturnType = PyResult<pyo3::PyObject>;
 
-    fn run(&self, args: AlgorithmArgs) -> pyo3::PyObject {
-        let backend = Infrastructure::create_backend(&args.config);
-        let counts = backend.run_circuits(&args.qcs, &args.config);
+    fn run(&self, args: AlgorithmArgs) -> PyResult<pyo3::PyObject> {
+        // Backend creation and execution surface any failure as a `PyErr`; the
+        // backend's `Drop` still releases resources if we return early.
+        let backend = Infrastructure::create_backend(&args.config)?;
+        let counts = backend.run_circuits(&args.qcs, &args.config)?;
         backend.close();
         // Convert native counts to a Python `list[dict]` at the FFI boundary.
-        Python::with_gil(|py| {
-            counts
-                .into_pyobject(py)
-                .expect("Failed to convert counts to a Python object")
-                .into_any()
-                .unbind()
-        })
+        Python::with_gil(|py| Ok(counts.into_pyobject(py)?.into_any().unbind()))
     }
 
     fn name(&self) -> String {

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -17,7 +17,7 @@ use pso::PSO;
 use qng::{PyVarianceOracle, QNG};
 
 use crate::algorithms::{AlgorithmArgs, AlgorithmSingleRun, AlgorithmTrait, DistributeByShotsRun};
-use crate::evaluation::{CircuitSource, EvaluationOracle, QmlOracle, VqcOracle};
+use crate::evaluation::{CircuitSource, EvaluationOracle, OracleErrorSlot, QmlOracle, VqcOracle};
 #[cfg(feature = "qmio")]
 use crate::infrastructure::execution_config::QmioProgramFormat;
 use crate::infrastructure::{
@@ -26,6 +26,7 @@ use crate::infrastructure::{
 use polypus_optimizers::{
     AlgorithmDifferentialEvolution, AlgorithmDifferentialEvolutionArgs, AlgorithmPSO,
     AlgorithmPSOArgs, AlgorithmQNG, AlgorithmQNGArgs, OptimizationOutcome, Optimizer,
+    OptimizerError,
 };
 use std::sync::Arc;
 
@@ -37,12 +38,28 @@ use std::sync::Arc;
 /// contract is still just the best-parameter vector, so the extra fields
 /// (fitness, iteration count, convergence flag) are intentionally dropped at
 /// this binding boundary.
-fn outcome_to_pyobject(py: Python<'_>, outcome: OptimizationOutcome) -> PyObject {
-    outcome
-        .best_params
-        .into_pyobject(py)
-        .expect("Error converting best_params to PyObject")
-        .unbind()
+fn outcome_to_pyobject(py: Python<'_>, outcome: OptimizationOutcome) -> PyResult<PyObject> {
+    Ok(outcome.best_params.into_pyobject(py)?.unbind())
+}
+
+/// Turn an optimizer result into the value the Python entry point returns.
+///
+/// An oracle failure recorded in `errors` takes precedence over the optimizer's
+/// own result: because [`EvaluationOracle`]/`VarianceOracle` cannot return a
+/// `Result`, an oracle records its first failure in the shared
+/// [`OracleErrorSlot`] and yields finite sentinels, so `optimize` may return
+/// `Ok` with a meaningless outcome. Surfacing the recorded error here is what
+/// makes the FFI boundary report the real cause instead of that garbage.
+fn finish_optimization(
+    py: Python<'_>,
+    result: Result<OptimizationOutcome, OptimizerError>,
+    errors: &OracleErrorSlot,
+) -> PyResult<PyObject> {
+    if let Some(eval_err) = errors.take() {
+        return Err(eval_err.into());
+    }
+    let outcome = result.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    outcome_to_pyobject(py, outcome)
 }
 
 /// Map the public `infrastructure` + `backend` strings and provider parameters
@@ -61,7 +78,7 @@ fn build_backend_config(
     nodes: u32,
     cores_per_qpu: u32,
 ) -> PyResult<BackendConfig> {
-    match Infrastructure::from_str(infrastructure) {
+    match Infrastructure::from_str(infrastructure)? {
         Infrastructure::Local => match backend {
             "aer" | "AerSimulator" => Ok(BackendConfig::Local {
                 backend: "AerSimulator".to_string(),
@@ -258,14 +275,15 @@ pub fn run_quantum_circuit<'py>(
         config,
     };
 
-    let algorithm: Box<dyn AlgorithmTrait<Args = AlgorithmArgs, AlgorithmReturnType = PyObject>> =
-        if n_qpus == 1 {
-            Box::new(AlgorithmSingleRun)
-        } else {
-            Box::new(DistributeByShotsRun)
-        };
+    let algorithm: Box<
+        dyn AlgorithmTrait<Args = AlgorithmArgs, AlgorithmReturnType = PyResult<PyObject>>,
+    > = if n_qpus == 1 {
+        Box::new(AlgorithmSingleRun)
+    } else {
+        Box::new(DistributeByShotsRun)
+    };
 
-    Ok(algorithm.run(args))
+    algorithm.run(args)
 }
 
 /// Unified entry point: train a variational quantum circuit with a chosen optimizer.
@@ -346,12 +364,17 @@ pub fn train<'py>(
         backend_config,
         opt_level: OptLevel::default(),
     });
-    let backend = Infrastructure::create_backend(&config);
+    let backend = Infrastructure::create_backend(&config)?;
+    // Shared error slot: the oracles record the first evaluation failure here
+    // (the optimizer traits cannot return a `Result`) and it is surfaced by
+    // `finish_optimization` after `optimize` returns.
+    let errors = OracleErrorSlot::new();
     let oracle: Box<dyn EvaluationOracle> = Box::new(VqcOracle {
         circuit: circuit_source,
         config: Arc::clone(&config),
         backend,
         expectation_fn: expectation_function.unbind(),
+        errors: errors.clone(),
     });
 
     if let Ok(de) = method.extract::<PyRef<DE>>() {
@@ -363,10 +386,11 @@ pub fn train<'py>(
             tolerance: de.tolerance,
             seed: None,
         };
-        return AlgorithmDifferentialEvolution
-            .optimize(args)
-            .map(|outcome| outcome_to_pyobject(method.py(), outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+        return finish_optimization(
+            method.py(),
+            AlgorithmDifferentialEvolution.optimize(args),
+            &errors,
+        );
     }
 
     if let Ok(pso) = method.extract::<PyRef<PSO>>() {
@@ -382,10 +406,7 @@ pub fn train<'py>(
             tolerance: pso.tolerance,
             seed: None,
         };
-        return AlgorithmPSO
-            .optimize(args)
-            .map(|outcome| outcome_to_pyobject(method.py(), outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+        return finish_optimization(method.py(), AlgorithmPSO.optimize(args), &errors);
     }
 
     if let Ok(qng) = method.extract::<PyRef<QNG>>() {
@@ -398,14 +419,12 @@ pub fn train<'py>(
             dimensions,
             variance_oracle: Box::new(PyVarianceOracle {
                 variance_function: qng.variance_function.clone_ref(method.py()),
+                errors: errors.clone(),
             }),
             tikhonov_reg: qng.tikhonov_reg,
             seed: None,
         };
-        return AlgorithmQNG
-            .optimize(args)
-            .map(|outcome| outcome_to_pyobject(method.py(), outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+        return finish_optimization(method.py(), AlgorithmQNG.optimize(args), &errors);
     }
 
     Err(pyo3::exceptions::PyTypeError::new_err(
@@ -524,12 +543,16 @@ pub fn qml_train<'py>(
         backend_config,
         opt_level: OptLevel::default(),
     });
-    let backend = Infrastructure::create_backend(&config);
+    let backend = Infrastructure::create_backend(&config)?;
+    // Shared error slot (see `train`): oracles record the first evaluation
+    // failure here and `finish_optimization` surfaces it after `optimize`.
+    let errors = OracleErrorSlot::new();
     let oracle: Box<dyn EvaluationOracle> = Box::new(QmlOracle {
         training_circuits: qcs,
         config: Arc::clone(&config),
         backend,
         expectation_fn: expectation_function.unbind(),
+        errors: errors.clone(),
     });
 
     if let Ok(de) = method.extract::<PyRef<DE>>() {
@@ -541,10 +564,7 @@ pub fn qml_train<'py>(
             tolerance: de.tolerance,
             seed: None,
         };
-        return AlgorithmDifferentialEvolution
-            .optimize(args)
-            .map(|outcome| outcome_to_pyobject(py, outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+        return finish_optimization(py, AlgorithmDifferentialEvolution.optimize(args), &errors);
     }
 
     if let Ok(pso) = method.extract::<PyRef<PSO>>() {
@@ -560,10 +580,7 @@ pub fn qml_train<'py>(
             tolerance: pso.tolerance,
             seed: None,
         };
-        return AlgorithmPSO
-            .optimize(args)
-            .map(|outcome| outcome_to_pyobject(py, outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+        return finish_optimization(py, AlgorithmPSO.optimize(args), &errors);
     }
 
     if let Ok(qng) = method.extract::<PyRef<QNG>>() {
@@ -576,14 +593,12 @@ pub fn qml_train<'py>(
             dimensions,
             variance_oracle: Box::new(PyVarianceOracle {
                 variance_function: qng.variance_function.clone_ref(py),
+                errors: errors.clone(),
             }),
             tikhonov_reg: qng.tikhonov_reg,
             seed: None,
         };
-        return AlgorithmQNG
-            .optimize(args)
-            .map(|outcome| outcome_to_pyobject(py, outcome))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()));
+        return finish_optimization(py, AlgorithmQNG.optimize(args), &errors);
     }
 
     Err(pyo3::exceptions::PyTypeError::new_err(
@@ -591,8 +606,18 @@ pub fn qml_train<'py>(
     ))
 }
 
+/// Number of backend resource-cleanup (`close`/`Drop`) failures recorded this
+/// process. A `Drop` must never panic, so a failed teardown (e.g. releasing a
+/// CUNQA SLURM allocation) is logged and counted rather than raised; this
+/// exposes the consultable count to Python for diagnostics/monitoring.
+#[pyfunction]
+fn backend_cleanup_failures() -> u64 {
+    crate::infrastructure::cleanup_failure_count()
+}
+
 #[pymodule]
 pub fn polypus(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    crate::exceptions::register(m)?;
     m.add_class::<DE>()?;
     m.add_class::<PSO>()?;
     m.add_class::<QNG>()?;
@@ -602,6 +627,7 @@ pub fn polypus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run_quantum_circuit, m)?)?;
     m.add_function(wrap_pyfunction!(statevector, m)?)?;
     m.add_function(wrap_pyfunction!(init_logger, m)?)?;
+    m.add_function(wrap_pyfunction!(backend_cleanup_failures, m)?)?;
 
     // qml submodule — exposes polypus.qml.train()
     let py = m.py();

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -18,6 +18,7 @@ use qng::{PyVarianceOracle, QNG};
 
 use crate::algorithms::{AlgorithmArgs, AlgorithmSingleRun, AlgorithmTrait, DistributeByShotsRun};
 use crate::evaluation::{CircuitSource, EvaluationOracle, OracleErrorSlot, QmlOracle, VqcOracle};
+use crate::infrastructure::execution_config::random_seed;
 #[cfg(feature = "qmio")]
 use crate::infrastructure::execution_config::QmioProgramFormat;
 use crate::infrastructure::{
@@ -33,12 +34,145 @@ use std::sync::Arc;
 /// Result of [`run_quantum_circuit`]: the measurement counts plus the run
 /// manifest that lets a run be logged and replayed (contract C-7).
 ///
-/// The optimizers now return a richer native struct, but the public Python
-/// contract is still just the best-parameter vector, so the extra fields
-/// (fitness, iteration count, convergence flag) are intentionally dropped at
-/// this binding boundary.
-fn outcome_to_pyobject(py: Python<'_>, outcome: OptimizationOutcome) -> PyResult<PyObject> {
-    Ok(outcome.best_params.into_pyobject(py)?.unbind())
+/// `counts` is the exact payload the runner produced before this wrapper
+/// existed — a `list[dict[str, int]]` for a single-QPU run
+/// ([`AlgorithmSingleRun`](crate::algorithms::AlgorithmSingleRun)), or a single
+/// merged `dict[str, int]` for a distributed (`n_qpus > 1`) run
+/// ([`DistributeByShotsRun`](crate::algorithms::DistributeByShotsRun)); the
+/// per-dict format is contract C-3. The manifest fields make a native run
+/// reproducible: feeding the reported [`seed`](Self::seed) back into
+/// `run_quantum_circuit(..., backend="polypus")` reproduces the counts
+/// byte-for-byte. `seed` is `None` for non-native backends, which Polypus does
+/// not seed.
+#[pyclass(frozen)]
+pub struct RunResult {
+    /// Measurement counts. Shape depends on `n_qpus` (see the type docs).
+    #[pyo3(get)]
+    pub counts: PyObject,
+    /// Run identifier used for logging, temp files and SLURM job names.
+    #[pyo3(get)]
+    pub id: String,
+    /// Effective RNG seed used by the native backend's shot sampling
+    /// (user-supplied or OS-entropy). `None` for non-native backends.
+    #[pyo3(get)]
+    pub seed: Option<u64>,
+    /// Device selected within the infrastructure (`"aer"`, `"polypus"`, …).
+    #[pyo3(get)]
+    pub backend: String,
+    /// Execution infrastructure label (`"local"`, `"cunqa"`, `"qmio"`).
+    #[pyo3(get)]
+    pub infrastructure: String,
+}
+
+#[pymethods]
+impl RunResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "RunResult(id={:?}, seed={:?}, backend={:?}, infrastructure={:?})",
+            self.id, self.seed, self.backend, self.infrastructure
+        )
+    }
+}
+
+/// Result of [`train`] / [`qml_train`]: the full [`OptimizationOutcome`] plus
+/// the effective RNG seed used, so a training run can be reported and reproduced
+/// (contract C-7).
+///
+/// Replaces the former bare `list[float]` return, which discarded the fitness,
+/// iteration count and convergence flag. `best_params` remains available as a
+/// field; the previously dropped [`OptimizationOutcome`] fields are now exposed
+/// alongside it, and `seed` records the value that drove the optimizer.
+#[pyclass(frozen)]
+pub struct TrainResult {
+    /// Best parameter vector found.
+    #[pyo3(get)]
+    pub best_params: Vec<f64>,
+    /// Fitness of [`best_params`](Self::best_params) (higher is better).
+    #[pyo3(get)]
+    pub best_fitness: f64,
+    /// Generations/iterations actually executed (below the budget when an
+    /// early-stopping criterion fired).
+    #[pyo3(get)]
+    pub iterations_run: usize,
+    /// Whether the optimizer's convergence criterion was satisfied.
+    #[pyo3(get)]
+    pub converged: bool,
+    /// Effective RNG seed that drove the optimizer (and, on the native backend,
+    /// shot sampling): the explicit `seed` kwarg, else the optimizer object's
+    /// `seed`, else a fresh OS-entropy value (contract C-7).
+    #[pyo3(get)]
+    pub seed: u64,
+}
+
+#[pymethods]
+impl TrainResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "TrainResult(best_fitness={}, iterations_run={}, converged={}, seed={}, best_params={:?})",
+            self.best_fitness, self.iterations_run, self.converged, self.seed, self.best_params
+        )
+    }
+}
+
+/// Wrap an [`OptimizationOutcome`] and the effective `seed` into the
+/// [`TrainResult`] that `train` / `qml_train` now return.
+///
+/// This is the current public Python contract for those entry points (contract
+/// C-7): the whole outcome — `best_params`, `best_fitness`, `iterations_run`,
+/// `converged` — plus the `seed`, rather than the bare best-parameter list the
+/// former `outcome_to_pyobject` produced.
+fn outcome_to_train_result(
+    py: Python<'_>,
+    outcome: OptimizationOutcome,
+    seed: u64,
+) -> PyResult<PyObject> {
+    Py::new(
+        py,
+        TrainResult {
+            best_params: outcome.best_params,
+            best_fitness: outcome.best_fitness,
+            iterations_run: outcome.iterations_run,
+            converged: outcome.converged,
+            seed,
+        },
+    )
+    .map(|result| result.into_any())
+}
+
+/// Whether this `infrastructure` + `backend` combination actually runs on the
+/// native pure-Rust statevector backend — the only backend whose shot sampling
+/// Polypus seeds. It is reached exclusively via `infrastructure="local"` +
+/// `backend="polypus"`; every other combination runs Aer, CUNQA or QMIO, none
+/// of which consume `ExecutionConfig::seed`, so an explicit seed there would be
+/// silently ineffective (see [`run_quantum_circuit`]).
+fn uses_native_backend(infrastructure: &str, backend: &str) -> bool {
+    infrastructure == "local" && is_native_backend(backend)
+}
+
+/// Resolve the optimizer seed for `train` / `qml_train` (contract C-7).
+///
+/// Precedence: the explicit `seed` kwarg wins when provided; otherwise the
+/// `seed` field pinned on the `DE`/`PSO`/`QNG` instance; otherwise a fresh
+/// OS-entropy value. The chosen value both drives the optimizer and is reported
+/// back in the [`TrainResult`], so the run can be replayed.
+fn resolve_optimizer_seed(kwarg_seed: Option<u64>, method_seed: Option<u64>) -> u64 {
+    kwarg_seed.or(method_seed).unwrap_or_else(random_seed)
+}
+
+/// Read the `seed` field pinned on the optimizer object passed as `method`,
+/// whichever of `DE`/`PSO`/`QNG` it is (`None` if it is none of them — the type
+/// error is surfaced later by the dispatch that actually runs the optimizer).
+fn method_seed(method: &Bound<'_, PyAny>) -> Option<u64> {
+    if let Ok(de) = method.extract::<PyRef<DE>>() {
+        return de.seed;
+    }
+    if let Ok(pso) = method.extract::<PyRef<PSO>>() {
+        return pso.seed;
+    }
+    if let Ok(qng) = method.extract::<PyRef<QNG>>() {
+        return qng.seed;
+    }
+    None
 }
 
 /// Turn an optimizer result into the value the Python entry point returns.
@@ -53,12 +187,13 @@ fn finish_optimization(
     py: Python<'_>,
     result: Result<OptimizationOutcome, OptimizerError>,
     errors: &OracleErrorSlot,
+    seed: u64,
 ) -> PyResult<PyObject> {
     if let Some(eval_err) = errors.take() {
         return Err(eval_err.into());
     }
     let outcome = result.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-    outcome_to_pyobject(py, outcome)
+    outcome_to_train_result(py, outcome, seed)
 }
 
 /// Map the public `infrastructure` + `backend` strings and provider parameters
@@ -312,7 +447,21 @@ pub fn run_quantum_circuit<'py>(
         Box::new(DistributeByShotsRun)
     };
 
-    algorithm.run(args)
+    // Keep the original counts payload intact and wrap it with the run manifest.
+    let counts = algorithm.run(args)?;
+    Python::with_gil(|py| {
+        Py::new(
+            py,
+            RunResult {
+                counts,
+                id,
+                seed: effective_seed,
+                backend: backend.to_string(),
+                infrastructure,
+            },
+        )
+        .map(|result| result.into_any())
+    })
 }
 
 /// Unified entry point: train a variational quantum circuit with a chosen optimizer.
@@ -437,6 +586,7 @@ pub fn train<'py>(
             method.py(),
             AlgorithmDifferentialEvolution.optimize(args),
             &errors,
+            effective_seed,
         );
     }
 
@@ -453,7 +603,12 @@ pub fn train<'py>(
             tolerance: pso.tolerance,
             seed: Some(effective_seed),
         };
-        return finish_optimization(method.py(), AlgorithmPSO.optimize(args), &errors);
+        return finish_optimization(
+            method.py(),
+            AlgorithmPSO.optimize(args),
+            &errors,
+            effective_seed,
+        );
     }
 
     if let Ok(qng) = method.extract::<PyRef<QNG>>() {
@@ -471,7 +626,12 @@ pub fn train<'py>(
             tikhonov_reg: qng.tikhonov_reg,
             seed: Some(effective_seed),
         };
-        return finish_optimization(method.py(), AlgorithmQNG.optimize(args), &errors);
+        return finish_optimization(
+            method.py(),
+            AlgorithmQNG.optimize(args),
+            &errors,
+            effective_seed,
+        );
     }
 
     Err(pyo3::exceptions::PyTypeError::new_err(
@@ -626,7 +786,12 @@ pub fn qml_train<'py>(
             tolerance: de.tolerance,
             seed: Some(effective_seed),
         };
-        return finish_optimization(py, AlgorithmDifferentialEvolution.optimize(args), &errors);
+        return finish_optimization(
+            py,
+            AlgorithmDifferentialEvolution.optimize(args),
+            &errors,
+            effective_seed,
+        );
     }
 
     if let Ok(pso) = method.extract::<PyRef<PSO>>() {
@@ -642,7 +807,7 @@ pub fn qml_train<'py>(
             tolerance: pso.tolerance,
             seed: Some(effective_seed),
         };
-        return finish_optimization(py, AlgorithmPSO.optimize(args), &errors);
+        return finish_optimization(py, AlgorithmPSO.optimize(args), &errors, effective_seed);
     }
 
     if let Ok(qng) = method.extract::<PyRef<QNG>>() {
@@ -660,7 +825,7 @@ pub fn qml_train<'py>(
             tikhonov_reg: qng.tikhonov_reg,
             seed: Some(effective_seed),
         };
-        return finish_optimization(py, AlgorithmQNG.optimize(args), &errors);
+        return finish_optimization(py, AlgorithmQNG.optimize(args), &errors, effective_seed);
     }
 
     Err(pyo3::exceptions::PyTypeError::new_err(

--- a/crates/polypus/src/bindings/qng.rs
+++ b/crates/polypus/src/bindings/qng.rs
@@ -1,3 +1,4 @@
+use crate::evaluation::{EvaluationError, OracleErrorSlot};
 use polypus_optimizers::VarianceOracle;
 use pyo3::prelude::*;
 
@@ -53,18 +54,44 @@ impl QNG {
 pub struct PyVarianceOracle {
     /// Python callable `fn(theta: list[float], a: int) -> float`.
     pub variance_function: Py<PyAny>,
+    /// Shared with the `train`/`qml.train` entry point: a failure calling the
+    /// user's `variance_function` is recorded here and surfaced as a `PyErr`
+    /// after `optimize` returns, since [`VarianceOracle`] cannot return a
+    /// `Result`.
+    pub errors: OracleErrorSlot,
 }
 
 impl PyVarianceOracle {
     /// Call the Python `variance_function(theta, param_index)` under an already
-    /// held GIL and extract the returned float.
+    /// held GIL, recording any failure and returning a finite sentinel so the
+    /// optimizer never observes a panic (contract C-5 keeps outputs finite).
     fn call(&self, py: Python<'_>, theta: &[f64], param_index: usize) -> f64 {
+        if self.errors.failed() {
+            return 0.0;
+        }
+        match self.try_call(py, theta, param_index) {
+            Ok(value) => value,
+            Err(e) => {
+                self.errors.record(e);
+                0.0
+            }
+        }
+    }
+
+    /// Fallible core of [`call`](Self::call): invoke the user callback and
+    /// extract the float, carrying any Python error verbatim.
+    fn try_call(
+        &self,
+        py: Python<'_>,
+        theta: &[f64],
+        param_index: usize,
+    ) -> Result<f64, EvaluationError> {
         self.variance_function
             .bind(py)
             .call1((theta.to_vec(), param_index as u32))
-            .expect("Error calling variance_function")
+            .map_err(EvaluationError::Python)?
             .extract()
-            .expect("Failed to extract float from variance_function")
+            .map_err(EvaluationError::Python)
     }
 }
 

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -1,0 +1,68 @@
+//! Error type for the optimizer-oracle / expectation-evaluation path.
+//!
+//! See [`crate::infrastructure::error`] for the crate-wide granularity
+//! decision. This enum wraps a [`BackendError`] (the underlying execution
+//! failure), a [`CircuitError`] (native parameter binding) or a raw [`PyErr`]
+//! (a Python callback/conversion), all reachable while an optimizer drives an
+//! oracle across the FFI.
+
+use std::fmt;
+
+use polypus_circuit::CircuitError;
+use pyo3::PyErr;
+
+use crate::exceptions::EvaluationError as PyEvaluationError;
+use crate::infrastructure::BackendError;
+
+/// A failure encountered while evaluating a candidate parameter vector.
+///
+/// The optimizer traits ([`EvaluationOracle`](polypus_optimizers::EvaluationOracle),
+/// [`VarianceOracle`](polypus_optimizers::VarianceOracle)) return plain
+/// `f64`/`Vec<f64>` and cannot carry a `Result` across the FFI, so an oracle
+/// records its first failure of this type in an
+/// [`OracleErrorSlot`](crate::evaluation::OracleErrorSlot) and the entry point
+/// surfaces it after `optimize` returns.
+///
+/// `Clone`/`Eq` are omitted: the [`EvaluationError::Python`] variant carries a
+/// [`PyErr`].
+#[derive(Debug)]
+pub enum EvaluationError {
+    /// The underlying execution backend failed.
+    Backend(BackendError),
+    /// Native parameter binding failed (wrong count, non-finite value, …).
+    Binding(CircuitError),
+    /// A Python callback or conversion on the evaluation path raised. Carried
+    /// verbatim so the original exception type is preserved across the FFI.
+    Python(PyErr),
+}
+
+impl fmt::Display for EvaluationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EvaluationError::Backend(err) => write!(f, "{err}"),
+            EvaluationError::Binding(err) => write!(f, "circuit binding failed: {err}"),
+            EvaluationError::Python(err) => write!(f, "Python evaluation error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for EvaluationError {}
+
+impl From<BackendError> for EvaluationError {
+    fn from(err: BackendError) -> Self {
+        EvaluationError::Backend(err)
+    }
+}
+
+impl From<EvaluationError> for PyErr {
+    fn from(err: EvaluationError) -> PyErr {
+        match err {
+            EvaluationError::Backend(backend_err) => backend_err.into(),
+            EvaluationError::Binding(circuit_err) => {
+                PyEvaluationError::new_err(circuit_err.to_string())
+            }
+            // Preserve the original Python exception type raised by the callback.
+            EvaluationError::Python(py_err) => py_err,
+        }
+    }
+}

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -1,6 +1,8 @@
+pub mod error;
 pub mod qml_oracle;
 pub mod vqc_oracle;
 
+pub use error::EvaluationError;
 pub use qml_oracle::QmlOracle;
 pub use vqc_oracle::VqcOracle;
 
@@ -8,6 +10,45 @@ use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use polypus_circuit::ParameterizedCircuit;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyModule};
+use std::sync::{Arc, Mutex};
+
+/// Thread-safe holder for the first error an oracle hits during `optimize`.
+///
+/// The optimizer traits ([`EvaluationOracle`] and
+/// [`VarianceOracle`](polypus_optimizers::VarianceOracle)) return plain
+/// `f64`/`Vec<f64>` — a pure-crate contract this crate cannot change — so a
+/// Python-side failure mid-optimization cannot be returned through the trait.
+/// Instead the oracle records it here and yields a finite sentinel; the entry
+/// point inspects the slot after `optimize` returns and surfaces the error as a
+/// `PyErr` (contract C-5 keeps oracle outputs finite regardless).
+#[derive(Clone, Default)]
+pub struct OracleErrorSlot(Arc<Mutex<Option<EvaluationError>>>);
+
+impl OracleErrorSlot {
+    /// A fresh, empty slot.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record `err` as the failure, keeping the *first* one recorded.
+    pub fn record(&self, err: EvaluationError) {
+        let mut guard = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        if guard.is_none() {
+            *guard = Some(err);
+        }
+    }
+
+    /// Whether a failure has been recorded (lets callers short-circuit further
+    /// work once evaluation is doomed).
+    pub fn failed(&self) -> bool {
+        self.0.lock().unwrap_or_else(|p| p.into_inner()).is_some()
+    }
+
+    /// Take the recorded failure, if any.
+    pub fn take(&self) -> Option<EvaluationError> {
+        self.0.lock().unwrap_or_else(|p| p.into_inner()).take()
+    }
+}
 
 /// A parameterised circuit template, in one of the representations Polypus
 /// supports as optimisation targets.
@@ -29,25 +70,24 @@ pub enum CircuitSource {
 impl CircuitSource {
     /// Bind one candidate parameter vector, producing an executable circuit.
     ///
-    /// # Panics
-    ///
-    /// Panics if binding fails (wrong number of parameters, Python error).
-    /// Entry points validate `dimensions` against the template up front, so a
-    /// failure here is a programming error, consistent with the rest of the
-    /// evaluation layer.
-    pub fn bind(&self, params: &[f64]) -> BoundCircuit {
+    /// Returns an [`EvaluationError`] on failure (wrong parameter count, a
+    /// Python error binding a Qiskit circuit) rather than panicking, so the
+    /// failure can cross the FFI as a typed exception. Entry points still
+    /// validate `dimensions` up front, so a failure here is normally
+    /// unreachable — but it is reported, never a panic.
+    pub fn bind(&self, params: &[f64]) -> Result<BoundCircuit, EvaluationError> {
         match self {
-            CircuitSource::Qiskit(circuit) => {
-                BoundCircuit::Qiskit(assign_parameters_qiskit(circuit, params))
-            }
+            CircuitSource::Qiskit(circuit) => Ok(BoundCircuit::Qiskit(assign_parameters_qiskit(
+                circuit, params,
+            )?)),
             // Pure Rust: no GIL anywhere on this path. The bound circuit keeps
             // its native structure so the statevector backend can simulate it
             // directly; Python backends serialise it to OpenQASM 2.0 on demand.
-            CircuitSource::Native(circuit) => BoundCircuit::Native(
+            CircuitSource::Native(circuit) => Ok(BoundCircuit::Native(
                 circuit
                     .assign_parameters(params)
-                    .unwrap_or_else(|e| panic!("Error binding native circuit: {e}")),
-            ),
+                    .map_err(EvaluationError::Binding)?,
+            )),
         }
     }
 
@@ -63,16 +103,26 @@ impl CircuitSource {
 }
 
 /// Bind `params` to a copy of a Qiskit `circuit` and return the bound circuit.
-pub(crate) fn assign_parameters_qiskit(circuit: &Py<PyAny>, params: &[f64]) -> Py<PyAny> {
+///
+/// Any Python error (constructing the kwargs, calling `assign_parameters`) is
+/// returned as [`EvaluationError::Python`] — carried verbatim so the caller can
+/// re-raise it with its original type across the FFI.
+pub(crate) fn assign_parameters_qiskit(
+    circuit: &Py<PyAny>,
+    params: &[f64],
+) -> Result<Py<PyAny>, EvaluationError> {
     Python::with_gil(|py| {
         let qc = circuit
             .clone_ref(py)
             .into_pyobject(py)
-            .expect("Failed to get circuit as PyObject");
-        let kwargs = [("inplace", false)].into_py_dict(py).unwrap();
-        qc.call_method("assign_parameters", (params.to_vec(),), Some(&kwargs))
-            .expect("Error assigning parameters to circuit")
-            .unbind()
+            .map_err(|e| EvaluationError::Python(e.into()))?;
+        let kwargs = [("inplace", false)]
+            .into_py_dict(py)
+            .map_err(EvaluationError::Python)?;
+        Ok(qc
+            .call_method("assign_parameters", (params.to_vec(),), Some(&kwargs))
+            .map_err(EvaluationError::Python)?
+            .unbind())
     })
 }
 
@@ -100,25 +150,27 @@ pub use polypus_optimizers::EvaluationOracle;
 /// This is the **single place** in the codebase that calls
 /// `polypus_python.expectation_values`, eliminating the duplication that
 /// previously existed across DE, PSO, QNG, and the orchestration layer.
-pub(crate) fn run_and_expect(
+///
+/// Returns an [`EvaluationError`] on any failure: a backend error is wrapped,
+/// and a Python error (import, `expectation_values`, extraction) is carried
+/// verbatim — never a panic.
+pub(crate) fn run_and_evaluate(
     backend: &dyn QuantumBackend,
     qcs: &[BoundCircuit],
     config: &ExecutionConfig,
     expectation_fn: &Py<PyAny>,
-) -> Vec<f64> {
-    let counts = backend.run_circuits(qcs, config);
+) -> Result<Vec<f64>, EvaluationError> {
+    let counts = backend.run_circuits(qcs, config)?;
     Python::with_gil(|py| {
         // Convert the native counts back into a Python `list[dict]` for the
         // Python `expectation_values` function. Once expectation computation is
         // also native this round-trip disappears entirely.
-        let py_counts = counts
-            .into_pyobject(py)
-            .expect("Failed to convert counts to a Python object");
+        let py_counts = counts.into_pyobject(py).map_err(EvaluationError::Python)?;
         PyModule::import(py, "polypus_python")
-            .expect("Failed to import polypus_python")
+            .map_err(EvaluationError::Python)?
             .call_method("expectation_values", (py_counts, expectation_fn), None)
-            .expect("Error computing expectation values")
+            .map_err(EvaluationError::Python)?
             .extract::<Vec<f64>>()
-            .expect("Failed to extract expectation values as Vec<f64>")
+            .map_err(EvaluationError::Python)
     })
 }

--- a/crates/polypus/src/evaluation/qml_oracle.rs
+++ b/crates/polypus/src/evaluation/qml_oracle.rs
@@ -1,4 +1,6 @@
-use crate::evaluation::{assign_parameters_qiskit, run_and_expect, EvaluationOracle};
+use crate::evaluation::{
+    assign_parameters_qiskit, run_and_evaluate, EvaluationError, EvaluationOracle, OracleErrorSlot,
+};
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use pyo3::prelude::*;
 use std::sync::Arc;
@@ -19,11 +21,39 @@ pub struct QmlOracle {
     pub config: Arc<ExecutionConfig>,
     pub backend: Arc<dyn QuantumBackend>,
     pub expectation_fn: Py<PyAny>,
+    /// Shared with the `qml.train` entry point: the first evaluation failure is
+    /// recorded here and surfaced as a `PyErr` after `optimize` returns, since
+    /// [`EvaluationOracle::evaluate_batch`] cannot return a `Result`.
+    pub errors: OracleErrorSlot,
 }
 
 impl EvaluationOracle for QmlOracle {
     fn evaluate_batch(&self, candidates: &[Vec<f64>]) -> Vec<f64> {
-        let rt = crate::utils::tokio_runtime();
+        // Once evaluation has failed, stop doing work: return finite sentinels
+        // and let the entry point surface the recorded error.
+        if self.errors.failed() {
+            return vec![0.0; candidates.len()];
+        }
+        match self.try_evaluate(candidates) {
+            Ok(values) => values,
+            Err(e) => {
+                self.errors.record(e);
+                vec![0.0; candidates.len()]
+            }
+        }
+    }
+}
+
+impl QmlOracle {
+    /// Fallible core of [`EvaluationOracle::evaluate_batch`]. Kept separate so
+    /// the trait method (which must return `Vec<f64>`) can record any error and
+    /// yield finite sentinels while the entry point re-raises it.
+    fn try_evaluate(&self, candidates: &[Vec<f64>]) -> Result<Vec<f64>, EvaluationError> {
+        let rt = crate::utils::tokio_runtime().map_err(|e| {
+            EvaluationError::Python(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to start the Tokio runtime for QML evaluation: {e}"
+            )))
+        })?;
 
         let handles: Vec<_> = candidates
             .iter()
@@ -56,9 +86,16 @@ impl EvaluationOracle for QmlOracle {
                 rt.block_on(async {
                     let mut out = Vec::with_capacity(handles.len());
                     for h in handles {
-                        out.push(h.await.expect("QML eval task panicked"));
+                        // A `JoinError` means the worker task itself panicked;
+                        // turn it into a typed error rather than re-panicking.
+                        let single = h.await.map_err(|e| {
+                            EvaluationError::Python(pyo3::exceptions::PyRuntimeError::new_err(
+                                format!("QML evaluation task failed: {e}"),
+                            ))
+                        })?;
+                        out.push(single?);
                     }
-                    out
+                    Ok(out)
                 })
             })
         })
@@ -68,27 +105,32 @@ impl EvaluationOracle for QmlOracle {
 /// Evaluate one candidate `theta` against all training circuits.
 ///
 /// Binds `theta` to each training circuit, runs them in batches of
-/// `config.n_qpus`, and returns the mean expectation value.
+/// `config.n_qpus`, and returns the mean expectation value. Any failure is
+/// returned as an [`EvaluationError`] instead of panicking.
 fn evaluate_qml_single(
     training_circuits: &[Py<PyAny>],
     config: &ExecutionConfig,
     backend: &dyn QuantumBackend,
     expectation_fn: &Py<PyAny>,
     theta: &[f64],
-) -> f64 {
+) -> Result<f64, EvaluationError> {
     // Training circuits are Qiskit objects (feature-map pre-binding is
     // Qiskit-specific); native QML circuits arrive with a later phase.
     let bound: Vec<BoundCircuit> = training_circuits
         .iter()
-        .map(|qc_xi| BoundCircuit::Qiskit(assign_parameters_qiskit(qc_xi, theta)))
-        .collect();
+        .map(|qc_xi| {
+            Ok(BoundCircuit::Qiskit(assign_parameters_qiskit(
+                qc_xi, theta,
+            )?))
+        })
+        .collect::<Result<_, EvaluationError>>()?;
 
     let batch_size = backend.max_batch_size(bound.len()).max(1);
     let mut all_ev: Vec<f64> = Vec::with_capacity(bound.len());
     for chunk in bound.chunks(batch_size) {
-        let ev = run_and_expect(backend, chunk, config, expectation_fn);
+        let ev = run_and_evaluate(backend, chunk, config, expectation_fn)?;
         all_ev.extend(ev);
     }
 
-    all_ev.iter().sum::<f64>() / all_ev.len() as f64
+    Ok(all_ev.iter().sum::<f64>() / all_ev.len() as f64)
 }

--- a/crates/polypus/src/evaluation/vqc_oracle.rs
+++ b/crates/polypus/src/evaluation/vqc_oracle.rs
@@ -1,4 +1,6 @@
-use crate::evaluation::{run_and_expect, CircuitSource, EvaluationOracle};
+use crate::evaluation::{
+    run_and_evaluate, CircuitSource, EvaluationError, EvaluationOracle, OracleErrorSlot,
+};
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use pyo3::prelude::*;
 use std::sync::Arc;
@@ -23,16 +25,40 @@ pub struct VqcOracle {
     pub config: Arc<ExecutionConfig>,
     pub backend: Arc<dyn QuantumBackend>,
     pub expectation_fn: Py<PyAny>,
+    /// Shared with the `train` entry point: the first evaluation failure is
+    /// recorded here and surfaced as a `PyErr` after `optimize` returns, since
+    /// [`EvaluationOracle::evaluate_batch`] cannot return a `Result`.
+    pub errors: OracleErrorSlot,
 }
 
 impl EvaluationOracle for VqcOracle {
     fn evaluate_batch(&self, candidates: &[Vec<f64>]) -> Vec<f64> {
+        // Once evaluation has failed, stop doing work: return finite sentinels
+        // and let the entry point surface the recorded error.
+        if self.errors.failed() {
+            return vec![0.0; candidates.len()];
+        }
+        match self.try_evaluate(candidates) {
+            Ok(values) => values,
+            Err(e) => {
+                self.errors.record(e);
+                vec![0.0; candidates.len()]
+            }
+        }
+    }
+}
+
+impl VqcOracle {
+    /// Fallible core of [`EvaluationOracle::evaluate_batch`]. Kept separate so
+    /// the trait method (which must return `Vec<f64>`) can record any error and
+    /// yield finite sentinels while the entry point re-raises it.
+    fn try_evaluate(&self, candidates: &[Vec<f64>]) -> Result<Vec<f64>, EvaluationError> {
         // Bind each candidate to the circuit template. For native circuits
         // this loop never touches Python.
         let bound: Vec<BoundCircuit> = candidates
             .iter()
             .map(|params| self.circuit.bind(params))
-            .collect();
+            .collect::<Result<_, _>>()?;
 
         // Submit circuits in backend-sized batches and collect expectations.
         // Local runs the whole batch in one Aer call (parallel experiments);
@@ -40,14 +66,14 @@ impl EvaluationOracle for VqcOracle {
         let batch_size = self.backend.max_batch_size(bound.len()).max(1);
         let mut results = Vec::with_capacity(candidates.len());
         for chunk in bound.chunks(batch_size) {
-            let ev = run_and_expect(
+            let ev = run_and_evaluate(
                 self.backend.as_ref(),
                 chunk,
                 &self.config,
                 &self.expectation_fn,
-            );
+            )?;
             results.extend(ev);
         }
-        results
+        Ok(results)
     }
 }

--- a/crates/polypus/src/exceptions.rs
+++ b/crates/polypus/src/exceptions.rs
@@ -1,0 +1,82 @@
+//! Custom Python exception hierarchy for the Polypus bindings.
+//!
+//! The orchestration/FFI crate turns its internal `Result` error enums
+//! ([`BackendError`](crate::infrastructure::BackendError),
+//! [`EvaluationError`](crate::evaluation::EvaluationError)) into typed Python
+//! exceptions so that a failure reaching Python is a catchable, documented
+//! class instead of a `pyo3_runtime.PanicException` (or a process abort).
+//!
+//! The hierarchy is rooted at `PolypusError` so user code can catch every
+//! Polypus-originated failure with a single `except polypus.PolypusError`.
+//! Domain subclasses mirror the layers that raise them:
+//!
+//! ```text
+//! Exception
+//! └── PolypusError
+//!     ├── BackendError            # execution/orchestration layer
+//!     │   ├── CunqaError          # CUNQA distributed-QPU backend
+//!     │   ├── QmioError           # QMIO real-QPU network path
+//!     │   └── NativeCircuitError  # pure-Rust circuit / simulator path
+//!     └── EvaluationError         # optimizer oracle / expectation evaluation
+//! ```
+//!
+//! Contract C-1 (see `docs/CONTRACTS.md`) keeps its documented failure modes:
+//! an *unknown infrastructure* still surfaces as `ValueError` and a *bad kwarg*
+//! at the `polypus_python` seam still surfaces as `TypeError`, because
+//! [`BackendError::Seam`](crate::infrastructure::BackendError::Seam) re-raises
+//! the original Python exception verbatim. The classes below are raised for the
+//! Rust-originated runtime failures that previously *panicked*.
+
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+
+create_exception!(
+    polypus,
+    PolypusError,
+    PyException,
+    "Base class for every Polypus runtime error."
+);
+create_exception!(
+    polypus,
+    BackendError,
+    PolypusError,
+    "A quantum-execution backend failed at runtime."
+);
+create_exception!(
+    polypus,
+    CunqaError,
+    BackendError,
+    "A failure originating in the CUNQA distributed-QPU backend."
+);
+create_exception!(
+    polypus,
+    QmioError,
+    BackendError,
+    "A failure on the QMIO real-QPU network/serialisation path."
+);
+create_exception!(
+    polypus,
+    NativeCircuitError,
+    BackendError,
+    "The native (pure-Rust) circuit or statevector-simulator path failed."
+);
+create_exception!(
+    polypus,
+    EvaluationError,
+    PolypusError,
+    "An oracle/expectation-evaluation failure during training."
+);
+
+/// Register the exception hierarchy on the extension module so Python can both
+/// see (`polypus.BackendError`) and catch these classes.
+pub fn register(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
+    use pyo3::types::PyModuleMethods;
+    let py = m.py();
+    m.add("PolypusError", py.get_type::<PolypusError>())?;
+    m.add("BackendError", py.get_type::<BackendError>())?;
+    m.add("CunqaError", py.get_type::<CunqaError>())?;
+    m.add("QmioError", py.get_type::<QmioError>())?;
+    m.add("NativeCircuitError", py.get_type::<NativeCircuitError>())?;
+    m.add("EvaluationError", py.get_type::<EvaluationError>())?;
+    Ok(())
+}

--- a/crates/polypus/src/infrastructure/cunqa.rs
+++ b/crates/polypus/src/infrastructure/cunqa.rs
@@ -1,13 +1,21 @@
+use crate::infrastructure::error::BackendError;
 use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Transpiler};
-use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
+use crate::infrastructure::{
+    record_cleanup_failure, BoundCircuit, ExecutionConfig, QuantumBackend,
+};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// The QPU-release operation, boxed so it can capture the CUNQA family handle
+/// obtained at construction and — crucially — so the panic-safety of `Drop` can
+/// be exercised in tests by injecting a failing closure that never touches the
+/// Python interpreter (see [`CunqaBackend::with_releaser`]).
+type ReleaseFn = Box<dyn Fn() -> Result<(), BackendError> + Send + Sync>;
+
 /// CunqaBackend: runs quantum circuits on the CUNQA distributed QPU platform.
 pub struct CunqaBackend {
-    family: Option<Py<PyAny>>,
     /// Guards against double-release of the QPU allocation (explicit `close()`
     /// followed by `Drop`, or vice versa).
     closed: AtomicBool,
@@ -22,6 +30,10 @@ pub struct CunqaBackend {
     /// QPUs transpile internally, so this defaults to the no-op
     /// [`IdentityTranspiler`] and the observable behavior is unchanged.
     transpiler: Box<dyn Transpiler>,
+    /// Releases the QPU allocation on `close`/`Drop`. Captured at construction
+    /// (holding the family handle) so `Drop` needs nothing but this field, and
+    /// so panic-safety is testable without a Python interpreter.
+    release: ReleaseFn,
 }
 
 impl QuantumBackend for CunqaBackend {
@@ -29,7 +41,7 @@ impl QuantumBackend for CunqaBackend {
         &self,
         qcs: &[BoundCircuit],
         config: &ExecutionConfig,
-    ) -> Vec<HashMap<String, u64>> {
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError> {
         Python::with_gil(|py| {
             // Native circuits are transpiled in pure Rust before submission;
             // Qiskit circuits pass through untouched and every native circuit
@@ -40,27 +52,33 @@ impl QuantumBackend for CunqaBackend {
             let qcs_pylist = PyList::empty(py);
             for qc in qcs {
                 let qc = qc.transpiled(self.transpiler.as_ref(), &opts);
-                qcs_pylist.append(qc.to_py_object(py)).unwrap();
+                qcs_pylist
+                    .append(qc.to_py_object(py)?)
+                    .map_err(|e| BackendError::Conversion(e.to_string()))?;
             }
 
-            let module = PyModule::import(py, "polypus_python").unwrap();
+            let module = PyModule::import(py, "polypus_python").map_err(BackendError::Seam)?;
             let kwargs = PyDict::new(py);
-            kwargs.set_item("family_id", &config.id).unwrap();
-            kwargs.set_item("backend", &self.backend).unwrap();
-            kwargs.set_item("qcs", qcs_pylist).unwrap();
-            kwargs.set_item("shots", config.shots).unwrap();
-            kwargs.set_item("sim_method", &self.sim_method).unwrap();
+            let conv = |e: PyErr| BackendError::Conversion(e.to_string());
+            kwargs.set_item("family_id", &config.id).map_err(conv)?;
+            kwargs.set_item("backend", &self.backend).map_err(conv)?;
+            kwargs.set_item("qcs", qcs_pylist).map_err(conv)?;
+            kwargs.set_item("shots", config.shots).map_err(conv)?;
+            kwargs
+                .set_item("sim_method", &self.sim_method)
+                .map_err(conv)?;
 
-            module
+            let result = module
                 .call_method("run_qcs", ("cunqa",), Some(&kwargs))
-                .unwrap_or_else(|e| {
-                    // Surface the failure before the panic PyO3 turns into a
-                    // Python exception (mirrors the QMIO backend's error paths).
+                .map_err(|e| {
+                    // Surface the failure at error level (mirrors the QMIO/local
+                    // error paths) before it crosses the FFI as an exception.
                     log::error!("CUNQA circuit execution failed: {e}");
-                    panic!("Error running circuits on CUNQA: {e}");
-                })
+                    BackendError::Seam(e)
+                })?;
+            result
                 .extract::<Vec<HashMap<String, u64>>>()
-                .expect("run_qcs must return list[dict[str, int]]")
+                .map_err(BackendError::Seam)
         })
     }
 
@@ -75,13 +93,29 @@ impl QuantumBackend for CunqaBackend {
         if self.closed.swap(true, Ordering::SeqCst) {
             return;
         }
-        self.drop_qpus();
+        log::info!("Dropping QPUs");
+        // Panic-free by construction: `release` returns a `Result`, so a failure
+        // is logged and recorded in the process-wide counter instead of
+        // propagated. This is what makes `Drop` safe even mid-unwind, and it is
+        // reached identically from the explicit `close()` calls in the
+        // orchestration algorithms.
+        match (self.release)() {
+            Ok(()) => log::info!("QPUs dropped successfully"),
+            Err(e) => {
+                log::error!("CUNQA QPU release failed: {e}");
+                record_cleanup_failure();
+            }
+        }
     }
 }
 
 /// RAII guarantee: QPUs are released even if the algorithm panics or returns
 /// early. This is essential for the HPC use case, where leaking a SLURM
 /// allocation would keep nodes reserved for the full requested walltime.
+///
+/// `close` can never panic (it only logs and counts a failed release), so this
+/// `Drop` is safe to run while another panic is already unwinding — the double
+/// panic that would abort the process cannot occur.
 impl Drop for CunqaBackend {
     fn drop(&mut self) {
         self.close();
@@ -96,67 +130,161 @@ impl CunqaBackend {
         cores_per_qpu: u32,
         backend: String,
         sim_method: String,
-    ) -> Self {
-        let mut backend = CunqaBackend {
-            family: None,
-            closed: AtomicBool::new(false),
-            backend,
-            sim_method,
-            n_qpus,
-            transpiler: Box::new(IdentityTranspiler),
-        };
-        backend.raise_qpus(n_qpus, nodes, id, cores_per_qpu);
-        backend
-    }
-
-    fn raise_qpus(&mut self, n_qpus: u32, nodes: u32, id: &str, cores_per_qpu: u32) {
+    ) -> Result<Self, BackendError> {
         // Allocating QPUs reserves an HPC (SLURM) allocation — a rare, coarse
         // lifecycle event an operator wants to see at the default level.
         log::info!(
             "Raising QPUs in CUNQA: n_qpus={n_qpus}, nodes={nodes}, id={id}, cores_per_qpu={cores_per_qpu}"
         );
-        Python::with_gil(|py| {
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("n", n_qpus).unwrap();
-            kwargs.set_item("t", "10:00:00").unwrap();
-            kwargs.set_item("n_nodes", nodes).unwrap();
-            kwargs.set_item("family_name", id).unwrap();
-            kwargs.set_item("cores_per_qpu", cores_per_qpu).unwrap();
-
-            let module = PyModule::import(py, "polypus_python").unwrap();
-            let connection = module
-                .call_method("connect_to_infrastructure", ("cunqa",), Some(&kwargs))
-                .unwrap_or_else(|e| {
-                    log::error!("CUNQA QPU allocation failed: {e}");
-                    panic!("Error raising QPUs in CUNQA: {e}");
-                });
-            let family: Py<PyAny> = connection
-                .extract()
-                .expect("Error extracting family from CUNQA");
-            log::info!("QPUs raised successfully");
-            self.family = Some(family);
-        });
+        let family = raise_qpus(n_qpus, nodes, id, cores_per_qpu)?;
+        // Capture the family handle in the release closure; it is the only thing
+        // `drop_qpus` needs, and keeping it here (rather than as a struct field)
+        // keeps the release operation self-contained and injectable.
+        let release: ReleaseFn = Box::new(move || drop_qpus(&family));
+        Ok(CunqaBackend {
+            closed: AtomicBool::new(false),
+            backend,
+            sim_method,
+            n_qpus,
+            transpiler: Box::new(IdentityTranspiler),
+            release,
+        })
     }
 
-    fn drop_qpus(&self) {
-        // Nothing to release if the allocation was never established. Guarding
-        // here is important because `drop_qpus` runs from `Drop`, and a panic
-        // while unwinding would abort the entire process.
-        let Some(family) = self.family.as_ref() else {
-            return;
-        };
-        log::info!("Dropping QPUs");
-        Python::with_gil(|py| {
-            let module = PyModule::import(py, "polypus_python").unwrap();
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("family", family.clone_ref(py)).unwrap();
-            module
-                .call_method("disconnect_from_infrastructure", ("cunqa",), Some(&kwargs))
-                .unwrap_or_else(|e| {
-                    log::error!("CUNQA QPU release failed: {e}");
-                    panic!("Error dropping QPUs in CUNQA: {e}");
-                });
-            log::info!("QPUs dropped successfully");
-        });
+    /// Construct a backend with an injected release operation, bypassing the
+    /// real CUNQA allocation. Test-only hook that lets the `Drop` panic-safety
+    /// test force a cleanup failure without a Python interpreter or SLURM.
+    #[cfg(test)]
+    fn with_releaser(release: ReleaseFn) -> Self {
+        CunqaBackend {
+            closed: AtomicBool::new(false),
+            backend: String::new(),
+            sim_method: String::new(),
+            n_qpus: 1,
+            transpiler: Box::new(IdentityTranspiler),
+            release,
+        }
+    }
+}
+
+/// Raise the SLURM QPU allocation via the `polypus_python` seam, returning the
+/// opaque CUNQA family handle.
+fn raise_qpus(
+    n_qpus: u32,
+    nodes: u32,
+    id: &str,
+    cores_per_qpu: u32,
+) -> Result<Py<PyAny>, BackendError> {
+    Python::with_gil(|py| {
+        let kwargs = PyDict::new(py);
+        let conv = |e: PyErr| BackendError::Conversion(e.to_string());
+        kwargs.set_item("n", n_qpus).map_err(conv)?;
+        kwargs.set_item("t", "10:00:00").map_err(conv)?;
+        kwargs.set_item("n_nodes", nodes).map_err(conv)?;
+        kwargs.set_item("family_name", id).map_err(conv)?;
+        kwargs
+            .set_item("cores_per_qpu", cores_per_qpu)
+            .map_err(conv)?;
+
+        let module = PyModule::import(py, "polypus_python").map_err(BackendError::Seam)?;
+        let connection = module
+            .call_method("connect_to_infrastructure", ("cunqa",), Some(&kwargs))
+            .map_err(|e| {
+                log::error!("CUNQA QPU allocation failed: {e}");
+                BackendError::Seam(e)
+            })?;
+        let family: Py<PyAny> = connection.extract().map_err(|e| {
+            BackendError::Cunqa(format!("could not extract the CUNQA family handle: {e}"))
+        })?;
+        log::info!("QPUs raised successfully");
+        Ok(family)
+    })
+}
+
+/// Release the QPU allocation identified by `family` through the
+/// `polypus_python` seam.
+///
+/// Panic-free: every failure is returned as a [`BackendError`] so the caller
+/// ([`CunqaBackend::close`], reached from `Drop`) can log-and-continue.
+/// Acquiring the GIL here is safe from within `Drop`: the extension module is
+/// only dropped while the interpreter is alive, and PyO3 0.24's
+/// [`Python::with_gil`] is re-entrant, so this cannot deadlock or propagate a
+/// panic through an in-progress unwind.
+fn drop_qpus(family: &Py<PyAny>) -> Result<(), BackendError> {
+    Python::with_gil(|py| {
+        let module = PyModule::import(py, "polypus_python").map_err(BackendError::Seam)?;
+        let kwargs = PyDict::new(py);
+        kwargs
+            .set_item("family", family.clone_ref(py))
+            .map_err(|e| BackendError::Conversion(e.to_string()))?;
+        module
+            .call_method("disconnect_from_infrastructure", ("cunqa",), Some(&kwargs))
+            .map_err(BackendError::Seam)?;
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::cleanup_failure_count;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+
+    /// Failure-injection test (issue acceptance criterion 2): a `CunqaBackend`
+    /// whose release always fails is dropped *while another panic is already
+    /// unwinding*. A panic in `Drop` mid-unwind would abort the process; this
+    /// test proves it does not, and that the failure is recorded.
+    ///
+    /// No Python interpreter is involved — the injected releaser is pure Rust —
+    /// so this honours ENGINEERING.md §3 (Python-runtime-free Rust test suite).
+    #[test]
+    fn drop_during_unwind_is_panic_free_and_records_failure() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let before = cleanup_failure_count();
+        let attempts_in = Arc::clone(&attempts);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _backend = CunqaBackend::with_releaser(Box::new(move || {
+                attempts_in.fetch_add(1, Ordering::SeqCst);
+                Err(BackendError::Cunqa("injected release failure".to_string()))
+            }));
+            // Drop runs while THIS panic unwinds out of the closure.
+            panic!("forced unwind with a live CunqaBackend");
+        }));
+
+        assert!(
+            result.is_err(),
+            "the forced panic must propagate — a double panic would have aborted the process"
+        );
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "Drop must attempt the release exactly once during the unwind"
+        );
+        assert!(
+            cleanup_failure_count() > before,
+            "the failed cleanup must be recorded in the process-wide counter"
+        );
+    }
+
+    /// `close()` is idempotent and never releases more than once, whether it is
+    /// called explicitly (orchestration path) or via `Drop`.
+    #[test]
+    fn close_is_idempotent_across_explicit_close_and_drop() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in = Arc::clone(&calls);
+        let backend = CunqaBackend::with_releaser(Box::new(move || {
+            calls_in.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }));
+        backend.close();
+        backend.close();
+        drop(backend);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "release must run exactly once across close/close/drop"
+        );
     }
 }

--- a/crates/polypus/src/infrastructure/error.rs
+++ b/crates/polypus/src/infrastructure/error.rs
@@ -1,0 +1,113 @@
+//! Error type for the orchestration / execution backend layer.
+//!
+//! # Granularity decision
+//!
+//! `crates/polypus` uses **two** hand-written error enums rather than one per
+//! module: [`BackendError`] here (backend construction, circuit execution,
+//! infrastructure selection, Rust↔Python conversion) and
+//! [`EvaluationError`](crate::evaluation::EvaluationError) for the optimizer
+//! oracle path. The feature-gated `QmioError` keeps its own rich enum (verified
+//! against the wire protocol) and is *wrapped* by `BackendError::Qmio` instead
+//! of being flattened. This mirrors the existing per-crate `error.rs` style
+//! (`polypus-circuit`, `polypus-optimizers`) while keeping the number of types
+//! the seam has to thread small.
+//!
+//! Every variant is a genuinely fallible interaction (Python call, IO, data
+//! conversion), never a pure invariant — so replacing the previous
+//! `unwrap()`/`expect()`/`panic!` sites with this `Result` is what lets the FFI
+//! boundary map a failure to a `PyErr` instead of unwinding across it
+//! (ENGINEERING.md §9).
+
+use std::fmt;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::PyErr;
+
+use crate::exceptions::{
+    BackendError as PyBackendError, CunqaError as PyCunqaError,
+    NativeCircuitError as PyNativeCircuitError,
+};
+
+/// Failure of a quantum-execution backend or of backend construction.
+///
+/// Mirrors the hand-written style of
+/// [`CircuitError`](polypus_circuit::CircuitError) and the crate's own
+/// `QmioError`: no `thiserror`, a `match`-based [`fmt::Display`] and an empty
+/// [`std::error::Error`] impl.
+///
+/// `Clone`/`Eq` are intentionally omitted: [`BackendError::Seam`] carries a
+/// [`PyErr`], which is neither `Clone` nor `Eq`.
+#[derive(Debug)]
+pub enum BackendError {
+    /// The requested infrastructure name is not recognised. Surfaces as
+    /// `ValueError` to honour contract C-1 (unknown infrastructure).
+    UnknownInfrastructure {
+        /// The rejected infrastructure string.
+        name: String,
+    },
+    /// A backend was asked to run a circuit representation it cannot execute
+    /// (e.g. a Qiskit `QuantumCircuit` on a GIL-free backend).
+    UnsupportedCircuit(String),
+    /// A native (pure-Rust) circuit failed to parse or to simulate.
+    NativeCircuit(String),
+    /// A CUNQA-specific failure originating in the Rust layer (family-handle
+    /// extraction, allocation bookkeeping).
+    Cunqa(String),
+    /// Converting data across the Rust↔Python boundary failed (our side of the
+    /// call — building kwargs, converting counts, …).
+    Conversion(String),
+    /// A Python exception raised by the `polypus_python` execution seam
+    /// (`connect_to_infrastructure` / `run_qcs` /
+    /// `disconnect_from_infrastructure`).
+    ///
+    /// Carried verbatim so its original type is preserved when it crosses back
+    /// into Python: contract C-1 requires an unknown infrastructure to be a
+    /// `ValueError` and an unexpected/missing kwarg to be a `TypeError`, and
+    /// both are raised on the Python side of the seam.
+    Seam(PyErr),
+    /// A failure on the QMIO network/serialisation path.
+    #[cfg(feature = "qmio")]
+    Qmio(super::qmio::QmioError),
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackendError::UnknownInfrastructure { name } => {
+                write!(f, "unknown infrastructure '{name}'")
+            }
+            BackendError::UnsupportedCircuit(m) => write!(f, "{m}"),
+            BackendError::NativeCircuit(m) => write!(f, "{m}"),
+            BackendError::Cunqa(m) => write!(f, "CUNQA backend error: {m}"),
+            BackendError::Conversion(m) => {
+                write!(f, "data conversion across the Python boundary failed: {m}")
+            }
+            BackendError::Seam(err) => write!(f, "polypus_python seam error: {err}"),
+            #[cfg(feature = "qmio")]
+            BackendError::Qmio(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+impl From<BackendError> for PyErr {
+    fn from(err: BackendError) -> PyErr {
+        match err {
+            // Re-raise the original Python exception unchanged so contract C-1's
+            // documented ValueError/TypeError failure modes are preserved.
+            BackendError::Seam(py_err) => py_err,
+            BackendError::UnknownInfrastructure { name } => PyValueError::new_err(format!(
+                "unknown infrastructure '{name}'; expected \"local\", \"cunqa\" or \"qmio\""
+            )),
+            BackendError::UnsupportedCircuit(m) => PyNativeCircuitError::new_err(m),
+            BackendError::NativeCircuit(m) => PyNativeCircuitError::new_err(m),
+            BackendError::Cunqa(m) => PyCunqaError::new_err(m),
+            BackendError::Conversion(m) => PyBackendError::new_err(m),
+            #[cfg(feature = "qmio")]
+            BackendError::Qmio(qmio_err) => {
+                crate::exceptions::QmioError::new_err(qmio_err.to_string())
+            }
+        }
+    }
+}

--- a/crates/polypus/src/infrastructure/local.rs
+++ b/crates/polypus/src/infrastructure/local.rs
@@ -1,3 +1,4 @@
+use crate::infrastructure::error::BackendError;
 use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Transpiler};
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use pyo3::prelude::*;
@@ -34,7 +35,7 @@ impl QuantumBackend for LocalBackend {
         &self,
         qcs: &[BoundCircuit],
         config: &ExecutionConfig,
-    ) -> Vec<HashMap<String, u64>> {
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError> {
         Python::with_gil(|py| {
             // Native circuits are transpiled in pure Rust before submission;
             // Qiskit circuits pass through untouched (Aer transpiles them) and
@@ -45,38 +46,46 @@ impl QuantumBackend for LocalBackend {
             let qcs_pylist = PyList::empty(py);
             for qc in qcs {
                 let qc = qc.transpiled(self.transpiler.as_ref(), &opts);
-                qcs_pylist.append(qc.to_py_object(py)).unwrap();
+                qcs_pylist
+                    .append(qc.to_py_object(py)?)
+                    .map_err(|e| BackendError::Conversion(e.to_string()))?;
             }
 
-            let module = PyModule::import(py, "polypus_python").unwrap();
+            let module = PyModule::import(py, "polypus_python").map_err(BackendError::Seam)?;
             let connection = module
                 .call_method("connect_to_infrastructure", ("local",), None)
-                .unwrap_or_else(|e| {
-                    // Surface the failure before the panic PyO3 turns into a
-                    // Python exception (mirrors the QMIO/CUNQA error paths).
+                .map_err(|e| {
+                    // Surface the failure before it crosses the FFI as a Python
+                    // exception (mirrors the QMIO/CUNQA error paths).
                     log::error!("local infrastructure connection failed: {e}");
-                    panic!("Error connecting to local infrastructure: {e}");
-                });
-            let connection_str = connection.extract::<String>().unwrap();
+                    BackendError::Seam(e)
+                })?;
+            let connection_str = connection.extract::<String>().map_err(BackendError::Seam)?;
 
             let kwargs = PyDict::new(py);
-            kwargs.set_item("id", &config.id).unwrap();
-            kwargs.set_item("backend", &self.backend).unwrap();
-            kwargs.set_item("qcs", qcs_pylist).unwrap();
-            kwargs.set_item("shots", config.shots).unwrap();
-            kwargs.set_item("sim_method", &self.sim_method).unwrap();
+            let conv = |e: PyErr| BackendError::Conversion(e.to_string());
+            kwargs.set_item("id", &config.id).map_err(conv)?;
+            kwargs.set_item("backend", &self.backend).map_err(conv)?;
+            kwargs.set_item("qcs", qcs_pylist).map_err(conv)?;
+            kwargs.set_item("shots", config.shots).map_err(conv)?;
+            kwargs
+                .set_item("sim_method", &self.sim_method)
+                .map_err(conv)?;
             if let Some(nm) = &self.noise_model {
-                kwargs.set_item("noise_model", nm.clone_ref(py)).unwrap();
+                kwargs
+                    .set_item("noise_model", nm.clone_ref(py))
+                    .map_err(conv)?;
             }
 
-            module
+            let result = module
                 .call_method("run_qcs", (connection_str,), Some(&kwargs))
-                .unwrap_or_else(|e| {
+                .map_err(|e| {
                     log::error!("local circuit execution failed: {e}");
-                    panic!("Error running run_qcs: {e}");
-                })
+                    BackendError::Seam(e)
+                })?;
+            result
                 .extract::<Vec<HashMap<String, u64>>>()
-                .expect("run_qcs must return list[dict[str, int]]")
+                .map_err(BackendError::Seam)
         })
     }
 }

--- a/crates/polypus/src/infrastructure/mod.rs
+++ b/crates/polypus/src/infrastructure/mod.rs
@@ -97,7 +97,13 @@ impl Infrastructure {
                 backend.clone(),
                 sim_method.clone(),
             )?)),
-            BackendConfig::LocalNative => Ok(Arc::new(NativeStatevectorBackend::new(&config.id))),
+            // The Python-facing layer resolves a concrete seed whenever the
+            // native backend runs; the entropy fallback here only guards a
+            // directly-built config that left `seed` unset (e.g. tests), so
+            // an omitted seed still yields independent noise, never a panic.
+            BackendConfig::LocalNative => Ok(Arc::new(NativeStatevectorBackend::new(
+                config.seed.unwrap_or_else(execution_config::random_seed),
+            ))),
             #[cfg(feature = "qmio")]
             BackendConfig::Qmio {
                 endpoint,

--- a/crates/polypus/src/infrastructure/mod.rs
+++ b/crates/polypus/src/infrastructure/mod.rs
@@ -1,8 +1,10 @@
 use pyo3::prelude::*;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 pub mod cunqa;
+pub mod error;
 pub mod execution_config;
 pub mod local;
 pub mod native;
@@ -11,12 +13,31 @@ pub mod qmio;
 pub mod transpiler;
 
 pub use cunqa::CunqaBackend;
+pub use error::BackendError;
 pub use execution_config::{BackendConfig, ExecutionConfig};
 pub use local::LocalBackend;
 pub use native::NativeStatevectorBackend;
 #[cfg(feature = "qmio")]
 pub use qmio::QmioBackend;
 pub use transpiler::{IdentityTranspiler, OptLevel, TranspileOptions, Transpiler};
+
+/// Process-wide count of backend cleanup (`close`/`Drop`) failures.
+///
+/// A `Drop` must never panic, so a failed teardown is logged and counted here
+/// rather than propagated. A per-instance flag would be useless — nobody holds
+/// the instance once `Drop` returns — so the consultable state lives in this
+/// process-wide counter, exposed to Python as `polypus.backend_cleanup_failures()`.
+static CLEANUP_FAILURES: AtomicU64 = AtomicU64::new(0);
+
+/// Record that a backend's resource cleanup failed. Called from `close`/`Drop`.
+pub fn record_cleanup_failure() {
+    CLEANUP_FAILURES.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Number of backend cleanup failures recorded so far this process (diagnostic).
+pub fn cleanup_failure_count() -> u64 {
+    CLEANUP_FAILURES.load(Ordering::SeqCst)
+}
 
 /// Supported quantum execution infrastructures.
 pub enum Infrastructure {
@@ -31,12 +52,14 @@ pub enum Infrastructure {
 
 impl Infrastructure {
     #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_str(s: &str) -> Result<Self, BackendError> {
         match s {
-            "local" => Infrastructure::Local,
-            "cunqa" => Infrastructure::Cunqa,
-            "qmio" => Infrastructure::Qmio,
-            _ => panic!("Unknown infrastructure: {}", s),
+            "local" => Ok(Infrastructure::Local),
+            "cunqa" => Ok(Infrastructure::Cunqa),
+            "qmio" => Ok(Infrastructure::Qmio),
+            other => Err(BackendError::UnknownInfrastructure {
+                name: other.to_string(),
+            }),
         }
     }
 
@@ -46,33 +69,35 @@ impl Infrastructure {
     /// chosen backend and its parameters can never desync. Adding a new backend
     /// (IBM, IQM, …) means adding one arm here and implementing
     /// [`QuantumBackend`] for the new type — no algorithm code changes.
-    pub fn create_backend(config: &ExecutionConfig) -> Arc<dyn QuantumBackend> {
+    pub fn create_backend(
+        config: &ExecutionConfig,
+    ) -> Result<Arc<dyn QuantumBackend>, BackendError> {
         match &config.backend_config {
             BackendConfig::Local {
                 backend,
                 sim_method,
                 noise_model,
-            } => Arc::new(LocalBackend::new(
+            } => Ok(Arc::new(LocalBackend::new(
                 backend.clone(),
                 sim_method.clone(),
                 noise_model
                     .as_ref()
                     .map(|nm| Python::with_gil(|py| nm.clone_ref(py))),
-            )),
+            ))),
             BackendConfig::Cunqa {
                 backend,
                 sim_method,
                 nodes,
                 cores_per_qpu,
-            } => Arc::new(CunqaBackend::new(
+            } => Ok(Arc::new(CunqaBackend::new(
                 config.n_qpus,
                 *nodes,
                 &config.id,
                 *cores_per_qpu,
                 backend.clone(),
                 sim_method.clone(),
-            )),
-            BackendConfig::LocalNative => Arc::new(NativeStatevectorBackend::new(&config.id)),
+            )?)),
+            BackendConfig::LocalNative => Ok(Arc::new(NativeStatevectorBackend::new(&config.id))),
             #[cfg(feature = "qmio")]
             BackendConfig::Qmio {
                 endpoint,
@@ -80,12 +105,15 @@ impl Infrastructure {
                 optimization,
                 repetition_period,
                 res_format,
-            } => Arc::new(QmioBackend::new(
-                endpoint.clone(),
-                *program_format,
-                *optimization,
-                *repetition_period,
-                res_format.clone(),
+            } => Ok(Arc::new(
+                QmioBackend::new(
+                    endpoint.clone(),
+                    *program_format,
+                    *optimization,
+                    *repetition_period,
+                    res_format.clone(),
+                )
+                .map_err(BackendError::Qmio)?,
             )),
         }
     }
@@ -118,22 +146,23 @@ impl BoundCircuit {
     /// Convert to the Python object expected by `polypus_python.run_qcs`:
     /// the Qiskit circuit as-is, or the QASM program as a `str` (the Python
     /// layer parses/forwards it per infrastructure).
-    pub fn to_py_object(&self, py: Python<'_>) -> Py<PyAny> {
+    pub fn to_py_object(&self, py: Python<'_>) -> Result<Py<PyAny>, BackendError> {
+        let conv = |e: PyErr| BackendError::Conversion(e.to_string());
         match self {
-            BoundCircuit::Qiskit(qc) => qc.clone_ref(py),
-            BoundCircuit::Qasm2(qasm) => qasm
+            BoundCircuit::Qiskit(qc) => Ok(qc.clone_ref(py)),
+            BoundCircuit::Qasm2(qasm) => Ok(qasm
                 .into_pyobject(py)
-                .expect("Failed to convert QASM string to Python")
+                .map_err(|e| conv(e.into()))?
                 .into_any()
-                .unbind(),
+                .unbind()),
             // Native circuits reach a Python backend (Aer/CUNQA) as OpenQASM 2.0,
             // exactly like the `Qasm2` variant; the conversion is pure Rust.
-            BoundCircuit::Native(circuit) => circuit
+            BoundCircuit::Native(circuit) => Ok(circuit
                 .to_qasm2()
                 .into_pyobject(py)
-                .expect("Failed to convert QASM string to Python")
+                .map_err(|e| conv(e.into()))?
                 .into_any()
-                .unbind(),
+                .unbind()),
         }
     }
 
@@ -199,11 +228,17 @@ pub trait QuantumBackend: Send + Sync {
     /// circuit. Keeping the return type native (rather than a Python object)
     /// means non-Python backends (IBM, IQM, a future native MPI scheduler) never
     /// have to touch the GIL, which is essential for HPC-scale distribution.
+    ///
+    /// A failure is returned as a [`BackendError`] (never a panic): a Python
+    /// exception from the `polypus_python` seam is carried verbatim in
+    /// [`BackendError::Seam`] so it re-raises with its original type, and
+    /// Rust-originated failures map to the typed
+    /// [`exceptions`](crate::exceptions) hierarchy at the FFI boundary.
     fn run_circuits(
         &self,
         qcs: &[BoundCircuit],
         config: &ExecutionConfig,
-    ) -> Vec<HashMap<String, u64>>;
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError>;
 
     /// Maximum number of circuits to submit per [`run_circuits`](Self::run_circuits)
     /// call, given the `total` circuits to evaluate.

--- a/crates/polypus/src/infrastructure/native.rs
+++ b/crates/polypus/src/infrastructure/native.rs
@@ -8,6 +8,7 @@
 //! string is also accepted (parsed in Rust); a Qiskit `QuantumCircuit` is not,
 //! since reading its gates would require the interpreter.
 
+use crate::infrastructure::error::BackendError;
 use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Transpiler};
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use polypus_circuit::{ConcreteCircuit, ParameterizedCircuit};
@@ -69,20 +70,25 @@ impl NativeStatevectorBackend {
         shots: u32,
         seed: u64,
         opts: &TranspileOptions,
-    ) -> HashMap<String, u64> {
+    ) -> Result<HashMap<String, u64>, BackendError> {
         // Obtain a ConcreteCircuit without touching Python.
         let concrete: ConcreteCircuit = match circuit {
             BoundCircuit::Native(cc) => cc.clone(),
             BoundCircuit::Qasm2(qasm) => ParameterizedCircuit::from_qasm2(qasm)
                 .and_then(|pc| pc.assign_parameters(&[]))
-                .unwrap_or_else(|e| {
+                .map_err(|e| {
                     log::error!("native backend could not parse OpenQASM 2.0: {e}");
-                    panic!("native backend could not parse OpenQASM 2.0: {e}");
-                }),
-            BoundCircuit::Qiskit(_) => panic!(
-                "the native statevector backend cannot execute a Qiskit QuantumCircuit; \
-                 pass a polypus.Circuit or an OpenQASM 2.0 string, or select backend=\"aer\""
-            ),
+                    BackendError::NativeCircuit(format!(
+                        "native backend could not parse OpenQASM 2.0: {e}"
+                    ))
+                })?,
+            BoundCircuit::Qiskit(_) => {
+                return Err(BackendError::UnsupportedCircuit(
+                    "the native statevector backend cannot execute a Qiskit QuantumCircuit; \
+                     pass a polypus.Circuit or an OpenQASM 2.0 string, or select backend=\"aer\""
+                        .to_string(),
+                ))
+            }
         };
 
         // Transpile the native circuit (GIL-free) before simulating. With the
@@ -92,10 +98,10 @@ impl NativeStatevectorBackend {
         let raw = self
             .simulator
             .run_and_sample(&concrete, shots as usize, seed)
-            .unwrap_or_else(|e| {
+            .map_err(|e| {
                 log::error!("native statevector simulation failed: {e}");
-                panic!("native statevector simulation failed: {e}");
-            });
+                BackendError::NativeCircuit(format!("native statevector simulation failed: {e}"))
+            })?;
 
         // Bitstring length = classical register width (qubit count when the
         // circuit has no measurements, mirroring a full-register read-out).
@@ -103,9 +109,10 @@ impl NativeStatevectorBackend {
             0 => concrete.num_qubits,
             c => c,
         };
-        raw.into_iter()
+        Ok(raw
+            .into_iter()
             .map(|(state, count)| (format!("{:0w$b}", state, w = width), count))
-            .collect()
+            .collect())
     }
 }
 
@@ -114,7 +121,7 @@ impl QuantumBackend for NativeStatevectorBackend {
         &self,
         qcs: &[BoundCircuit],
         config: &ExecutionConfig,
-    ) -> Vec<HashMap<String, u64>> {
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError> {
         // Tuning travels as an argument; the strategy is the injected field.
         let opts = TranspileOptions {
             level: config.opt_level,
@@ -191,12 +198,14 @@ mod tests {
     #[test]
     fn bell_counts_only_correlated_outcomes() {
         let backend = NativeStatevectorBackend::new("test");
-        let counts = backend.simulate_one(
-            &BoundCircuit::Native(bell()),
-            2000,
-            7,
-            &TranspileOptions::default(),
-        );
+        let counts = backend
+            .simulate_one(
+                &BoundCircuit::Native(bell()),
+                2000,
+                7,
+                &TranspileOptions::default(),
+            )
+            .unwrap();
         let total: u64 = counts.values().sum();
         assert_eq!(total, 2000);
         for key in counts.keys() {
@@ -215,8 +224,12 @@ mod tests {
             NativeStatevectorBackend::with_transpiler("bell", Box::new(IdentityTranspiler));
         let circuit = BoundCircuit::Native(bell());
         assert_eq!(
-            default_backend.simulate_one(&circuit, 1000, 42, &opts),
-            explicit_backend.simulate_one(&circuit, 1000, 42, &opts),
+            default_backend
+                .simulate_one(&circuit, 1000, 42, &opts)
+                .unwrap(),
+            explicit_backend
+                .simulate_one(&circuit, 1000, 42, &opts)
+                .unwrap(),
         );
     }
 
@@ -229,12 +242,14 @@ mod tests {
             .unwrap()
             .to_qasm2();
         let backend = NativeStatevectorBackend::new("t");
-        let counts = backend.simulate_one(
-            &BoundCircuit::Qasm2(qasm),
-            128,
-            1,
-            &TranspileOptions::default(),
-        );
+        let counts = backend
+            .simulate_one(
+                &BoundCircuit::Qasm2(qasm),
+                128,
+                1,
+                &TranspileOptions::default(),
+            )
+            .unwrap();
         // X|0> = |1>: every shot reads "1".
         assert_eq!(counts.get("1"), Some(&128));
     }
@@ -245,8 +260,12 @@ mod tests {
     fn qasm2_path_matches_native_path() {
         let backend = NativeStatevectorBackend::new("eq");
         let opts = TranspileOptions::default();
-        let native = backend.simulate_one(&BoundCircuit::Native(bell()), 1000, 5, &opts);
-        let qasm = backend.simulate_one(&BoundCircuit::Qasm2(bell().to_qasm2()), 1000, 5, &opts);
+        let native = backend
+            .simulate_one(&BoundCircuit::Native(bell()), 1000, 5, &opts)
+            .unwrap();
+        let qasm = backend
+            .simulate_one(&BoundCircuit::Qasm2(bell().to_qasm2()), 1000, 5, &opts)
+            .unwrap();
         assert_eq!(native, qasm);
     }
 
@@ -275,7 +294,9 @@ mod tests {
             }),
         );
         let cfg = config_with(OptLevel::Heavy);
-        backend.run_circuits(&[BoundCircuit::Native(bell())], &cfg);
+        backend
+            .run_circuits(&[BoundCircuit::Native(bell())], &cfg)
+            .unwrap();
         assert_eq!(seen.load(Ordering::SeqCst), OptLevel::Heavy as u8);
     }
 
@@ -287,7 +308,9 @@ mod tests {
     fn injected_strategy_runs_through_run_circuits() {
         let backend = NativeStatevectorBackend::with_transpiler("inj", Box::new(BarrierTranspiler));
         let cfg = config_with(OptLevel::default());
-        let counts = backend.run_circuits(&[BoundCircuit::Native(bell())], &cfg);
+        let counts = backend
+            .run_circuits(&[BoundCircuit::Native(bell())], &cfg)
+            .unwrap();
         assert_eq!(counts.len(), 1);
         let total: u64 = counts[0].values().sum();
         assert_eq!(total, u64::from(cfg.shots));
@@ -302,6 +325,9 @@ mod tests {
         let a = NativeStatevectorBackend::new(&cfg.id);
         let b = NativeStatevectorBackend::new(&cfg.id);
         let batch = vec![BoundCircuit::Native(bell())];
-        assert_eq!(a.run_circuits(&batch, &cfg), b.run_circuits(&batch, &cfg));
+        assert_eq!(
+            a.run_circuits(&batch, &cfg).unwrap(),
+            b.run_circuits(&batch, &cfg).unwrap()
+        );
     }
 }

--- a/crates/polypus/src/infrastructure/native.rs
+++ b/crates/polypus/src/infrastructure/native.rs
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn bell_counts_only_correlated_outcomes() {
-        let backend = NativeStatevectorBackend::new("test");
+        let backend = NativeStatevectorBackend::new(0);
         let counts = backend
             .simulate_one(
                 &BoundCircuit::Native(bell()),
@@ -262,7 +262,7 @@ mod tests {
             .assign_parameters(&[])
             .unwrap()
             .to_qasm2();
-        let backend = NativeStatevectorBackend::new("t");
+        let backend = NativeStatevectorBackend::new(0);
         let counts = backend
             .simulate_one(
                 &BoundCircuit::Qasm2(qasm),
@@ -346,8 +346,8 @@ mod tests {
     #[test]
     fn same_seed_reproduces_counts() {
         let cfg = config_with(OptLevel::default());
-        let a = NativeStatevectorBackend::new(&cfg.id);
-        let b = NativeStatevectorBackend::new(&cfg.id);
+        let a = NativeStatevectorBackend::new(2024);
+        let b = NativeStatevectorBackend::new(2024);
         let batch = vec![BoundCircuit::Native(bell())];
         assert_eq!(
             a.run_circuits(&batch, &cfg).unwrap(),
@@ -363,7 +363,10 @@ mod tests {
         let a = NativeStatevectorBackend::new(1);
         let b = NativeStatevectorBackend::new(2);
         let batch = vec![BoundCircuit::Native(uniform3())];
-        assert_ne!(a.run_circuits(&batch, &cfg), b.run_circuits(&batch, &cfg));
+        assert_ne!(
+            a.run_circuits(&batch, &cfg).unwrap(),
+            b.run_circuits(&batch, &cfg).unwrap()
+        );
     }
 
     /// Acceptance criterion (defect #1), negative half: with **no explicit
@@ -379,8 +382,14 @@ mod tests {
         use crate::infrastructure::Infrastructure;
         let cfg = config_with(OptLevel::default()); // id "abc", seed: None
         let batch = vec![BoundCircuit::Native(uniform3())];
-        let a = Infrastructure::create_backend(&cfg).run_circuits(&batch, &cfg);
-        let b = Infrastructure::create_backend(&cfg).run_circuits(&batch, &cfg);
+        let a = Infrastructure::create_backend(&cfg)
+            .unwrap()
+            .run_circuits(&batch, &cfg)
+            .unwrap();
+        let b = Infrastructure::create_backend(&cfg)
+            .unwrap()
+            .run_circuits(&batch, &cfg)
+            .unwrap();
         assert_ne!(
             a, b,
             "no-seed runs with the same id must produce independent noise"

--- a/crates/polypus/src/infrastructure/qmio.rs
+++ b/crates/polypus/src/infrastructure/qmio.rs
@@ -56,7 +56,10 @@
 //!    (header and body), which matches the 2.0-style body the QMIO examples use.
 //!    Verify acceptance against the live QPU (point 6).
 
-use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
+use crate::infrastructure::error::BackendError;
+use crate::infrastructure::{
+    record_cleanup_failure, BoundCircuit, ExecutionConfig, QuantumBackend,
+};
 use polypus_circuit::{CircuitError, ConcreteCircuit, ParameterizedCircuit};
 use serde_json::json;
 use serde_pickle::{DeOptions, SerOptions, Value as PickleValue};
@@ -85,13 +88,12 @@ enum ProgramPayload {
 
 /// Errors raised on the QMIO network/serialisation path.
 ///
-/// [`QuantumBackend::run_circuits`] cannot return a `Result` (its signature is
-/// shared by every backend), so a fatal error is logged and turned into a panic
-/// — which PyO3 surfaces to Python as an exception. This mirrors how
-/// [`CunqaBackend`](crate::infrastructure::CunqaBackend) and
-/// [`NativeStatevectorBackend`](crate::infrastructure::NativeStatevectorBackend)
-/// report unrecoverable failures, while keeping the network code itself free of
-/// scattered `unwrap()`s.
+/// These bubble up through [`QuantumBackend::run_circuits`] as a
+/// [`BackendError::Qmio`], which the FFI boundary maps to the typed
+/// `polypus.QmioError` Python exception — never a panic. The enum keeps its own
+/// rich variants (verified against the wire protocol) instead of being
+/// flattened into [`BackendError`]; see [`crate::infrastructure::error`] for the
+/// crate-wide granularity decision.
 #[derive(Debug)]
 pub enum QmioError {
     /// A Qiskit `QuantumCircuit` reached the GIL-free QMIO path.
@@ -122,6 +124,12 @@ pub enum QmioError {
     },
     /// The reply exceeded [`QmioBackend::max_reply_bytes`].
     ResponseTooLarge { bytes: usize, limit: usize },
+    /// The dedicated Tokio runtime could not be built at construction time.
+    Runtime(String),
+    /// An internal invariant of the request loop did not hold (e.g. the socket
+    /// was unexpectedly absent after a successful connect). Returned rather than
+    /// panicked so it can never abort the process; the request is retried.
+    Internal(String),
 }
 
 impl fmt::Display for QmioError {
@@ -151,6 +159,10 @@ impl fmt::Display for QmioError {
                 f,
                 "QMIO reply of {bytes} bytes exceeds the {limit}-byte safety limit"
             ),
+            QmioError::Runtime(m) => {
+                write!(f, "could not build the Tokio runtime for the QMIO backend: {m}")
+            }
+            QmioError::Internal(m) => write!(f, "internal QMIO backend error: {m}"),
         }
     }
 }
@@ -199,7 +211,7 @@ impl QmioBackend {
         optimization: u8,
         repetition_period: Option<f64>,
         res_format: String,
-    ) -> Self {
+    ) -> Result<Self, QmioError> {
         let endpoint = if endpoint.is_empty() {
             DEFAULT_ENDPOINT.to_string()
         } else {
@@ -212,10 +224,10 @@ impl QmioBackend {
             .worker_threads(1)
             .enable_all()
             .build()
-            .expect("failed to build the Tokio runtime for the QMIO backend");
+            .map_err(|e| QmioError::Runtime(e.to_string()))?;
         let recv_timeout = Duration::from_millis(env_u64("QMIO_RECV_TIMEOUT_MS", 300_000));
         let max_retries = env_u64("QMIO_MAX_RETRIES", 3) as usize;
-        QmioBackend {
+        Ok(QmioBackend {
             endpoint,
             program_format,
             optimization,
@@ -229,7 +241,7 @@ impl QmioBackend {
             // 64 MiB: far above any realistic counts payload, far below "OOM".
             max_reply_bytes: 64 * 1024 * 1024,
             closed: AtomicBool::new(false),
-        }
+        })
     }
 
     /// Serialise one bound circuit into the program payload for the configured
@@ -292,7 +304,10 @@ impl QmioBackend {
         // default `info` log.
         log::debug!("QMIO request: {program:?}, config: {config_json}");
         let request = pickle_request(program, config_json)?;
-        let mut guard = self.socket.lock().expect("QMIO socket mutex poisoned");
+        // Recover the guard even if a previous holder panicked: a poisoned lock
+        // carries no broken invariant here (the socket is `Option`-guarded), and
+        // recovering it keeps this path panic-free.
+        let mut guard = self.socket.lock().unwrap_or_else(|p| p.into_inner());
 
         self.runtime.block_on(async {
             let mut last_err: Option<QmioError> = None;
@@ -324,7 +339,17 @@ impl QmioBackend {
                         }
                     }
                 }
-                let socket = guard.as_mut().expect("socket present after connect");
+                let socket = match guard.as_mut() {
+                    Some(socket) => socket,
+                    None => {
+                        // Cannot happen (we just connected), but never panic:
+                        // record it and let the loop reconnect and retry.
+                        last_err = Some(QmioError::Internal(
+                            "socket unexpectedly absent after connect".to_string(),
+                        ));
+                        continue;
+                    }
+                };
 
                 // Send, bounded by the timeout. A REQ socket that fails or times
                 // out while sending is unusable and must be discarded.
@@ -353,7 +378,15 @@ impl QmioBackend {
 
                 // Receive, bounded by the configured timeout. On timeout or
                 // error the REQ socket is stuck, so we discard and retry.
-                let socket = guard.as_mut().expect("socket present after send");
+                let socket = match guard.as_mut() {
+                    Some(socket) => socket,
+                    None => {
+                        last_err = Some(QmioError::Internal(
+                            "socket unexpectedly absent after send".to_string(),
+                        ));
+                        continue;
+                    }
+                };
                 match tokio::time::timeout(self.recv_timeout, socket.recv()).await {
                     Ok(Ok(reply)) => {
                         // Raw wire reply (unparsed ZMQ frames): the noisiest,
@@ -396,33 +429,11 @@ impl QuantumBackend for QmioBackend {
         &self,
         qcs: &[BoundCircuit],
         config: &ExecutionConfig,
-    ) -> Vec<HashMap<String, u64>> {
-        // The config JSON is identical for every circuit in the batch.
-        let config_json = build_config_json(
-            config.shots,
-            self.repetition_period,
-            &self.res_format,
-            self.optimization,
-        )
-        .and_then(|v| serde_json::to_string(&v).map_err(|e| QmioError::Json(e.to_string())))
-        .unwrap_or_else(|e| {
-            log::error!("QMIO config build failed: {e}");
-            panic!("QMIO backend error: {e}");
-        });
-
-        // One REQ/REP exchange per circuit: the endpoint is a single QPU.
-        qcs.iter()
-            .map(|qc| {
-                let program = self.serialize_program(qc).unwrap_or_else(|e| {
-                    log::error!("QMIO circuit serialisation failed: {e}");
-                    panic!("QMIO backend error: {e}");
-                });
-                self.run_one(&program, &config_json).unwrap_or_else(|e| {
-                    log::error!("QMIO execution failed: {e}");
-                    panic!("QMIO backend error talking to {}: {e}", self.endpoint);
-                })
-            })
-            .collect()
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError> {
+        self.run_all(qcs, config).map_err(|e| {
+            log::error!("QMIO backend error talking to {}: {e}", self.endpoint);
+            BackendError::Qmio(e)
+        })
     }
 
     fn max_batch_size(&self, _total: usize) -> usize {
@@ -434,12 +445,51 @@ impl QuantumBackend for QmioBackend {
         if self.closed.swap(true, Ordering::SeqCst) {
             return;
         }
-        if let Ok(mut guard) = self.socket.lock() {
-            if let Some(socket) = guard.take() {
-                // Graceful close must run inside the runtime context.
-                let _ = self.runtime.block_on(socket.close());
+        // Recover a poisoned guard so `close` still attempts a graceful shutdown
+        // (and never panics) — this runs from `Drop`.
+        let mut guard = self.socket.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(socket) = guard.take() {
+            // Graceful close must run inside the runtime context. `close`
+            // returns any errors it hit instead of a `Result`; log (never
+            // discard) them and record the failed cleanup.
+            let errors = self.runtime.block_on(socket.close());
+            if !errors.is_empty() {
+                log::error!(
+                    "QMIO socket close reported {} error(s): {errors:?}",
+                    errors.len()
+                );
+                record_cleanup_failure();
             }
         }
+    }
+}
+
+impl QmioBackend {
+    /// Execute every circuit in the batch, returning the first failure as a
+    /// [`QmioError`]. Split out from `run_circuits` so the whole batch is a
+    /// single `?`-threaded `Result` with no per-circuit panic.
+    fn run_all(
+        &self,
+        qcs: &[BoundCircuit],
+        config: &ExecutionConfig,
+    ) -> Result<Vec<HashMap<String, u64>>, QmioError> {
+        // The config JSON is identical for every circuit in the batch.
+        let config_value = build_config_json(
+            config.shots,
+            self.repetition_period,
+            &self.res_format,
+            self.optimization,
+        )?;
+        let config_json =
+            serde_json::to_string(&config_value).map_err(|e| QmioError::Json(e.to_string()))?;
+
+        // One REQ/REP exchange per circuit: the endpoint is a single QPU.
+        qcs.iter()
+            .map(|qc| {
+                let program = self.serialize_program(qc)?;
+                self.run_one(&program, &config_json)
+            })
+            .collect()
     }
 }
 
@@ -467,7 +517,12 @@ async fn connect(endpoint: &str) -> Result<ReqSocket, QmioError> {
 /// request will transparently reconnect.
 async fn drop_socket(guard: &mut Option<ReqSocket>) {
     if let Some(socket) = guard.take() {
-        let _ = socket.close().await;
+        // Don't discard the close errors silently (ENGINEERING.md §9): this is a
+        // transient reconnect on a faulted socket, so they are informational.
+        let errors = socket.close().await;
+        if !errors.is_empty() {
+            log::debug!("QMIO faulted-socket close reported errors: {errors:?}");
+        }
     }
 }
 
@@ -747,6 +802,7 @@ mod tests {
             None,
             "binary_count".to_string(),
         )
+        .unwrap()
     }
 
     #[test]
@@ -1031,7 +1087,8 @@ mod tests {
             0,
             None,
             "binary_count".to_string(),
-        );
+        )
+        .unwrap();
         let config = ExecutionConfig {
             id: "qmio-sim".to_string(),
             shots: 1024,
@@ -1047,7 +1104,9 @@ mod tests {
             opt_level: crate::infrastructure::OptLevel::default(),
         };
 
-        let counts = backend.run_circuits(&[BoundCircuit::Native(bell())], &config);
+        let counts = backend
+            .run_circuits(&[BoundCircuit::Native(bell())], &config)
+            .unwrap();
         assert_eq!(counts.len(), 1);
         assert_eq!(counts[0].get("00"), Some(&500));
         assert_eq!(counts[0].get("11"), Some(&524));
@@ -1072,7 +1131,8 @@ mod tests {
             1,
             None,
             "binary_count".to_string(),
-        );
+        )
+        .unwrap();
         let config = ExecutionConfig {
             id: "qmio-real".to_string(),
             shots: 1000,
@@ -1087,7 +1147,9 @@ mod tests {
             },
             opt_level: crate::infrastructure::OptLevel::default(),
         };
-        let counts = backend.run_circuits(&[BoundCircuit::Native(bell())], &config);
+        let counts = backend
+            .run_circuits(&[BoundCircuit::Native(bell())], &config)
+            .unwrap();
         assert_eq!(counts.len(), 1);
         assert_eq!(counts[0].values().sum::<u64>(), 1000);
     }

--- a/crates/polypus/src/lib.rs
+++ b/crates/polypus/src/lib.rs
@@ -64,6 +64,8 @@
 pub mod algorithms;
 mod bindings;
 pub mod evaluation;
+/// Custom Python exception hierarchy raised across the FFI boundary.
+pub mod exceptions;
 pub mod infrastructure;
 pub mod utils;
 

--- a/crates/polypus/src/utils.rs
+++ b/crates/polypus/src/utils.rs
@@ -3,13 +3,30 @@ use std::sync::OnceLock;
 static TOKIO_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 /// Returns a reference to the global multi-threaded Tokio runtime used by Polypus.
-/// The runtime is created lazily on first access and lives for the process lifetime.
-pub fn tokio_runtime() -> &'static tokio::runtime::Runtime {
-    TOKIO_RT.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .thread_name("polypus-worker")
-            .enable_all()
-            .build()
-            .expect("Failed to create Tokio runtime")
-    })
+///
+/// The runtime is created lazily on first access and lives for the process
+/// lifetime. Building it can only fail on OS resource exhaustion; that failure
+/// is returned (never a panic) so callers on the FFI path can surface it as a
+/// typed error. The runtime is built *outside* the `OnceLock` initializer so a
+/// failure is returned to the caller and simply retried on the next call,
+/// rather than poisoning a lazy `get_or_init`.
+pub fn tokio_runtime() -> std::io::Result<&'static tokio::runtime::Runtime> {
+    // Fast path: already built.
+    if let Some(rt) = TOKIO_RT.get() {
+        return Ok(rt);
+    }
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .thread_name("polypus-worker")
+        .enable_all()
+        .build()?;
+    // Store it; if another thread raced us, keep whichever won (both are valid).
+    let _ = TOKIO_RT.set(rt);
+    match TOKIO_RT.get() {
+        Some(rt) => Ok(rt),
+        // Unreachable in practice (a `set` just succeeded, ours or the racer's),
+        // but returned as an error rather than unwrapped so this stays panic-free.
+        None => Err(std::io::Error::other(
+            "the global Tokio runtime is unexpectedly unavailable",
+        )),
+    }
 }

--- a/crates/polypus/tests/native_circuit_path.rs
+++ b/crates/polypus/tests/native_circuit_path.rs
@@ -8,7 +8,7 @@
 //! therefore proof of GIL-freedom, not just a convention.
 
 use polypus::circuit::{Param, ParameterizedCircuit};
-use polypus::evaluation::CircuitSource;
+use polypus::evaluation::{CircuitSource, EvaluationError};
 use polypus::infrastructure::BoundCircuit;
 
 /// QAOA MaxCut ansatz used across the test suite (4 qubits, ring graph, p=1).
@@ -34,7 +34,9 @@ fn qaoa_template() -> ParameterizedCircuit {
 #[test]
 fn native_bind_requires_no_python_interpreter() {
     let source = CircuitSource::Native(qaoa_template());
-    let bound = source.bind(&[0.4, 0.8]);
+    let bound = source
+        .bind(&[0.4, 0.8])
+        .expect("binding a valid native template must succeed");
     match bound {
         // A native template binds to the native variant; serialising it to
         // OpenQASM 2.0 is pure Rust, so this still needs no interpreter.
@@ -63,7 +65,8 @@ fn native_bind_is_threadsafe_without_gil() {
             std::thread::spawn(move || {
                 for j in 0..100 {
                     let theta = [0.01 * i as f64, 0.02 * j as f64];
-                    let BoundCircuit::Native(circuit) = src.bind(&theta) else {
+                    let bound = src.bind(&theta).expect("native binding must succeed");
+                    let BoundCircuit::Native(circuit) = bound else {
                         panic!("expected native circuit");
                     };
                     assert!(circuit.to_qasm2().starts_with("OPENQASM 2.0;"));
@@ -83,10 +86,15 @@ fn native_num_params_known_without_python() {
 }
 
 #[test]
-#[should_panic(expected = "wrong number of parameter values")]
-fn native_bind_panics_on_wrong_param_count() {
+fn native_bind_errors_on_wrong_param_count() {
+    // A wrong parameter count is now a typed binding error, not a panic — it
+    // reaches Python as an EvaluationError instead of unwinding across the FFI.
     let source = CircuitSource::Native(qaoa_template());
-    let _ = source.bind(&[0.1]); // template declares 2 params
+    let result = source.bind(&[0.1]); // template declares 2 params
+    assert!(
+        matches!(result, Err(EvaluationError::Binding(_))),
+        "expected a typed native binding error"
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/polypus/tests/running_quantum_circuits_local.rs
+++ b/crates/polypus/tests/running_quantum_circuits_local.rs
@@ -4,7 +4,7 @@ use polypus::algorithms::{
 };
 use polypus::circuit::ParameterizedCircuit;
 use polypus::infrastructure::{
-    BackendConfig, BoundCircuit, ExecutionConfig, Infrastructure, OptLevel,
+    BackendConfig, BackendError, BoundCircuit, ExecutionConfig, Infrastructure, OptLevel,
 };
 use polypus::AlgorithmTrait;
 use pyo3::prelude::*;
@@ -78,7 +78,7 @@ fn qng_description_is_non_empty() {
 fn infrastructure_from_str_local() {
     assert!(matches!(
         Infrastructure::from_str("local"),
-        Infrastructure::Local
+        Ok(Infrastructure::Local)
     ));
 }
 
@@ -86,14 +86,20 @@ fn infrastructure_from_str_local() {
 fn infrastructure_from_str_cunqa() {
     assert!(matches!(
         Infrastructure::from_str("cunqa"),
-        Infrastructure::Cunqa
+        Ok(Infrastructure::Cunqa)
     ));
 }
 
 #[test]
-#[should_panic(expected = "Unknown infrastructure")]
-fn infrastructure_from_str_unknown_panics() {
-    Infrastructure::from_str("unknown_backend");
+fn infrastructure_from_str_unknown_is_typed_error() {
+    // An unknown infrastructure is now a typed `Result` error (surfaced across
+    // the FFI as a `ValueError`, contract C-1), never a panic.
+    match Infrastructure::from_str("unknown_backend") {
+        Err(BackendError::UnknownInfrastructure { name }) => {
+            assert_eq!(name, "unknown_backend");
+        }
+        _ => panic!("expected an UnknownInfrastructure error, not a panic"),
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -130,7 +136,9 @@ fn native_bell_args(shots: u32, n_qpus: u32, id: &str) -> AlgorithmArgs {
 /// Run the distribute-by-shots algorithm and return the merged counts.
 fn distributed_counts(shots: u32, n_qpus: u32, id: &str) -> HashMap<String, u64> {
     pyo3::prepare_freethreaded_python();
-    let result = DistributeByShotsRun.run(native_bell_args(shots, n_qpus, id));
+    let result = DistributeByShotsRun
+        .run(native_bell_args(shots, n_qpus, id))
+        .expect("distribute-by-shots must succeed on the native backend");
     Python::with_gil(|py| {
         result
             .extract::<HashMap<String, u64>>(py)

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -20,7 +20,7 @@ Rules of the road:
 
 | Contract | Seam | Enforcing test | Status | Known break (audit) |
 |---|---|---|---|---|
-| C-1 | Rust → Python execution | `tests/python/test_seam_contract.py` | ⏳ to add | `disconnect` reads `slurm_job_id`, not `family` (C1) |
+| C-1 | Rust → Python execution | `tests/python/test_seam_contract.py` | ✅ present | `disconnect` reads `slurm_job_id`, not `family` (C1) |
 | C-2 | Gate vocabulary symmetry | round-trip + QIR-vs-sim equivalence | ⏳ to add | `cp` missing from importer; QIR decomp not equivalent (C2, C3) |
 | C-3 | Measurement counts format | shot-conservation + last-write-wins | ✅ present | shots dropped on uneven distribution (C6) |
 | C-4 | Terminal measurement placement | rejection tests (sim + QIR) | ⏳ to add | measurement semantics (C5) |
@@ -84,8 +84,31 @@ Returns exactly `len(counts)` finite floats, in order.
   "must-be-consumed" rule above: neither side silently drops or invents args).
 - A missing **required** kwarg raises `TypeError`.
 
-**Enforcing test:** `tests/python/test_seam_contract.py` (to be added — must
-run in CI against a mock of `cunqa.qutils`, so no SLURM is needed).
+A failure **must never** cross the seam as a `pyo3_runtime.PanicException` or a
+process abort (it used to: the Rust side `unwrap()`/`panic!`-ed on these calls).
+The Rust orchestration layer now returns a typed `Result` on every path:
+
+- A Python exception raised *by the seam function itself* (the three failure
+  modes above, or any runtime error inside `run_qcs`) is **re-raised verbatim**,
+  preserving its original type — so the `ValueError`/`TypeError` guarantees
+  above hold unchanged.
+- A failure originating *in the Rust layer* (backend construction, a native
+  circuit that will not parse/simulate, the QMIO network path, a data
+  conversion) raises a class from the `polypus` exception hierarchy:
+  `PolypusError` (base) → `BackendError` → {`CunqaError`, `QmioError`,
+  `NativeCircuitError`}, and `PolypusError` → `EvaluationError`. Catching
+  `polypus.PolypusError` catches them all.
+
+`disconnect_from_infrastructure` runs from `CunqaBackend`'s `Drop`, which **must
+never panic**: a release failure is logged (`log::error!`) and recorded in the
+process-wide `polypus.backend_cleanup_failures()` counter rather than raised
+(see ENGINEERING.md §9). This is independent of the known break below, which is
+about *which kwarg* the Python side reads.
+
+**Enforcing test:** `tests/python/test_seam_contract.py` — runs in CI without
+SLURM by monkeypatching the `polypus_python` seam (`run_qcs`) to force a
+failure, asserting it surfaces as a typed Python exception (never a
+`PanicException`) with the C-1 type preserved.
 
 ---
 

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -156,6 +156,25 @@ unrecoverable invariants, always with a clear message). Each crate defines its
 own error type (`error.rs`); reuse and extend it instead of introducing ad-hoc
 errors or bare strings. Never silence or discard errors (`let _ = ...`).
 Errors crossing the FFI boundary become `PyErr` via `Result` — never a panic.
+In the `polypus` crate this means every path reachable from a `#[pyfunction]` /
+`#[pymethods]` returns a typed error (`BackendError`, `EvaluationError`, or the
+crate's `QmioError`) mapped to the `polypus::exceptions` Python hierarchy — even
+where the failure is "unlikely". A Python exception raised by the
+`polypus_python` seam is carried verbatim and re-raised with its original type,
+so contract C-1's `ValueError`/`TypeError` failure modes are preserved.
+
+**`Drop` must be panic-free.** No `Drop` impl may panic under any circumstance:
+a panic while another panic is already unwinding aborts the whole process,
+defeating the RAII guarantee (for `CunqaBackend` this would leak the SLURM
+allocation). A `Drop` that does fallible cleanup (releasing QPUs, closing a
+socket) **logs the failure with `log::error!` and continues** — it never
+propagates the error. Because a per-instance flag is worthless once the instance
+is gone, the failure is *also* recorded in process-wide state that a higher
+layer can inspect (the `backend_cleanup_failures()` counter, exposed to Python).
+Acquiring the GIL inside a `Drop` is allowed only when it is explicitly safe
+against re-entrancy (PyO3 0.24's `Python::with_gil` is re-entrant) and cannot
+propagate a panic through the in-progress unwind; keep the fallible operation
+behind a `Result`-returning helper so the `Drop` body only logs and counts.
 
 **Ownership and types.** Prefer borrowing over cloning; avoid unnecessary
 `.clone()`. In signatures accept `&str` over `&String` and `&[T]` over
@@ -208,7 +227,8 @@ it into an unrelated diff. `cargo deny check` gates licenses and advisories.
       deserializers? (§8)
 - [ ] `fmt` + `clippy -D warnings` + tests green; performance claims backed
       by a benchmark? (§9, `docs/CONTRIBUTING.md`)
-- [ ] Explicit errors (no `unwrap`/`panic` in production), edge cases
+- [ ] Explicit errors (no `unwrap`/`panic` in production, including
+      `#[pyfunction]`-reachable paths), no `Drop` that can panic, edge cases
       covered, public items documented? (§9)
 - [ ] Does the change touch a seam listed in `docs/CONTRACTS.md`? Then the same PR
       updates the contract and its enforcing test.

--- a/tests/python/test_error_hierarchy.py
+++ b/tests/python/test_error_hierarchy.py
@@ -1,0 +1,79 @@
+"""
+Custom Python exception hierarchy tests.
+
+Failures that previously *panicked* on paths reachable from ``#[pyfunction]``
+now cross the FFI boundary as typed, catchable exceptions rooted at
+``polypus.PolypusError`` — never a ``pyo3_runtime.PanicException`` or an
+interpreter abort. These tests pin the hierarchy and one representative
+Rust-originated failure (mirrors the panic-to-typed-error pattern documented in
+``test_vqc.py`` and ``test_backend_selection.py``).
+"""
+
+import pytest
+
+
+class TestExceptionHierarchy:
+    def test_classes_are_exposed(self):
+        import polypus
+
+        for name in (
+            "PolypusError",
+            "BackendError",
+            "CunqaError",
+            "QmioError",
+            "NativeCircuitError",
+            "EvaluationError",
+        ):
+            assert hasattr(polypus, name), f"polypus.{name} is not exported"
+            assert issubclass(getattr(polypus, name), Exception)
+
+    def test_domain_subclassing(self):
+        import polypus
+
+        assert issubclass(polypus.PolypusError, Exception)
+        assert issubclass(polypus.BackendError, polypus.PolypusError)
+        assert issubclass(polypus.CunqaError, polypus.BackendError)
+        assert issubclass(polypus.QmioError, polypus.BackendError)
+        assert issubclass(polypus.NativeCircuitError, polypus.BackendError)
+        assert issubclass(polypus.EvaluationError, polypus.PolypusError)
+
+
+class TestRustOriginatedFailuresAreTyped:
+    def test_invalid_native_qasm_raises_native_circuit_error(self):
+        """An unparseable OpenQASM 2.0 string handed to the native backend used
+        to panic in ``simulate_one``; it now raises ``NativeCircuitError``."""
+        import polypus
+
+        with pytest.raises(polypus.NativeCircuitError):
+            polypus.run_quantum_circuit(
+                "this is definitely not valid openqasm",
+                shots=64,
+                infrastructure="local",
+                backend="polypus",
+            )
+
+    def test_native_circuit_error_is_catchable_as_base_classes(self):
+        """The typed error is catchable at every level of the hierarchy, so
+        callers can be as specific or as broad as they like."""
+        import polypus
+
+        bad_qasm = "still not valid openqasm"
+        kwargs = dict(shots=32, infrastructure="local", backend="polypus")
+
+        for exc_type in (
+            polypus.NativeCircuitError,
+            polypus.BackendError,
+            polypus.PolypusError,
+            Exception,
+        ):
+            with pytest.raises(exc_type):
+                polypus.run_quantum_circuit(bad_qasm, **kwargs)
+
+    def test_unknown_infrastructure_is_value_error_not_panic(self):
+        """Contract C-1: an unknown infrastructure is a ``ValueError`` (never a
+        ``PanicException``)."""
+        import polypus
+
+        qc = polypus.Circuit(1).h(0).measure_all()
+        with pytest.raises(ValueError):
+            polypus.run_quantum_circuit(qc, shots=10, infrastructure="does-not-exist")

--- a/tests/python/test_seam_contract.py
+++ b/tests/python/test_seam_contract.py
@@ -1,0 +1,91 @@
+"""
+Enforcing test for contract C-1 (Rust → Python execution seam).
+
+C-1 freezes the three ``polypus_python`` functions the Rust orchestration layer
+calls and their documented failure modes. This test runs **without SLURM**: the
+seam is exercised by monkeypatching ``polypus_python.run_qcs`` so a failure can
+be forced deterministically.
+
+It locks in the panic-safety guarantee introduced with the typed error
+hierarchy: a failure crossing the seam surfaces as a proper Python exception,
+never a ``pyo3_runtime.PanicException`` / interpreter crash, and the C-1 failure
+types (``ValueError`` for an unknown infrastructure, ``TypeError`` for a bad
+kwarg) are preserved because the Rust side re-raises the original exception
+verbatim.
+
+Note: this deliberately exercises the ``local`` path (real
+``connect_to_infrastructure("local")`` + mocked ``run_qcs``). It does **not**
+touch the CUNQA ``disconnect`` path, which still carries the separately-tracked
+"known break" (reads ``slurm_job_id`` instead of ``family``, CONTRACTS.md C-1);
+that defect is out of scope here and is not exercised or masked.
+"""
+
+import pytest
+
+
+def _native_qc():
+    import polypus
+
+    return polypus.Circuit(1).h(0).measure_all()
+
+
+def test_unknown_infrastructure_raises_value_error():
+    # Rejected before any seam call; C-1 says ValueError, never a panic.
+    import polypus
+
+    with pytest.raises(ValueError):
+        polypus.run_quantum_circuit(_native_qc(), shots=10, infrastructure="nope")
+
+
+def test_seam_type_error_is_preserved(monkeypatch):
+    # C-1: an unexpected/missing kwarg raises TypeError on the Python side. It
+    # must reach the caller as TypeError, not a PanicException.
+    import polypus
+    import polypus_python
+
+    def bad_kwarg(*_args, **_kwargs):
+        raise TypeError("run_qcs() got an unexpected keyword argument 'bogus'")
+
+    monkeypatch.setattr(polypus_python, "run_qcs", bad_kwarg)
+    with pytest.raises(TypeError):
+        polypus.run_quantum_circuit(
+            _native_qc(), shots=10, infrastructure="local", backend="aer"
+        )
+
+
+def test_seam_runtime_failure_is_not_panic(monkeypatch):
+    # A generic execution failure at the seam must surface as the original
+    # Python exception (propagated verbatim), never a PanicException / abort.
+    import polypus
+    import polypus_python
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated backend execution failure")
+
+    monkeypatch.setattr(polypus_python, "run_qcs", boom)
+    with pytest.raises(RuntimeError, match="simulated backend execution failure"):
+        polypus.run_quantum_circuit(
+            _native_qc(), shots=10, infrastructure="local", backend="aer"
+        )
+
+
+def test_seam_failure_is_never_a_panic_exception(monkeypatch):
+    """Whatever the seam raises, the caller never sees pyo3's PanicException."""
+    import polypus
+    import polypus_python
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(polypus_python, "run_qcs", boom)
+    try:
+        polypus.run_quantum_circuit(
+            _native_qc(), shots=10, infrastructure="local", backend="aer"
+        )
+    except BaseException as exc:  # noqa: BLE001 - we assert on the type below
+        assert type(exc).__name__ != "PanicException", (
+            "a seam failure must not surface as a Rust panic"
+        )
+        assert isinstance(exc, RuntimeError)
+    else:
+        pytest.fail("expected the mocked seam failure to raise")


### PR DESCRIPTION
The orchestration/FFI crate used unwrap()/expect()/panic! on paths reachable from #[pyfunction]/#[pymethods], violating ENGINEERING.md §9. Worst case, CunqaBackend::drop_qpus could panic inside Drop and abort the process mid-unwind, defeating the RAII release of the SLURM allocation.

- QuantumBackend::run_circuits now returns Result<_, BackendError>; add typed BackendError/EvaluationError enums (hand-written, QmioError style) mapped to a new pyo3 exception hierarchy (PolypusError > BackendError > {CunqaError, QmioError, NativeCircuitError}; PolypusError > EvaluationError).
- Seam failures are carried verbatim and re-raised, so contract C-1's ValueError/TypeError failure modes are preserved.
- Optimizer oracles (which cannot return Result) record the first failure in a shared OracleErrorSlot, surfaced as a PyErr after optimize() returns.
- CunqaBackend release runs behind an injectable closure; close()/Drop log and increment a process-wide counter (polypus.backend_cleanup_failures()) instead of panicking. QMIO Drop logs socket close errors instead of discarding them.
- Add a Rust failure-injection test (Drop mid-unwind, no Python), Python error hierarchy tests, and the C-1 enforcing test (tests/python/test_seam_contract.py).
- Document the Drop panic-safety rule (ENGINEERING.md §9) and the seam exception behavior (CONTRACTS.md C-1).