### PR TITLE
ci: harden and extend CI per team review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Keep the GitHub Actions used by CI up to date (checkout, setup-python,
+# rust-toolchain, rust-cache, ...). Rust/Python dependencies are deliberately
+# not tracked here: there is no committed lockfile, so CI already resolves
+# fresh semver-compatible versions on every run.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# CI only reads the repo; keep the default token read-only.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -17,6 +21,7 @@ jobs:
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -24,9 +29,33 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  # Python lint + formatting (packages, tests, benchmarks, examples).
+  # Config lives in [tool.ruff] in the root pyproject.toml.
+  ruff:
+    name: ruff (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+      - run: ruff format --check
+
+  # Security advisories (RustSec), license allowlist and registry sources,
+  # per deny.toml. Runs `cargo metadata` only — no build, no Python needed.
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       # PyO3's build script needs to locate a Python interpreter even for a
@@ -47,9 +76,30 @@ jobs:
       - name: Clippy (qmio backend)
         run: cargo clippy -p polypus --features qmio --all-targets -- -D warnings
 
+  # Guard the declared MSRV (rust-version in Cargo.toml). Without a committed
+  # Cargo.lock this resolves fresh dependencies each run, so a new release of
+  # a dependency can raise the effective MSRV and turn this job red without
+  # any change in the repo — if that happens, bump rust-version deliberately.
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (workspace, default features)
+        run: cargo check --workspace --all-targets
+      - name: Check (qmio backend)
+        run: cargo check -p polypus --features qmio --all-targets
+
   test:
     name: test (Rust)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       # Needed only at build/link time (PyO3 links libpython). The Rust tests
@@ -81,12 +131,14 @@ jobs:
       - name: Test polypus (qmio backend)
         run: cargo test -p polypus --features qmio
 
-  # Sanity-check that the rustdoc still builds cleanly (broken intra-doc links
-  # fail via -D warnings). Catches doc-comment regressions on PRs; the actual
-  # publish to Pages lives in docs.yml and only runs on push to main.
+  # Sanity-check that the rustdoc still builds cleanly across the whole
+  # workspace (broken intra-doc links fail via -D warnings). Catches
+  # doc-comment regressions on PRs; the actual publish to Pages lives in
+  # docs.yml, only runs on push to main, and still documents `polypus` only.
   docs:
     name: docs build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       # PyO3's build script needs a Python interpreter to compile `polypus`.
@@ -96,18 +148,32 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build docs (no deploy)
-        run: cargo doc --no-deps -p polypus
+        run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
 
+  # Smoke-test that the PyO3 extension wheel builds on every supported
+  # platform, at the floor and latest supported Python (no abi3, so wheels
+  # are per-version). The full test suite still runs on Linux only.
   build-extension:
-    name: build Python extension
-    runs-on: ubuntu-latest
+    name: build extension (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.13"]
+        exclude:
+          # macos-latest runners are arm64; actions/setup-python has no
+          # reliable 3.9 build there. macOS is covered by 3.13.
+          - os: macos-latest
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install maturin
@@ -122,15 +188,21 @@ jobs:
   # instructions: install dev deps, then build & install the pure-Python
   # `polypus_python` package, then build & install the Rust extension, then run
   # pytest. Order matters — see the note on the polypus_python step below.
+  # Runs at the floor and latest supported Python versions.
   # ---------------------------------------------------------------------------
   python-tests:
-    name: test (Python)
+    name: test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install dev dependencies
@@ -150,5 +222,10 @@ jobs:
         run: |
           maturin build --release --features extension-module -m crates/polypus/Cargo.toml --out dist
           pip install --no-index --find-links dist polypus
+      # Examples and benchmarks are not executed (no __main__ guards; some
+      # need optional deps like cunqa), but they must at least stay valid
+      # Python — this catches syntax rot without running them.
+      - name: Compile-check examples and benchmarks
+        run: python -m compileall -q examples benchmarks
       - name: Run Python tests
         run: pytest tests/python

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,15 @@ resolver = "2"
 [workspace.package]
 version = "0.4.0"
 edition = "2021"
+# MSRV, guarded by the `msrv` CI job. Currently set by the dependency tree
+# (the qmio feature pulls `saa`, which uses edition 2024 → Cargo 1.85); the
+# workspace's own code needs far less. Bump deliberately when a dep requires it.
+rust-version = "1.85"
 authors = ["Diego Beltran Fernandez Prada <diego.fernandez@bahiasoftware.es>", "Victor Soñora Pombo", "Sergio Figueiras Gomez", "Miguel Boubeta Martinez", "Galicia Supercomputing Center (CESGA)"]
-license = "European Union Public Licence (EUPL), version 1.2 or – as soon they will be approved by the European Commission – subsequent versions of the EUPL."
+# SPDX identifier (required by cargo-deny and crates.io). The full licence
+# text, including the "or subsequent versions approved by the European
+# Commission" clause, lives in the LICENSE file at the repo root.
+license = "EUPL-1.2"
 
 [workspace.dependencies]
 polypus-circuit    = { path = "crates/polypus-circuit", version = "0.4.0" }

--- a/benchmarks/bench_batching.py
+++ b/benchmarks/bench_batching.py
@@ -39,8 +39,9 @@ def train_once(run_id):
     t0 = time.perf_counter()
     polypus.train(
         ansatz(),
-        polypus.DE(generations=GENERATIONS, population_size=POPULATION,
-                   tolerance=1e-12),
+        polypus.DE(
+            generations=GENERATIONS, population_size=POPULATION, tolerance=1e-12
+        ),
         shots=SHOTS,
         n_qpus=1,
         dimensions=2,
@@ -81,20 +82,26 @@ class _MergedResult:
 
 def main():
     real_sim = local_mod.AerSimulator
-    print(f"DE {GENERATIONS}x{POPULATION}, {N_QUBITS} qubits, {SHOTS} shots, "
-          f"best of {REPEATS}:")
+    print(
+        f"DE {GENERATIONS}x{POPULATION}, {N_QUBITS} qubits, {SHOTS} shots, "
+        f"best of {REPEATS}:"
+    )
 
     results = {}
-    for label, sim_cls in (("batched (current)", real_sim),
-                           ("per-circuit (legacy)", UnbatchedSpy)):
+    for label, sim_cls in (
+        ("batched (current)", real_sim),
+        ("per-circuit (legacy)", UnbatchedSpy),
+    ):
         local_mod.AerSimulator = sim_cls
         try:
             times = [train_once(f"bench_{label[:7]}_{i}") for i in range(REPEATS)]
         finally:
             local_mod.AerSimulator = real_sim
         results[label] = min(times)
-        print(f"  {label:22s}: {min(times):6.2f}s best, "
-              f"{statistics.mean(times):6.2f}s mean")
+        print(
+            f"  {label:22s}: {min(times):6.2f}s best, "
+            f"{statistics.mean(times):6.2f}s mean"
+        )
 
     speedup = results["per-circuit (legacy)"] / results["batched (current)"]
     print(f"  speedup               : {speedup:6.1f}x")

--- a/benchmarks/bench_native_vs_qiskit.py
+++ b/benchmarks/bench_native_vs_qiskit.py
@@ -62,9 +62,11 @@ def main():
     qk, nv = qiskit_qaoa(), native_qaoa()
 
     # 1. Binding microbenchmark
-    us_qiskit = bench(lambda i: qk.assign_parameters([0.001 * i, 0.002 * i], inplace=False))
+    us_qiskit = bench(
+        lambda i: qk.assign_parameters([0.001 * i, 0.002 * i], inplace=False)
+    )
     us_native = bench(lambda i: nv.to_qasm2([0.001 * i, 0.002 * i]))
-    print(f"binding (QAOA 4q, 2 params, mean of best round, n=2000):")
+    print("binding (QAOA 4q, 2 params, mean of best round, n=2000):")
     print(f"  qiskit assign_parameters : {us_qiskit:8.1f} us/candidate")
     print(f"  native  bind+QASM        : {us_native:8.1f} us/candidate")
     print(f"  speedup                  : {us_qiskit / us_native:8.1f}x")
@@ -88,8 +90,10 @@ def main():
 
     for label, qc_factory in (("qiskit", qiskit_qaoa), ("native", native_qaoa)):
         times = [train_once(qc_factory(), f"bench_{label}_{i}") for i in range(3)]
-        print(f"train DE 10x20 ({label:6s})    : {min(times):.2f}s best, "
-              f"{statistics.mean(times):.2f}s mean of 3")
+        print(
+            f"train DE 10x20 ({label:6s})    : {min(times):.2f}s best, "
+            f"{statistics.mean(times):.2f}s mean of 3"
+        )
 
 
 if __name__ == "__main__":

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -36,14 +36,17 @@ from pathlib import Path
 
 try:
     import matplotlib
+
     matplotlib.use("Agg")  # non-interactive backend, safe in any environment
     import matplotlib.pyplot as plt
+
     HAS_MATPLOTLIB = True
 except ImportError:
     HAS_MATPLOTLIB = False
 
 try:
     from scipy.optimize import differential_evolution as scipy_de
+
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -75,11 +78,15 @@ def make_ghz(n_qubits: int) -> QuantumCircuit:
 
 
 # ── Single timed + traced run ─────────────────────────────────────────────────
-def _run_once(qc: QuantumCircuit, shots: int, n_qpus: int, sim_method: str) -> tuple[float, float]:
+def _run_once(
+    qc: QuantumCircuit, shots: int, n_qpus: int, sim_method: str
+) -> tuple[float, float]:
     """Return (elapsed_seconds, peak_ram_mb)."""
     tracemalloc.start()
     t0 = time.perf_counter()
-    polypus.run_quantum_circuit(qc, shots=shots, infrastructure="local", n_qpus=n_qpus, sim_method=sim_method)
+    polypus.run_quantum_circuit(
+        qc, shots=shots, infrastructure="local", n_qpus=n_qpus, sim_method=sim_method
+    )
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
@@ -102,7 +109,11 @@ def run_sweep(
     for shots in shots_list:
         for n_qpus in qpus_list:
             done += 1
-            print(f"  [{done}/{total}] n_qpus={n_qpus:>2}  shots={shots:<6}", end="", flush=True)
+            print(
+                f"  [{done}/{total}] n_qpus={n_qpus:>2}  shots={shots:<6}",
+                end="",
+                flush=True,
+            )
 
             times, rams = [], []
             for _ in range(repeats):
@@ -114,17 +125,23 @@ def run_sweep(
             mean_r = statistics.mean(rams)
             throughput = shots / mean_t
 
-            results.append({
-                "n_qubits":    n_qubits,
-                "n_qpus":      n_qpus,
-                "shots":       shots,
-                "time_mean_s": round(mean_t, 4),
-                "time_std_s":  round(statistics.stdev(times) if repeats > 1 else 0.0, 4),
-                "shots_per_s": round(throughput, 1),
-                "ram_peak_mb": round(mean_r, 2),
-            })
+            results.append(
+                {
+                    "n_qubits": n_qubits,
+                    "n_qpus": n_qpus,
+                    "shots": shots,
+                    "time_mean_s": round(mean_t, 4),
+                    "time_std_s": round(
+                        statistics.stdev(times) if repeats > 1 else 0.0, 4
+                    ),
+                    "shots_per_s": round(throughput, 1),
+                    "ram_peak_mb": round(mean_r, 2),
+                }
+            )
 
-            print(f"  →  {mean_t:.3f}s  |  {throughput:,.0f} shots/s  |  {mean_r:.1f} MB")
+            print(
+                f"  →  {mean_t:.3f}s  |  {throughput:,.0f} shots/s  |  {mean_r:.1f} MB"
+            )
 
     return results
 
@@ -170,8 +187,16 @@ def print_table(results: list[dict], n_qubits: int) -> None:
 
 # ── CSV export ────────────────────────────────────────────────────────────────
 def save_csv(results: list[dict], path: Path) -> None:
-    fieldnames = ["n_qubits", "n_qpus", "shots", "time_mean_s", "time_std_s",
-                  "shots_per_s", "ram_peak_mb", "speedup"]
+    fieldnames = [
+        "n_qubits",
+        "n_qpus",
+        "shots",
+        "time_mean_s",
+        "time_std_s",
+        "shots_per_s",
+        "ram_peak_mb",
+        "speedup",
+    ]
     with path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -191,25 +216,24 @@ def save_plots(results: list[dict], n_qubits: int, out_dir: Path) -> None:
         s: sorted([r for r in results if r["shots"] == s], key=lambda r: r["n_qpus"])
         for s in shots_values
     }
-    all_qpus = sorted({r["n_qpus"] for r in results})
-
     metrics = [
-        ("time_mean_s", "Execution time (s)",   "lower is better"),
+        ("time_mean_s", "Execution time (s)", "lower is better"),
         ("shots_per_s", "Throughput (shots/s)", "higher is better"),
-        ("ram_peak_mb", "Peak RAM (MB)",         "lower is better"),
+        ("ram_peak_mb", "Peak RAM (MB)", "lower is better"),
     ]
 
     fig, axes = plt.subplots(1, 3, figsize=(14, 4))
     fig.suptitle(
         f"Polypus benchmark — GHZ {n_qubits}q · infrastructure=local",
-        fontsize=13, fontweight="bold",
+        fontsize=13,
+        fontweight="bold",
     )
 
     for ax, (field, ylabel, note) in zip(axes, metrics):
         for s in shots_values:
             rows = qpus_per_shots[s]
             xs = [r["n_qpus"] for r in rows if r[field] is not None]
-            ys = [r[field]    for r in rows if r[field] is not None]
+            ys = [r[field] for r in rows if r[field] is not None]
             ax.plot(xs, ys, marker="o", label=f"{s:,} shots")
 
         ax.set_xlabel("n_qpus")
@@ -228,6 +252,7 @@ def save_plots(results: list[dict], n_qubits: int, out_dir: Path) -> None:
 # ── Parameterized VQC (optimizer comparison) ─────────────────────────────────
 def make_parameterized_vqc(n_qubits: int) -> tuple[QuantumCircuit, int]:
     from qiskit.circuit import ParameterVector
+
     n_params = n_qubits * 2
     params = ParameterVector("θ", n_params)
     qc = QuantumCircuit(n_qubits)
@@ -263,8 +288,8 @@ def run_optimizer_comparison(
     """Time Polypus DE/PSO/QNG vs SciPy DE on a small hardware-efficient VQC."""
     qc, n_params = make_parameterized_vqc(n_qubits)
     bounds_tuple = (-3.14159, 3.14159)
-    bounds_list  = [bounds_tuple] * n_params
-    comp: dict   = {"scipy_de": None, "de": {}, "pso": {}, "qng": {}}
+    bounds_list = [bounds_tuple] * n_params
+    comp: dict = {"scipy_de": None, "de": {}, "pso": {}, "qng": {}}
 
     def _variance_fn(theta: list, a: int) -> float:
         """Constant diagonal QFI element — sufficient for benchmarking QNG plumbing."""
@@ -272,20 +297,32 @@ def run_optimizer_comparison(
 
     # ── SciPy DE (baseline: single-QPU, sequential) ───────────────────────────
     if HAS_SCIPY:
+
         def scipy_cost(params):
             bound_qc = qc.assign_parameters(dict(zip(qc.parameters, params)))
             result = polypus.run_quantum_circuit(
-                bound_qc, shots=shots, infrastructure="local", n_qpus=1,
+                bound_qc,
+                shots=shots,
+                infrastructure="local",
+                n_qpus=1,
                 sim_method=sim_method,
             )
             return _hamming_cost_counts(result)
 
         popsize_mult = max(1, population_size // n_params)
-        print(f"  [scipy DE ] generations={generations}  pop_mult={popsize_mult}  shots={shots}",
-              flush=True)
+        print(
+            f"  [scipy DE ] generations={generations}  pop_mult={popsize_mult}  shots={shots}",
+            flush=True,
+        )
         t0 = time.perf_counter()
-        scipy_de(scipy_cost, bounds_list, maxiter=generations, popsize=popsize_mult,
-                 seed=42, workers=1)
+        scipy_de(
+            scipy_cost,
+            bounds_list,
+            maxiter=generations,
+            popsize=popsize_mult,
+            seed=42,
+            workers=1,
+        )
         comp["scipy_de"] = round(time.perf_counter() - t0, 4)
         print(f"             → {comp['scipy_de']:.3f}s")
     else:
@@ -293,17 +330,32 @@ def run_optimizer_comparison(
 
     # ── Polypus optimizers vs n_qpus ─────────────────────────────────────────
     optimizers = [
-        ("de",  lambda: polypus.DE(generations=generations,
-                                    population_size=population_size,
-                                    tolerance=1e-10)),
-        ("pso", lambda: polypus.PSO(generations=generations,
-                                    population_size=population_size,
-                                    bounds=bounds_tuple,
-                                    tolerance=1e-10)),
-        ("qng", lambda: polypus.QNG(_variance_fn,
-                                    max_iters=generations,
-                                    bounds=bounds_tuple,
-                                    learning_rate=0.1)),
+        (
+            "de",
+            lambda: polypus.DE(
+                generations=generations,
+                population_size=population_size,
+                tolerance=1e-10,
+            ),
+        ),
+        (
+            "pso",
+            lambda: polypus.PSO(
+                generations=generations,
+                population_size=population_size,
+                bounds=bounds_tuple,
+                tolerance=1e-10,
+            ),
+        ),
+        (
+            "qng",
+            lambda: polypus.QNG(
+                _variance_fn,
+                max_iters=generations,
+                bounds=bounds_tuple,
+                learning_rate=0.1,
+            ),
+        ),
     ]
 
     total = len(qpus_list)
@@ -342,11 +394,11 @@ def save_comparison_plot(
         print("  [warn] matplotlib not installed — skipping plots.")
         return
 
-    qpus       = sorted({q for m in ("de", "pso", "qng") for q in comp[m]})
+    qpus = sorted({q for m in ("de", "pso", "qng") for q in comp[m]})
     scipy_time = comp["scipy_de"]
 
     methods = [
-        ("de",  "Polypus DE",  "#1f77b4"),
+        ("de", "Polypus DE", "#1f77b4"),
         ("pso", "Polypus PSO", "#2ca02c"),
         ("qng", "Polypus QNG", "#9467bd"),
     ]
@@ -355,7 +407,8 @@ def save_comparison_plot(
     fig.suptitle(
         f"Polypus optimizers vs SciPy DE  —  VQC {n_qubits}q"
         f" · {generations} iterations · pop={population_size}",
-        fontsize=11, fontweight="bold",
+        fontsize=11,
+        fontweight="bold",
     )
 
     # ── Panel 1: absolute time ────────────────────────────────────────────
@@ -364,8 +417,13 @@ def save_comparison_plot(
         times = [comp[key].get(q) for q in qpus]
         ax.plot(qpus, times, marker="o", label=label, color=color)
     if scipy_time is not None:
-        ax.axhline(scipy_time, linestyle="--", color="#ff7f0e", linewidth=1.5,
-                   label=f"SciPy DE  ({scipy_time:.2f}s)")
+        ax.axhline(
+            scipy_time,
+            linestyle="--",
+            color="#ff7f0e",
+            linewidth=1.5,
+            label=f"SciPy DE  ({scipy_time:.2f}s)",
+        )
     ax.set_xlabel("n_qpus")
     ax.set_ylabel("Wall-clock time (s)")
     ax.set_title("Optimization time")
@@ -377,15 +435,24 @@ def save_comparison_plot(
     if scipy_time is not None:
         for key, label, color in methods:
             speedups = [scipy_time / comp[key][q] for q in qpus if comp[key].get(q)]
-            ax.plot(qpus[:len(speedups)], speedups, marker="o", label=label, color=color)
-        ax.axhline(1.0, linestyle="--", color="#ff7f0e", linewidth=1.0,
-                   label="SciPy DE baseline")
+            ax.plot(
+                qpus[: len(speedups)], speedups, marker="o", label=label, color=color
+            )
+        ax.axhline(
+            1.0,
+            linestyle="--",
+            color="#ff7f0e",
+            linewidth=1.0,
+            label="SciPy DE baseline",
+        )
         ax.set_ylabel("Speedup vs SciPy DE")
     else:
         for key, label, color in methods:
             times = [comp[key].get(q) for q in qpus]
-            base  = times[0] or 1
-            ax.plot(qpus, [base / t for t in times], marker="o", label=label, color=color)
+            base = times[0] or 1
+            ax.plot(
+                qpus, [base / t for t in times], marker="o", label=label, color=color
+            )
         ax.axhline(1.0, linestyle="--", color="grey", linewidth=0.8)
         ax.set_ylabel("Speedup vs n_qpus=1")
     ax.set_xlabel("n_qpus")
@@ -397,7 +464,7 @@ def save_comparison_plot(
     ax = axes[2]
     for key, label, color in methods:
         times = [comp[key].get(q) for q in qpus]
-        base  = times[0] or 1
+        base = times[0] or 1
         ax.plot(qpus, [base / t for t in times], marker="o", label=label, color=color)
     ax.plot(qpus, qpus, linestyle="--", color="grey", linewidth=0.8, label="ideal")
     ax.set_xlabel("n_qpus")
@@ -424,11 +491,16 @@ def save_qubit_heatmap(
     import numpy as np
 
     qubits_list = sorted(multi_comp.keys())
-    qpus = sorted({q for n_q in qubits_list
-                   for m in ("de", "pso", "qng")
-                   for q in multi_comp[n_q][m]})
+    qpus = sorted(
+        {
+            q
+            for n_q in qubits_list
+            for m in ("de", "pso", "qng")
+            for q in multi_comp[n_q][m]
+        }
+    )
     methods = [
-        ("de",  "Polypus DE"),
+        ("de", "Polypus DE"),
         ("pso", "Polypus PSO"),
         ("qng", "Polypus QNG"),
     ]
@@ -447,12 +519,14 @@ def save_qubit_heatmap(
 
     n_rows = len(qubits_list)
     fig, axes = plt.subplots(
-        1, 3,
+        1,
+        3,
         figsize=(5 * len(methods), max(3, 1.2 + 1.1 * n_rows)),
     )
     fig.suptitle(
         f"Speedup vs SciPy DE  ·  {generations} iterations  ·  pop={population_size}",
-        fontsize=11, fontweight="bold",
+        fontsize=11,
+        fontweight="bold",
     )
 
     for ax, (key, label) in zip(axes, methods):
@@ -465,8 +539,12 @@ def save_qubit_heatmap(
                     data[i, j] = scipy_t / t
 
         im = ax.imshow(
-            data, aspect="auto", cmap="YlOrRd",
-            origin="lower", vmin=0, vmax=vmax,
+            data,
+            aspect="auto",
+            cmap="YlOrRd",
+            origin="lower",
+            vmin=0,
+            vmax=vmax,
         )
         ax.set_xticks(range(len(qpus)))
         ax.set_xticklabels([str(q) for q in qpus])
@@ -481,9 +559,16 @@ def save_qubit_heatmap(
                 v = data[i, j]
                 if not np.isnan(v):
                     txt_color = "black" if (v / vmax) > 0.55 else "white"
-                    ax.text(j, i, f"{v:.1f}×",
-                            ha="center", va="center",
-                            fontsize=9, fontweight="bold", color=txt_color)
+                    ax.text(
+                        j,
+                        i,
+                        f"{v:.1f}×",
+                        ha="center",
+                        va="center",
+                        fontsize=9,
+                        fontweight="bold",
+                        color=txt_color,
+                    )
 
         plt.colorbar(im, ax=ax, label="Speedup vs SciPy DE", shrink=0.8)
 
@@ -501,66 +586,96 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
-        "--qpus", nargs="+", type=int, default=None,
+        "--qpus",
+        nargs="+",
+        type=int,
+        default=None,
         metavar="N",
         help="List of n_qpus values to test (default: 1 2 4)",
     )
     p.add_argument(
-        "--shots", nargs="+", type=int, default=None,
+        "--shots",
+        nargs="+",
+        type=int,
+        default=None,
         metavar="N",
         help="List of shot counts to test (default: 500 2000)",
     )
     p.add_argument(
-        "--qubits", type=int, default=25,
+        "--qubits",
+        type=int,
+        default=25,
         metavar="N",
         help="Number of qubits in the GHZ circuit (default: 25)",
     )
     p.add_argument(
-        "--repeats", type=int, default=3,
+        "--repeats",
+        type=int,
+        default=3,
         metavar="N",
         help="Repetitions per data point for averaging (default: 3)",
     )
     p.add_argument(
-        "--quick", action="store_true",
+        "--quick",
+        action="store_true",
         help="Fast sweep: n_qpus=[1,2], shots=[500], repeats=1",
     )
     p.add_argument(
-        "--outdir", type=Path, default=None,
+        "--outdir",
+        type=Path,
+        default=None,
         metavar="DIR",
         help="Output folder for CSV and plots (default: benchmarks/bench_TIMESTAMP/)",
     )
     p.add_argument(
-        "--no-plots", action="store_true",
+        "--no-plots",
+        action="store_true",
         help="Skip generating plots (CSV only)",
     )
     p.add_argument(
-        "--no-compare", action="store_true",
+        "--no-compare",
+        action="store_true",
         help="Skip Polypus DE · PSO · QNG vs SciPy DE optimizer comparison",
     )
     p.add_argument(
-        "--sim-method", type=str, default="automatic",
+        "--sim-method",
+        type=str,
+        default="automatic",
         metavar="METHOD",
         help="Aer simulation method (default: automatic). "
-             "Options: automatic, statevector, matrix_product_state, "
-             "density_matrix, stabilizer, extended_stabilizer. "
-             "Use matrix_product_state when testing with noise models.",
+        "Options: automatic, statevector, matrix_product_state, "
+        "density_matrix, stabilizer, extended_stabilizer. "
+        "Use matrix_product_state when testing with noise models.",
     )
     p.add_argument(
-        "--cmp-generations", type=int, default=None, metavar="N",
+        "--cmp-generations",
+        type=int,
+        default=None,
+        metavar="N",
         help="Generations for optimizer comparison (default: 20, quick: 5)",
     )
     p.add_argument(
-        "--cmp-popsize", type=int, default=None, metavar="N",
+        "--cmp-popsize",
+        type=int,
+        default=None,
+        metavar="N",
         help="Population size for optimizer comparison (default: 8, quick: 4)",
     )
     p.add_argument(
-        "--cmp-shots", type=int, default=None, metavar="N",
+        "--cmp-shots",
+        type=int,
+        default=None,
+        metavar="N",
         help="Shots for optimizer comparison (default: 1000, quick: 300)",
     )
     p.add_argument(
-        "--cmp-qubits", nargs="+", type=int, default=None, metavar="N",
+        "--cmp-qubits",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="N",
         help="Qubit counts to sweep in optimizer comparison "
-             "(default: [4, 8] in quick mode, [4, 8, 12] otherwise).",
+        "(default: [4, 8] in quick mode, [4, 8, 12] otherwise).",
     )
     return p.parse_args()
 
@@ -569,12 +684,12 @@ def main() -> None:
     args = parse_args()
 
     if args.quick:
-        qpus   = [1, 2, 4 ,8, 16]
-        shots  = [10000]
+        qpus = [1, 2, 4, 8, 16]
+        shots = [10000]
         repeats = 3
     else:
-        qpus   = args.qpus   or [1, 2, 4 ,8, 16]
-        shots  = args.shots  or [10000]
+        qpus = args.qpus or [1, 2, 4, 8, 16]
+        shots = args.shots or [10000]
         repeats = args.repeats
 
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -602,21 +717,27 @@ def main() -> None:
 
     # ── Optimizer comparison: Polypus DE · PSO · QNG vs SciPy DE ──────────────
     if not args.no_compare:
-        cmp_gen   = args.cmp_generations or (5    if args.quick else 20)
-        cmp_pop   = args.cmp_popsize     or (4    if args.quick else 8)
-        cmp_shots = args.cmp_shots       or (300  if args.quick else 1000)
+        cmp_gen = args.cmp_generations or (5 if args.quick else 20)
+        cmp_pop = args.cmp_popsize or (4 if args.quick else 8)
+        cmp_shots = args.cmp_shots or (300 if args.quick else 1000)
 
         cmp_qubits_list = args.cmp_qubits or ([4, 8] if args.quick else [4, 8, 12])
 
-        print(f"\n[polypus-bench] Optimizer comparison — Polypus DE · PSO · QNG vs SciPy DE")
+        print(
+            "\n[polypus-bench] Optimizer comparison — Polypus DE · PSO · QNG vs SciPy DE"
+        )
         print(f"  Qubit sweep : {cmp_qubits_list}")
-        print(f"  generations : {cmp_gen}   population_size : {cmp_pop}   shots : {cmp_shots}")
+        print(
+            f"  generations : {cmp_gen}   population_size : {cmp_pop}   shots : {cmp_shots}"
+        )
 
         multi_comp: dict = {}
         for n_q in cmp_qubits_list:
             header = f"\n  {'─' * 10} {n_q} qubits · {n_q * 2} params {'─' * 10}"
             print(header)
-            multi_comp[n_q] = run_optimizer_comparison(qpus, cmp_shots, n_q, cmp_gen, cmp_pop, args.sim_method)
+            multi_comp[n_q] = run_optimizer_comparison(
+                qpus, cmp_shots, n_q, cmp_gen, cmp_pop, args.sim_method
+            )
 
         if not args.no_plots:
             if len(cmp_qubits_list) == 1:

--- a/crates/polypus-circuit/Cargo.toml
+++ b/crates/polypus-circuit/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polypus-circuit"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Pure-Rust quantum circuit representation with OpenQASM 2.0 export, used by Polypus. No PyO3 / Python dependency."

--- a/crates/polypus-logger/Cargo.toml
+++ b/crates/polypus-logger/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polypus-logger"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Shared, pure-Rust logging sink for the Polypus workspace: a configurable `log::Log` implementation (text/JSON, stdout/stderr/file) installed once per process. Library crates only emit through the `log` facade; this crate is depended on by whoever installs the logger."

--- a/crates/polypus-optimizers/Cargo.toml
+++ b/crates/polypus-optimizers/Cargo.toml
@@ -2,6 +2,7 @@
 name              = "polypus-optimizers"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description       = "Pure-Rust variational optimizers for Polypus (Differential Evolution, Particle Swarm Optimization, Quantum Natural Gradient). Decoupled from circuits and Python via the EvaluationOracle/VarianceOracle contracts. No PyO3, no Python."

--- a/crates/polypus-physics/Cargo.toml
+++ b/crates/polypus-physics/Cargo.toml
@@ -2,6 +2,7 @@
 name              = "polypus-physics"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description       = "Pure-Rust particle-physics simulation layer for Polypus: classical Monte Carlo transport and quantum Hamiltonian definitions as Pauli sums. No Python, no external physics framework."

--- a/crates/polypus-sim/Cargo.toml
+++ b/crates/polypus-sim/Cargo.toml
@@ -2,6 +2,7 @@
 name              = "polypus-sim"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description       = "Pure-Rust statevector simulator for Polypus circuits: consumes polypus-circuit's ConcreteCircuit directly (no OpenQASM round-trip), GIL-free, with optional rayon parallelism. No Python."

--- a/crates/polypus/Cargo.toml
+++ b/crates/polypus/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polypus"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,17 @@
 # Uses the RustSec advisory database (https://github.com/rustsec/advisory-db).
 # Recent cargo-deny versions default vulnerabilities to "deny" and unmaintained
 # crates to "warn", so no explicit severity keys are needed here.
-ignore = []
+ignore = [
+    # PyCFunction::new_closure lacked a Sync bound in pyo3 <0.29. The
+    # workspace never calls new_closure (verified: no occurrences under
+    # crates/), so the advisory does not apply. Remove this entry when the
+    # pyo3 >=0.29 migration lands.
+    { id = "RUSTSEC-2026-0177", reason = "PyCFunction::new_closure is not used in this workspace" },
+    # Out-of-bounds read in `nth`/`nth_back` on PyList/PyTuple iterators
+    # (also reachable via `skip`/`step_by`). No such calls exist on pyo3
+    # iterators in this workspace. Remove when the pyo3 >=0.26 upgrade lands.
+    { id = "RUSTSEC-2026-0176", reason = "nth/nth_back (and skip/step_by) are never called on PyList/PyTuple iterators here" },
+]
 
 [licenses]
 # Polypus is licensed under EUPL-1.2. Allow it plus the common permissive

--- a/examples/basic_qml.py
+++ b/examples/basic_qml.py
@@ -1,5 +1,6 @@
-import polypus, numpy as np
-from qiskit.circuit.library import zz_feature_map, real_amplitudes
+import numpy as np
+import polypus
+from qiskit.circuit.library import real_amplitudes, zz_feature_map
 
 # Install the logger sink so the internal Rust log records are written to a file.
 # NOTE: optimizer progress is logged at DEBUG level, and the default build
@@ -12,16 +13,26 @@ feature_map = zz_feature_map(feature_dimension=4, reps=2)
 ansatz = real_amplitudes(num_qubits=4, reps=2)
 
 X_train = np.random.rand(10, 4)  # Dummy training data (10 samples, 4 features)
+
+
 # Loss: maximise the fraction of |1⟩ outcomes across all measured qubits
-my_loss = lambda bitstring: sum(int(b) for b in bitstring) / len(bitstring)
+def my_loss(bitstring):
+    return sum(int(b) for b in bitstring) / len(bitstring)
 
 
 result = polypus.qml.train(
-    feature_map, ansatz, X_train,
+    feature_map,
+    ansatz,
+    X_train,
     polypus.PSO(generations=50, population_size=20, bounds=(0, np.pi)),
-    shots=1024, n_qpus=4, dimensions=len(ansatz.parameters),
+    shots=1024,
+    n_qpus=4,
+    dimensions=len(ansatz.parameters),
     expectation_function=my_loss,
-    infrastructure="local", nodes=1, cores_per_qpu=2, id="qml_run",
+    infrastructure="local",
+    nodes=1,
+    cores_per_qpu=2,
+    id="qml_run",
 )
 
 print(result)

--- a/examples/infraestructures.py
+++ b/examples/infraestructures.py
@@ -117,8 +117,10 @@ exp_aer = sum(maxcut_value(k) * v for k, v in counts_aer.items()) / SHOTS
 exp_native = sum(maxcut_value(k) * v for k, v in counts_native.items()) / SHOTS
 print(f"Mean cut   Aer: {exp_aer:.4f}   polypus: {exp_native:.4f}")
 print(f"Optimal cut (brute force): {OPTIMAL}")
-print(f"Approximation ratio   Aer: {exp_aer / OPTIMAL:.4f}"
-      f"   polypus: {exp_native / OPTIMAL:.4f}")
+print(
+    f"Approximation ratio   Aer: {exp_aer / OPTIMAL:.4f}"
+    f"   polypus: {exp_native / OPTIMAL:.4f}"
+)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -219,13 +221,21 @@ mean_aer, best_aer = evaluate_solution(params_aer, "aer")
 mean_native, best_native = evaluate_solution(params_native, "polypus")
 
 print(f"\nOptimal cut (brute force): {OPTIMAL}")
-print(f"Aer:     best (gamma, beta) = ({params_aer[0]:.3f}, {params_aer[1]:.3f})"
-      f"   time = {dt_aer:.2f} s")
-print(f"         mean cut = {mean_aer:.3f} (approx ratio {mean_aer / OPTIMAL:.3f})"
-      f"   best sampled cut = {best_aer}/{OPTIMAL}")
-print(f"polypus: best (gamma, beta) = ({params_native[0]:.3f}, {params_native[1]:.3f})"
-      f"   time = {dt_native:.2f} s")
-print(f"         mean cut = {mean_native:.3f} (approx ratio {mean_native / OPTIMAL:.3f})"
-      f"   best sampled cut = {best_native}/{OPTIMAL}")
+print(
+    f"Aer:     best (gamma, beta) = ({params_aer[0]:.3f}, {params_aer[1]:.3f})"
+    f"   time = {dt_aer:.2f} s"
+)
+print(
+    f"         mean cut = {mean_aer:.3f} (approx ratio {mean_aer / OPTIMAL:.3f})"
+    f"   best sampled cut = {best_aer}/{OPTIMAL}"
+)
+print(
+    f"polypus: best (gamma, beta) = ({params_native[0]:.3f}, {params_native[1]:.3f})"
+    f"   time = {dt_native:.2f} s"
+)
+print(
+    f"         mean cut = {mean_native:.3f} (approx ratio {mean_native / OPTIMAL:.3f})"
+    f"   best sampled cut = {best_native}/{OPTIMAL}"
+)
 if dt_native:
     print(f"speedup: {dt_aer / dt_native:.2f}x")

--- a/examples/max_cut_qaoa.py
+++ b/examples/max_cut_qaoa.py
@@ -1,20 +1,20 @@
-import numpy as np
-import networkx as nx
-import matplotlib.pyplot as plt
-import itertools
-import time
 import argparse
-import os
 import csv
+import itertools
+import os
+import time
+from multiprocessing import Pool
+
+import matplotlib.pyplot as plt
+import networkx as nx
+import numpy as np
 import polypus
+from polypus_python.qaoa_utils import build_qaoa_circuit, expectation_value
 from qiskit import QuantumCircuit
 from qiskit.circuit import ParameterVector
-
-from polypus_python.qaoa_utils import build_qaoa_circuit, expectation_value
 from qiskit_aer import AerSimulator
 from scipy.optimize import differential_evolution
-from multiprocessing import Pool
-import math
+
 
 # Auxiliar functions for QAOA
 def maxcut_cost_layer(graph):
@@ -23,13 +23,17 @@ def maxcut_cost_layer(graph):
             qc.cx(i, j)
             qc.rz(-gamma, j)
             qc.cx(i, j)
+
     return layer_fn
+
 
 def standard_mixer_layer(n_qubits):
     def layer_fn(qc, layer, beta):
         for i in range(n_qubits):
             qc.rx(2 * beta, i)
+
     return layer_fn
+
 
 def bitstring_to_obj(bitstring):
     bitstring = bitstring[::-1]
@@ -38,6 +42,7 @@ def bitstring_to_obj(bitstring):
         if bitstring[i] != bitstring[j]:
             cut += 1
     return cut
+
 
 def maxcut_bruteforce(graph):
     n = graph.number_of_nodes()
@@ -51,9 +56,11 @@ def maxcut_bruteforce(graph):
             max_cut = cut
     return max_cut
 
+
 # ──────────────────────────────────────────────────────────────────────────────
 # QNG helpers: alternating-parameter circuit and variance function
 # ──────────────────────────────────────────────────────────────────────────────
+
 
 def build_qaoa_circuit_qng(graph, layers):
     """
@@ -68,12 +75,12 @@ def build_qaoa_circuit_qng(graph, layers):
     """
     n_qubits = graph.number_of_nodes()
     edges = list(graph.edges())
-    theta = ParameterVector('\u03b8', 2 * layers)  # θ
+    theta = ParameterVector("\u03b8", 2 * layers)  # θ
     qc = QuantumCircuit(n_qubits)
     qc.h(range(n_qubits))
     for layer in range(layers):
         gamma = theta[2 * layer]
-        beta  = theta[2 * layer + 1]
+        beta = theta[2 * layer + 1]
         # Cost layer (ZZ Hamiltonian)
         for i, j in edges:
             qc.cx(i, j)
@@ -106,26 +113,26 @@ def make_variance_function(graph, n_qubits, n_shots):
         if a == 0:
             return 0.0
 
-        theta_a = ParameterVector('\u03b8', a)  # θ — same name, different circuit
+        theta_a = ParameterVector("\u03b8", a)  # θ — same name, different circuit
         qc_inter = QuantumCircuit(n_qubits)
         qc_inter.h(range(n_qubits))
 
         for k in range(a):
-            if k % 2 == 0:      # gamma (ZZ cost layer)
+            if k % 2 == 0:  # gamma (ZZ cost layer)
                 gamma = theta_a[k]
                 for i, j in edges:
                     qc_inter.cx(i, j)
                     qc_inter.rz(-gamma, j)
                     qc_inter.cx(i, j)
-            else:               # beta (X mixer layer)
+            else:  # beta (X mixer layer)
                 beta = theta_a[k]
                 for qubit in range(n_qubits):
                     qc_inter.rx(2 * beta, qubit)
 
         # Rotate into the correct measurement basis
-        if a % 2 == 0:          # next param is gamma -> ZZ Hamiltonian -> Z basis
+        if a % 2 == 0:  # next param is gamma -> ZZ Hamiltonian -> Z basis
             qc_inter.measure_all()
-        else:                   # next param is beta  -> X Hamiltonian  -> X basis
+        else:  # next param is beta  -> X Hamiltonian  -> X basis
             qc_inter.h(range(n_qubits))
             qc_inter.measure_all()
 
@@ -140,19 +147,20 @@ def make_variance_function(graph, n_qubits, n_shots):
         for bitstring, count in counts.items():
             prob = count / shots_total
             bits = bitstring[::-1]
-            if a % 2 == 0:      # ZZ Hamiltonian
+            if a % 2 == 0:  # ZZ Hamiltonian
                 h_val = sum(
-                    (1 if bits[i] == '0' else -1) * (1 if bits[j] == '0' else -1)
+                    (1 if bits[i] == "0" else -1) * (1 if bits[j] == "0" else -1)
                     for i, j in edges
                 )
-            else:               # X Hamiltonian
-                h_val = sum(1 if bits[i] == '0' else -1 for i in range(n_qubits))
-            exp_H  += h_val * prob
-            exp_H2 += (h_val ** 2) * prob
+            else:  # X Hamiltonian
+                h_val = sum(1 if bits[i] == "0" else -1 for i in range(n_qubits))
+            exp_H += h_val * prob
+            exp_H2 += (h_val**2) * prob
 
-        return exp_H2 - exp_H ** 2
+        return exp_H2 - exp_H**2
 
     return variance_fn
+
 
 def qaoa_expectation(params):
     qc_bound = qc.assign_parameters(params)
@@ -161,46 +169,109 @@ def qaoa_expectation(params):
     counts = result.get_counts()
     return -expectation_value(counts, bitstring_to_obj)
 
+
 def compute_mean_energy(counts):
     total_shots = sum(counts.values())
-    return sum(bitstring_to_obj(bs[::-1]) * freq for bs, freq in counts.items()) / total_shots
+    return (
+        sum(bitstring_to_obj(bs[::-1]) * freq for bs, freq in counts.items())
+        / total_shots
+    )
 
-def log_experiment_results(n_qubits, method, execution_time, approximation_ratio, n_shots, n_nodes, cores_per_qpu):
+
+def log_experiment_results(
+    n_qubits,
+    method,
+    execution_time,
+    approximation_ratio,
+    n_shots,
+    n_nodes,
+    cores_per_qpu,
+):
     log_dir = os.path.join(os.getcwd(), "examples")
     os.makedirs(log_dir, exist_ok=True)
-    file_name = os.path.join(log_dir, 'qaoa_results.csv')
-    headers = ['n_qubits', 'method', 'time', 'approximation_ratio', 'n_shots', 'n_nodes', 'cores_per_qpu']
+    file_name = os.path.join(log_dir, "qaoa_results.csv")
+    headers = [
+        "n_qubits",
+        "method",
+        "time",
+        "approximation_ratio",
+        "n_shots",
+        "n_nodes",
+        "cores_per_qpu",
+    ]
     file_exists = os.path.isfile(file_name)
-    with open(file_name, mode='a', newline='') as file:
-        writer = csv.writer(file, delimiter='|')
+    with open(file_name, mode="a", newline="") as file:
+        writer = csv.writer(file, delimiter="|")
         if not file_exists:
             writer.writerow(headers)
-        writer.writerow([n_qubits, method, execution_time, approximation_ratio, n_shots, n_nodes, cores_per_qpu])
+        writer.writerow(
+            [
+                n_qubits,
+                method,
+                execution_time,
+                approximation_ratio,
+                n_shots,
+                n_nodes,
+                cores_per_qpu,
+            ]
+        )
 
-def plot_results(graph, counts, best_bitstring, cut, method_label, elapsed,
-                 best_solution, population_size, max_generations, layers, algorithm, experiment_id):
+
+def plot_results(
+    graph,
+    counts,
+    best_bitstring,
+    cut,
+    method_label,
+    elapsed,
+    best_solution,
+    population_size,
+    max_generations,
+    layers,
+    algorithm,
+    experiment_id,
+):
     n = graph.number_of_nodes()
     pos = nx.spring_layout(graph, seed=42)
     fig, axes = plt.subplots(1, 3, figsize=(18, 6))
 
     # 1. Original graph
-    nx.draw(graph, pos, ax=axes[0], with_labels=True, node_color='lightgray',
-            edge_color='black', node_size=800, font_color='black')
+    nx.draw(
+        graph,
+        pos,
+        ax=axes[0],
+        with_labels=True,
+        node_color="lightgray",
+        edge_color="black",
+        node_size=800,
+        font_color="black",
+    )
     axes[0].set_title("Original Graph")
 
     # 2. Best cut
-    color_map = ['red' if best_bitstring[i] == '0' else 'blue' for i in range(n)]
-    nx.draw(graph, pos, ax=axes[1], with_labels=True, node_color=color_map,
-            node_size=800, font_color='white')
-    cut_edges = [(i, j) for i, j in graph.edges() if best_bitstring[i] != best_bitstring[j]]
-    nx.draw_networkx_edges(graph, pos, ax=axes[1], edgelist=cut_edges, width=4, edge_color='yellow')
+    color_map = ["red" if best_bitstring[i] == "0" else "blue" for i in range(n)]
+    nx.draw(
+        graph,
+        pos,
+        ax=axes[1],
+        with_labels=True,
+        node_color=color_map,
+        node_size=800,
+        font_color="white",
+    )
+    cut_edges = [
+        (i, j) for i, j in graph.edges() if best_bitstring[i] != best_bitstring[j]
+    ]
+    nx.draw_networkx_edges(
+        graph, pos, ax=axes[1], edgelist=cut_edges, width=4, edge_color="yellow"
+    )
     axes[1].set_title(f"{method_label} Cut: {cut} - Time: {elapsed:.2f}s")
 
     # 3. Counts distribution
-    axes[2].bar(counts.keys(), counts.values(), color='blue')
-    axes[2].set_xlabel('Bitstring')
-    axes[2].set_ylabel('Counts')
-    axes[2].set_title('Counts Distribution')
+    axes[2].bar(counts.keys(), counts.values(), color="blue")
+    axes[2].set_xlabel("Bitstring")
+    axes[2].set_ylabel("Counts")
+    axes[2].set_title("Counts Distribution")
     plt.xticks(rotation=90)
     plt.subplots_adjust(bottom=0.2)
 
@@ -214,7 +285,10 @@ def plot_results(graph, counts, best_bitstring, cut, method_label, elapsed,
     plt.savefig(f"examples/plots_maxcut/maxcut_result_{experiment_id}.png")
     plt.close(fig)
 
-def final_evaluation(qc, graph, layers, cost_layers, mixer_layers, params, n_shots, best_solution):
+
+def final_evaluation(
+    qc, graph, layers, cost_layers, mixer_layers, params, n_shots, best_solution
+):
     qc_eval = build_qaoa_circuit(graph, layers, cost_layers, mixer_layers)
     qc_eval.assign_parameters(params, inplace=True)
     counts = AerSimulator().run(qc_eval, shots=n_shots).result().get_counts()
@@ -225,22 +299,42 @@ def final_evaluation(qc, graph, layers, cost_layers, mixer_layers, params, n_sho
 
 
 if __name__ == "__main__":
-
     polypus.init_logger(run_name="max_cut_qaoa")
 
     # Experiment setup
-    np.random.seed(1) 
+    np.random.seed(1)
     N_SHOTS = 10000
     N_QPUS = 64
 
     # Select method
     parser = argparse.ArgumentParser(description="Run QAOA for MaxCut")
-    parser.add_argument('--method', type=str, required=True, help='Method to use (scipy, polypus_local, polypus_cunqa)') 
-    parser.add_argument('--qubits', type=int, default=4, help='Number of qubits for the QAOA circuit')
-    parser.add_argument('--experiment_id', type=int, default=0, help='Experiment ID for logging purposes')
-    parser.add_argument('--run', type=int, default=0, help='Run number for logging purposes')
-    parser.add_argument('--cores_per_qpu', type=int, default= 2, help='Number of cores per QPU for Cunqa infrastructure')
-    parser.add_argument('--num_nodes', type=int, default=1, help="Number of nodes in CUNQA")
+    parser.add_argument(
+        "--method",
+        type=str,
+        required=True,
+        help="Method to use (scipy, polypus_local, polypus_cunqa)",
+    )
+    parser.add_argument(
+        "--qubits", type=int, default=4, help="Number of qubits for the QAOA circuit"
+    )
+    parser.add_argument(
+        "--experiment_id",
+        type=int,
+        default=0,
+        help="Experiment ID for logging purposes",
+    )
+    parser.add_argument(
+        "--run", type=int, default=0, help="Run number for logging purposes"
+    )
+    parser.add_argument(
+        "--cores_per_qpu",
+        type=int,
+        default=2,
+        help="Number of cores per QPU for Cunqa infrastructure",
+    )
+    parser.add_argument(
+        "--num_nodes", type=int, default=1, help="Number of nodes in CUNQA"
+    )
     args = parser.parse_args()
     method = args.method
     n_qubits = args.qubits
@@ -260,7 +354,9 @@ if __name__ == "__main__":
     layers = n_qubits // 2
     layers *= LAYERS_FACTOR
     cost_layers = [maxcut_cost_layer(graph) for _ in range(layers)]
-    mixer_layers = [standard_mixer_layer(graph.number_of_nodes()) for _ in range(layers)]
+    mixer_layers = [
+        standard_mixer_layer(graph.number_of_nodes()) for _ in range(layers)
+    ]
     qc = build_qaoa_circuit(graph, layers, cost_layers, mixer_layers)
     POPULATION_SIZE = (2 * layers) * POPULATION_FACTOR
     MAX_GENERATIONS = n_qubits * GENERATIONS_FACTOR
@@ -268,50 +364,104 @@ if __name__ == "__main__":
 
     N_QPUS_PER_NODE = 64 // CORES_PER_QPU
     N_QPUS = NUM_NODES * N_QPUS_PER_NODE
-    print(f"Using {N_QPUS} QPUs across {NUM_NODES} nodes with {CORES_PER_QPU} cores per QPU")
+    print(
+        f"Using {N_QPUS} QPUs across {NUM_NODES} nodes with {CORES_PER_QPU} cores per QPU"
+    )
 
-    if method not in ['scipy', 'polypus_local', 'polypus_cunqa',
-                       'polypus_local_pso', 'polypus_cunqa_pso',
-                       'polypus_local_qng', 'polypus_cunqa_qng']:
-        raise ValueError("Method must be one of: 'scipy', 'polypus_local', 'polypus_cunqa', 'polypus_local_pso', 'polypus_cunqa_pso', 'polypus_local_qng', 'polypus_cunqa_qng'")
+    if method not in [
+        "scipy",
+        "polypus_local",
+        "polypus_cunqa",
+        "polypus_local_pso",
+        "polypus_cunqa_pso",
+        "polypus_local_qng",
+        "polypus_cunqa_qng",
+    ]:
+        raise ValueError(
+            "Method must be one of: 'scipy', 'polypus_local', 'polypus_cunqa', 'polypus_local_pso', 'polypus_cunqa_pso', 'polypus_local_qng', 'polypus_cunqa_qng'"
+        )
 
-    if method == 'scipy':
-
+    if method == "scipy":
         bounds = [(0, np.pi)] * (2 * layers)
-        print("Running differential evolution with scipy... optimized for parallel execution")
-        total_workers = int(os.environ["OMP_NUM_THREADS"]) if "OMP_NUM_THREADS" in os.environ else 1
+        print(
+            "Running differential evolution with scipy... optimized for parallel execution"
+        )
+        total_workers = (
+            int(os.environ["OMP_NUM_THREADS"]) if "OMP_NUM_THREADS" in os.environ else 1
+        )
         print(f"Using {total_workers} workers for parallel execution")
         pool = Pool(total_workers)
         tic = time.time()
-        res = differential_evolution(qaoa_expectation, bounds, maxiter=MAX_GENERATIONS, polish=False, popsize=max(1, POPULATION_SIZE // (2 * layers)), disp=True, workers=pool.map, tol=TOL)
+        res = differential_evolution(
+            qaoa_expectation,
+            bounds,
+            maxiter=MAX_GENERATIONS,
+            polish=False,
+            popsize=max(1, POPULATION_SIZE // (2 * layers)),
+            disp=True,
+            workers=pool.map,
+            tol=TOL,
+        )
         time_scipy = time.time() - tic
-        print(f"Scipy DE finished in {time_scipy:.2f} seconds with best cost: {-res.fun:.2f}")
+        print(
+            f"Scipy DE finished in {time_scipy:.2f} seconds with best cost: {-res.fun:.2f}"
+        )
         pool.close()
         pool.join()
 
         param_dict = {qc.parameters[i]: res.x[i] for i in range(2 * layers)}
-        counts = AerSimulator().run(qc.assign_parameters(param_dict), shots=N_SHOTS).result().get_counts()
+        counts = (
+            AerSimulator()
+            .run(qc.assign_parameters(param_dict), shots=N_SHOTS)
+            .result()
+            .get_counts()
+        )
         best_bitstring = max(counts, key=counts.get)
         cut = bitstring_to_obj(best_bitstring)
         approximation_ratio = compute_mean_energy(counts) / BEST_SOLUTION
         print(f"Mean energy: {approximation_ratio * BEST_SOLUTION:.4f}")
         print(f"Approximation ratio: {approximation_ratio}")
 
-        log_experiment_results(n_qubits, 'scipy_optimized', time_scipy, approximation_ratio, N_SHOTS, NUM_NODES, CORES_PER_QPU)
-        plot_results(graph, counts, best_bitstring, cut, "Scipy Optimized QAOA", time_scipy,
-                     BEST_SOLUTION, POPULATION_SIZE, MAX_GENERATIONS, layers, "DE", id)
+        log_experiment_results(
+            n_qubits,
+            "scipy_optimized",
+            time_scipy,
+            approximation_ratio,
+            N_SHOTS,
+            NUM_NODES,
+            CORES_PER_QPU,
+        )
+        plot_results(
+            graph,
+            counts,
+            best_bitstring,
+            cut,
+            "Scipy Optimized QAOA",
+            time_scipy,
+            BEST_SOLUTION,
+            POPULATION_SIZE,
+            MAX_GENERATIONS,
+            layers,
+            "DE",
+            id,
+        )
 
-    elif method in ('polypus_local', 'polypus_cunqa'):
-
-        infrastructure = "local" if method == 'polypus_local' else "cunqa"
+    elif method in ("polypus_local", "polypus_cunqa"):
+        infrastructure = "local" if method == "polypus_local" else "cunqa"
         # MPS gives per-shot QPU parallelism on distributed backends; for local
         # runs the automatic method (statevector) is ~19x faster on small circuits.
-        de_sim_method = "matrix_product_state" if infrastructure == "cunqa" else "automatic"
+        de_sim_method = (
+            "matrix_product_state" if infrastructure == "cunqa" else "automatic"
+        )
 
         tic = time.time()
         result_params = polypus.train(
             qc,
-            polypus.DE(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, tolerance=TOL),
+            polypus.DE(
+                generations=MAX_GENERATIONS,
+                population_size=POPULATION_SIZE,
+                tolerance=TOL,
+            ),
             shots=N_SHOTS,
             n_qpus=N_QPUS,
             dimensions=2 * layers,
@@ -320,23 +470,56 @@ if __name__ == "__main__":
             nodes=NUM_NODES,
             cores_per_qpu=CORES_PER_QPU,
             id=id,
-            sim_method=de_sim_method)
+            sim_method=de_sim_method,
+        )
         elapsed = time.time() - tic
 
         counts, best_bitstring, cut, approximation_ratio = final_evaluation(
-            qc, graph, layers, cost_layers, mixer_layers, result_params, N_SHOTS, BEST_SOLUTION)
-        log_experiment_results(n_qubits, method, elapsed, approximation_ratio, N_SHOTS, NUM_NODES, CORES_PER_QPU)
-        plot_results(graph, counts, best_bitstring, cut, "Polypus QAOA", elapsed,
-                     BEST_SOLUTION, POPULATION_SIZE, MAX_GENERATIONS, layers, "DE", id)
+            qc,
+            graph,
+            layers,
+            cost_layers,
+            mixer_layers,
+            result_params,
+            N_SHOTS,
+            BEST_SOLUTION,
+        )
+        log_experiment_results(
+            n_qubits,
+            method,
+            elapsed,
+            approximation_ratio,
+            N_SHOTS,
+            NUM_NODES,
+            CORES_PER_QPU,
+        )
+        plot_results(
+            graph,
+            counts,
+            best_bitstring,
+            cut,
+            "Polypus QAOA",
+            elapsed,
+            BEST_SOLUTION,
+            POPULATION_SIZE,
+            MAX_GENERATIONS,
+            layers,
+            "DE",
+            id,
+        )
 
-    elif method in ('polypus_local_pso', 'polypus_cunqa_pso'):
-
-        infrastructure = "local" if method == 'polypus_local_pso' else "cunqa"
+    elif method in ("polypus_local_pso", "polypus_cunqa_pso"):
+        infrastructure = "local" if method == "polypus_local_pso" else "cunqa"
 
         tic = time.time()
         result_params = polypus.train(
             qc,
-            polypus.PSO(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, bounds=(0.0, np.pi), tolerance=TOL),
+            polypus.PSO(
+                generations=MAX_GENERATIONS,
+                population_size=POPULATION_SIZE,
+                bounds=(0.0, np.pi),
+                tolerance=TOL,
+            ),
             shots=N_SHOTS,
             n_qpus=N_QPUS,
             dimensions=2 * layers,
@@ -344,33 +527,66 @@ if __name__ == "__main__":
             infrastructure=infrastructure,
             nodes=NUM_NODES,
             cores_per_qpu=CORES_PER_QPU,
-            id=id)
+            id=id,
+        )
         elapsed = time.time() - tic
 
         counts, best_bitstring, cut, approximation_ratio = final_evaluation(
-            qc, graph, layers, cost_layers, mixer_layers, result_params, N_SHOTS, BEST_SOLUTION)
-        log_experiment_results(n_qubits, method, elapsed, approximation_ratio, N_SHOTS, NUM_NODES, CORES_PER_QPU)
-        plot_results(graph, counts, best_bitstring, cut, "Polypus PSO QAOA", elapsed,
-                     BEST_SOLUTION, POPULATION_SIZE, MAX_GENERATIONS, layers, "PSO", id)
+            qc,
+            graph,
+            layers,
+            cost_layers,
+            mixer_layers,
+            result_params,
+            N_SHOTS,
+            BEST_SOLUTION,
+        )
+        log_experiment_results(
+            n_qubits,
+            method,
+            elapsed,
+            approximation_ratio,
+            N_SHOTS,
+            NUM_NODES,
+            CORES_PER_QPU,
+        )
+        plot_results(
+            graph,
+            counts,
+            best_bitstring,
+            cut,
+            "Polypus PSO QAOA",
+            elapsed,
+            BEST_SOLUTION,
+            POPULATION_SIZE,
+            MAX_GENERATIONS,
+            layers,
+            "PSO",
+            id,
+        )
 
-    elif method in ('polypus_local_qng', 'polypus_cunqa_qng'):
-
-        infrastructure = "local" if method == 'polypus_local_qng' else "cunqa"
+    elif method in ("polypus_local_qng", "polypus_cunqa_qng"):
+        infrastructure = "local" if method == "polypus_local_qng" else "cunqa"
 
         # QNG uses its own alternating-parameter circuit and a variance callback
         qc_qng = build_qaoa_circuit_qng(graph, layers)
         variance_fn = make_variance_function(graph, n_qubits, N_SHOTS)
 
         QNG_LEARNING_RATE = 0.1
-        QNG_STEP_SIZE     = 0.1
-        QNG_TIKHONOV_REG  = 0.05
+        QNG_STEP_SIZE = 0.1
+        QNG_TIKHONOV_REG = 0.05
 
         tic = time.time()
         result_params = polypus.train(
             qc_qng,
-            polypus.QNG(variance_fn, max_iters=MAX_GENERATIONS, bounds=(0.0, np.pi),
-                        learning_rate=QNG_LEARNING_RATE, finite_difference_step=QNG_STEP_SIZE,
-                        tikhonov_reg=QNG_TIKHONOV_REG),
+            polypus.QNG(
+                variance_fn,
+                max_iters=MAX_GENERATIONS,
+                bounds=(0.0, np.pi),
+                learning_rate=QNG_LEARNING_RATE,
+                finite_difference_step=QNG_STEP_SIZE,
+                tikhonov_reg=QNG_TIKHONOV_REG,
+            ),
             shots=N_SHOTS,
             n_qpus=N_QPUS,
             dimensions=2 * layers,
@@ -378,7 +594,8 @@ if __name__ == "__main__":
             infrastructure=infrastructure,
             nodes=NUM_NODES,
             cores_per_qpu=CORES_PER_QPU,
-            id=id)
+            id=id,
+        )
         elapsed = time.time() - tic
 
         # Final evaluation uses the QNG circuit (alternating parameterisation)
@@ -389,6 +606,26 @@ if __name__ == "__main__":
         cut = bitstring_to_obj(best_bitstring)
         approximation_ratio = compute_mean_energy(counts) / BEST_SOLUTION
 
-        log_experiment_results(n_qubits, method, elapsed, approximation_ratio, N_SHOTS, NUM_NODES, CORES_PER_QPU)
-        plot_results(graph, counts, best_bitstring, cut, "Polypus QNG QAOA", elapsed,
-                     BEST_SOLUTION, POPULATION_SIZE, MAX_GENERATIONS, layers, "QNG", id)
+        log_experiment_results(
+            n_qubits,
+            method,
+            elapsed,
+            approximation_ratio,
+            N_SHOTS,
+            NUM_NODES,
+            CORES_PER_QPU,
+        )
+        plot_results(
+            graph,
+            counts,
+            best_bitstring,
+            cut,
+            "Polypus QNG QAOA",
+            elapsed,
+            BEST_SOLUTION,
+            POPULATION_SIZE,
+            MAX_GENERATIONS,
+            layers,
+            "QNG",
+            id,
+        )

--- a/examples/polypus_cunqa_basic.py
+++ b/examples/polypus_cunqa_basic.py
@@ -15,7 +15,9 @@ print(result)
 
 # 2. Single Run Local with distribute by shots
 print("Calling Polypus Local with 10 qpus")
-result = polypus.run_quantum_circuit(qft_circuit, shots=10000, infraestructure="local", n_qpus=10)
+result = polypus.run_quantum_circuit(
+    qft_circuit, shots=10000, infraestructure="local", n_qpus=10
+)
 print(result)
 
 # 3. Single Run QMIO
@@ -25,5 +27,7 @@ print(result)
 
 # 4. Distribute by shots
 print("Calling Polypus Single Run for 10 QPUs")
-result = polypus.run_quantum_circuit(qft_circuit, shots=10000, infraestructure="qmio", n_qpus=10)
+result = polypus.run_quantum_circuit(
+    qft_circuit, shots=10000, infraestructure="qmio", n_qpus=10
+)
 print(result)

--- a/examples/single_run.py
+++ b/examples/single_run.py
@@ -1,6 +1,7 @@
+import time
+
 import polypus
 from qiskit import QuantumCircuit
-import time
 
 polypus.init_logger(run_name="single_run")
 
@@ -18,7 +19,9 @@ qc.measure_all()
 # Single run on local
 print("Running single run local")
 tic1 = time.time()
-result1 = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure="local", n_qpus=1)
+result1 = polypus.run_quantum_circuit(
+    qc, shots=NUM_SHOTS, infrastructure="local", n_qpus=1
+)
 tac1 = time.time()
 time.sleep(5)
 

--- a/packages/polypus_python/polypus_python/__init__.py
+++ b/packages/polypus_python/polypus_python/__init__.py
@@ -1,8 +1,17 @@
-import sys, os
+import os
+import sys
+
 sys.path.append(os.getenv("HOME"))
 
-from .running_functions import run_qcs_in_qpu, run_qc_in_qpu
-from .running_functions import test_connection
-from .running_functions import serialize_quantum_circuit
+from .connectivity import (
+    connect_to_infrastructure,
+    disconnect_from_infrastructure,
+    run_qcs,
+)
 from .qaoa_utils import build_qaoa_circuit, expectation_value, expectation_values
-from .connectivity import connect_to_infrastructure, run_qcs, disconnect_from_infrastructure
+from .running_functions import (
+    run_qc_in_qpu,
+    run_qcs_in_qpu,
+    serialize_quantum_circuit,
+    test_connection,
+)

--- a/packages/polypus_python/polypus_python/connectivity.py
+++ b/packages/polypus_python/polypus_python/connectivity.py
@@ -1,5 +1,7 @@
 from .local import Local
+
 # from .cunqa import Cunqa
+
 
 def connect_to_infrastructure(infrastructure: str, **kwargs):
     if infrastructure == "local":
@@ -10,21 +12,28 @@ def connect_to_infrastructure(infrastructure: str, **kwargs):
     else:
         raise ValueError(f"Unknown infrastructure: {infrastructure}")
 
+
 def disconnect_from_infrastructure(infrastructure: str, **kwargs):
     if infrastructure == "local":
         return
     elif infrastructure == "cunqa":
+        # CUNQA is an optional dependency; import it only when this path runs.
+        from .cunqa import Cunqa
+
         return Cunqa().drop_qpus(**kwargs)
     else:
         raise ValueError(f"Unknown infrastructure: {infrastructure}")
-    
+
+
 def run_qcs(infrastructure, **args):
     if infrastructure == "local":
         local = Local(num_qpus=1, qubits_per_qpu=[32], qpu_types=["AerSimulator"])
         return local.run_qcs(**args)
     elif infrastructure == "cunqa":
+        # CUNQA is an optional dependency; import it only when this path runs.
+        from .cunqa import Cunqa
+
         cunqa = Cunqa()
         return cunqa.run_qcs(**args)
     else:
         raise ValueError(f"Unknown infrastructure: {infrastructure}")
-

--- a/packages/polypus_python/polypus_python/cunqa.py
+++ b/packages/polypus_python/polypus_python/cunqa.py
@@ -1,22 +1,26 @@
+import os
+import sys
 
 from qiskit import QuantumCircuit
-from qiskit_aer import AerSimulator
-import os, sys
+
 sys.path.append(os.getenv("HOME"))
 
-from .infrastructure import Infraestructure
-from cunqa.qutils import get_QPUs, qraise, qdrop
 from cunqa.qjob import gather
+from cunqa.qutils import get_QPUs, qdrop, qraise
+
+from .infrastructure import Infraestructure
+
 
 class Cunqa(Infraestructure):
-
     def get_qpus(self, **kwargs) -> object:
 
         n = kwargs["n"]
         t = kwargs["t"]
         n_nodes = kwargs["n_nodes"]
         family_name = kwargs["family_name"]
-        family = qraise(n, t, quantum_comm=False, cloud=True, n_nodes=n_nodes, family=family_name)
+        family = qraise(
+            n, t, quantum_comm=False, cloud=True, n_nodes=n_nodes, family=family_name
+        )
         return family
 
     def drop_qpus(self, **kwargs) -> object:
@@ -27,7 +31,6 @@ class Cunqa(Infraestructure):
     def run_qcs(self, **args) -> object:
 
         family_id = args["family_id"]
-        backend = args["backend"] 
         # Native polypus circuits arrive as OpenQASM 2.0 strings; CUNQA QPUs
         # currently consume QuantumCircuit objects, so parse here.
         qcs = [
@@ -35,7 +38,6 @@ class Cunqa(Infraestructure):
             for qc in args["qcs"]
         ]
         shots = args["shots"]
-        sim_method = args.get("sim_method", "automatic")
 
         sys.path.append(os.getenv("HOME"))
         try:
@@ -49,7 +51,7 @@ class Cunqa(Infraestructure):
             for i in range(len(qcs)):
                 qjob = qpus[i].run(qcs[i], shots=shots, transpile=False)
                 qjobs.append(qjob)
-            
+
             results = gather(qjobs)
             counts = [result.counts for result in results]
             return counts

--- a/packages/polypus_python/polypus_python/infrastructure.py
+++ b/packages/polypus_python/polypus_python/infrastructure.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+
 class Infraestructure(ABC):
     def __init__(self, **kwargs):
         """
@@ -10,9 +11,9 @@ class Infraestructure(ABC):
 
         Any missing value defaults to None.
         """
-        self.num_qpus = kwargs.get('num_qpus', None)
-        self.qubits_per_qpu = kwargs.get('qubits_per_qpu', None)
-        self.qpu_types = kwargs.get('qpu_types', None)
+        self.num_qpus = kwargs.get("num_qpus", None)
+        self.qubits_per_qpu = kwargs.get("qubits_per_qpu", None)
+        self.qpu_types = kwargs.get("qpu_types", None)
 
     @abstractmethod
     def get_qpus(self, **kwargs) -> object:

--- a/packages/polypus_python/polypus_python/local.py
+++ b/packages/polypus_python/polypus_python/local.py
@@ -1,4 +1,3 @@
-
 from qiskit import QuantumCircuit
 from qiskit_aer import AerSimulator
 
@@ -14,8 +13,7 @@ def _ensure_quantum_circuits(qcs):
     backends that speak QASM natively can skip this step entirely.
     """
     return [
-        QuantumCircuit.from_qasm_str(qc) if isinstance(qc, str) else qc
-        for qc in qcs
+        QuantumCircuit.from_qasm_str(qc) if isinstance(qc, str) else qc for qc in qcs
     ]
 
 
@@ -51,4 +49,3 @@ class Local(Infraestructure):
         )
         result = sim.run(qcs, shots=shots).result()
         return [result.get_counts(i) for i in range(len(qcs))]
-

--- a/packages/polypus_python/polypus_python/qaoa_utils.py
+++ b/packages/polypus_python/polypus_python/qaoa_utils.py
@@ -1,9 +1,12 @@
-from qiskit.circuit import QuantumCircuit, ParameterVector
+from qiskit.circuit import ParameterVector, QuantumCircuit
 
-def build_qaoa_circuit(graph, n_layers, cost_hamiltonian_layers, mixer_hamiltonian_layers) -> QuantumCircuit:
+
+def build_qaoa_circuit(
+    graph, n_layers, cost_hamiltonian_layers, mixer_hamiltonian_layers
+) -> QuantumCircuit:
     """
     Build a generic QAOA circuit.
- 
+
     Args:
         n_qubits (int): Number of qubits.
         n_layers (int): Number of QAOA layers (p).
@@ -22,10 +25,10 @@ def build_qaoa_circuit(graph, n_layers, cost_hamiltonian_layers, mixer_hamiltoni
     n_qubits = graph.number_of_nodes()
 
     qc = QuantumCircuit(n_qubits)
-    
+
     # Parameter vector: first n_layers for gamma, then n_layers for beta
-    gamma = ParameterVector('γ', n_layers)
-    beta = ParameterVector('β', n_layers)
+    gamma = ParameterVector("γ", n_layers)
+    beta = ParameterVector("β", n_layers)
 
     # Initial state: Hadamard on all qubits
     for i in range(n_qubits):
@@ -40,6 +43,7 @@ def build_qaoa_circuit(graph, n_layers, cost_hamiltonian_layers, mixer_hamiltoni
 
     qc.measure_all()
     return qc
+
 
 def expectation_value(counts, bitstring_to_obj):
     """
@@ -62,6 +66,7 @@ def expectation_value(counts, bitstring_to_obj):
     if sum_count == 0:
         return 0.0
     return avg / sum_count
+
 
 def expectation_values(array_counts, bitstring_to_obj):
     """
@@ -86,8 +91,9 @@ def expectation_values(array_counts, bitstring_to_obj):
             expectation_values.append(0.0)
         else:
             expectation_values.append(avg / sum_count)
-    
+
     return expectation_values
+
 
 def assign_parameters(qc, params):
     """

--- a/packages/polypus_python/polypus_python/run_worker.py
+++ b/packages/polypus_python/polypus_python/run_worker.py
@@ -1,4 +1,5 @@
 import argparse
+
 from polypus_python import running_functions as rf
 
 if __name__ == "__main__":

--- a/packages/polypus_python/polypus_python/run_worker_qpu.py
+++ b/packages/polypus_python/polypus_python/run_worker_qpu.py
@@ -1,4 +1,5 @@
 import argparse
+
 from polypus_python import running_functions as rf
 
 if __name__ == "__main__":

--- a/packages/polypus_python/polypus_python/running_functions.py
+++ b/packages/polypus_python/polypus_python/running_functions.py
@@ -1,18 +1,18 @@
-import time
-from qiskit_aer import AerSimulator
 import json
-import os, sys
-import random
-from qiskit import QuantumCircuit
-from qiskit.qpy import dump
-from qiskit.qpy.exceptions import QpyError
-from qiskit.qpy import load
-from qiskit.exceptions import QiskitError, MissingOptionalLibraryError
 import logging
-import shutil
+import os
+import sys
+import time
 from collections import Counter
+
+from qiskit.exceptions import MissingOptionalLibraryError, QiskitError
+from qiskit.qpy import dump, load
+from qiskit.qpy.exceptions import QpyError
+from qiskit_aer import AerSimulator
+
 sys.path.append(os.getenv("HOME"))
 # from cunqa import get_QPUs, gather
+
 
 def get_logger(id):
     """Get or create the module logger that logs only to a file."""
@@ -23,11 +23,12 @@ def get_logger(id):
         os.makedirs(log_dir, exist_ok=True)
         log_file = os.path.join(log_dir, f"polypus_python_{id}.log")
         file_handler = logging.FileHandler(log_file)
-        formatter = logging.Formatter('[%(asctime)s][%(levelname)s] %(message)s')
+        formatter = logging.Formatter("[%(asctime)s][%(levelname)s] %(message)s")
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
     logger.setLevel(logging.DEBUG)
     return logger
+
 
 def log_message(id, message, level="error"):
     logger = get_logger(id)
@@ -44,75 +45,84 @@ def log_message(id, message, level="error"):
     else:
         logger.debug(message)
 
+
 def _load_configuration(id):
-    """ Load the configuration json file """
+    """Load the configuration json file"""
 
     # Get the path to the configuration file
-    config_file = 'configuration_backend.json'
+    config_file = "configuration_backend.json"
 
     try:
         config_path = os.path.join(os.getcwd(), config_file)
     except Exception as e:
-        log_message(id,f"Error constructing configuration file path: {e} - {config_path}", "error")
+        log_message(
+            id,
+            f"Error constructing configuration file path: {e} - {config_path}",
+            "error",
+        )
         return {"success": False, "error": "PathConstructionError", "message": str(e)}
 
     # Load the configuration from the JSON file
     try:
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             config = json.load(f)
-    except FileNotFoundError:
-        log_message(id,f"Configuration file not found: {e}", "error")
+    except FileNotFoundError as e:
+        log_message(id, f"Configuration file not found: {e}", "error")
         raise
-    except json.JSONDecodeError:
-        log_message(id,f"Error decoding JSON configuration: {e}", "error")
+    except json.JSONDecodeError as e:
+        log_message(id, f"Error decoding JSON configuration: {e}", "error")
         raise
-    except Exception:
-        log_message(id,f"Unexpected error loading configuration: {e}", "error")
+    except Exception as e:
+        log_message(id, f"Unexpected error loading configuration: {e}", "error")
         raise
 
-    log_message(id,"Configuration loaded successfully.", "info")
+    log_message(id, "Configuration loaded successfully.", "info")
     return config
+
 
 def _get_temp_directory(id):
     """Get the temporary directory for storing serialized files."""
     try:
         temp_dir = os.path.join(os.getcwd(), "temp")
     except Exception as e:
-        log_message(id,f"Error constructing temp directory path: {e}", "error")
+        log_message(id, f"Error constructing temp directory path: {e}", "error")
         raise
     os.makedirs(temp_dir, exist_ok=True)  # Ensure the folder exists
     return temp_dir
 
+
 def _deserialize_quantum_circuit(id):
     """Deserialize a quantum circuit from a QPY file, handling possible errors."""
-    
+
     # Temporary directory for the serialized file
     temp_dir = _get_temp_directory(id)
     try:
         filename = os.path.join(temp_dir, f"circuit_{id}.qpy")
     except Exception as e:
-        log_message(id,f"Error constructing QPY filename: {e}", "error")
+        log_message(id, f"Error constructing QPY filename: {e}", "error")
         raise
 
     try:
         with open(filename, "rb") as f:
             circuits = list(load(f))
             if not circuits:
-                log_message(id,"No circuits found in QPY file.", "error")
+                log_message(id, "No circuits found in QPY file.", "error")
                 raise QpyError("No circuits found in QPY file.")
             return circuits[0]
     except QpyError as e:
-        log_message(id,f"QPY deserialization error: {e}", "error")
+        log_message(id, f"QPY deserialization error: {e}", "error")
         raise
     except TypeError as e:
-        log_message(id,f"Type error during deserialization: {e}", "error")
+        log_message(id, f"Type error during deserialization: {e}", "error")
         raise
     except Exception as e:
-        log_message(id,f"Unexpected error during deserialization: {e}", "error")
+        log_message(id, f"Unexpected error during deserialization: {e}", "error")
         raise
+
 
 def test_connection():
     print("Testing connection to the QASM simulator backend...")
+
 
 def serialize_quantum_circuit(id, qc):
     """Serialize the quantum circuit using Qiskit qpy, handling possible errors."""
@@ -125,24 +135,29 @@ def serialize_quantum_circuit(id, qc):
         with open(temp_file, "wb") as f:
             # Serialize the quantum circuit to a file
             dump(qc, f)
-            log_message(id,f"Quantum circuit serialized successfully to {temp_file}.", "info")
+            log_message(
+                id, f"Quantum circuit serialized successfully to {temp_file}.", "info"
+            )
     except QpyError as e:
-        log_message(id,f"QPY serialization error: {e}", "error")
+        log_message(id, f"QPY serialization error: {e}", "error")
         raise
     except QiskitError as e:
-        log_message(id,f"Qiskit error during serialization: {e}", "error")
+        log_message(id, f"Qiskit error during serialization: {e}", "error")
         raise
     except MissingOptionalLibraryError as e:
-        log_message(id,f"Missing optional library error during serialization: {e}", "error")
+        log_message(
+            id, f"Missing optional library error during serialization: {e}", "error"
+        )
         raise
     except TypeError as e:
-        log_message(id,f"Type error during serialization: {e}", "error")
+        log_message(id, f"Type error during serialization: {e}", "error")
         raise
     except Exception as e:
-        log_message(id,f"Unexpected error during serialization: {e}", "error")
+        log_message(id, f"Unexpected error during serialization: {e}", "error")
         raise
-    
+
     return True
+
 
 def run_qcs_in_qpu(id, qcs, shots):
 
@@ -151,71 +166,83 @@ def run_qcs_in_qpu(id, qcs, shots):
     #     counts.append(AerSimulator().run(qcs[i], shots=shots).result().get_counts(qcs[i]))
     # return counts
 
+    # CUNQA is an optional dependency; import it only when this path runs.
+    from cunqa.qjob import gather
+    from cunqa.qutils import get_QPUs
+
     # # Get the QPUs
-    tic_total = time.time()
     # sys.path.append(os.getenv("HOME"))
     try:
         qpus = get_QPUs(local=False, family=id)
         # log_message(id,f"Time to get QPUs: {time.time() - tic_total}s", "debug")
-    except Exception as e:
+    except Exception:
         # log_message(id,f"Error getting QPUs: {e}", "error")
         raise
-    
+
     # Asynchronously run the quantum circuits on the QPUs
     try:
         qjobs = []
         for i in range(len(qcs)):
-            qjob = qpus[i].run(qcs[i], shots = shots, transpile=False)
+            qjob = qpus[i].run(qcs[i], shots=shots, transpile=False)
             qjobs.append(qjob)
             # log_message(id,f"Running qpu: {qpus[i]}", "info")
-        
+
         results = gather(qjobs)
         # log_message(id, f"Results: {results}", "debug")
         counts = [result.counts for result in results]
         return counts
     except Exception as e:
-        log_message(id,f"Error running quantum circuits on QPUs: {e}", "error")
+        log_message(id, f"Error running quantum circuits on QPUs: {e}", "error")
         raise
 
+
 def run_qc_in_qpu(id, qc, shots):
+    # CUNQA is an optional dependency; import it only when this path runs.
+    from cunqa.qjob import gather
+    from cunqa.qutils import get_QPUs
 
     # Get the QPUs
     tic_total = time.time()
     sys.path.append(os.getenv("HOME"))
     try:
-        qpus = getQPUs(local=False, family=id)
-        log_message(id,f"Time to get the QPU: {time.time() - tic_total}s", "debug")
+        qpus = get_QPUs(local=False, family=id)
+        log_message(id, f"Time to get the QPU: {time.time() - tic_total}s", "debug")
     except Exception as e:
-        log_message(id,f"Error getting QPU: {e}", "error")
+        log_message(id, f"Error getting QPU: {e}", "error")
         raise
-    
+
     # Asynchronously run the quantum circuits on the QPUs
     try:
         qjobs = []
         for i in range(len(qpus)):
-            qjob = qpus[i].run(qc, shots = shots, transpile=False)
+            qjob = qpus[i].run(qc, shots=shots, transpile=False)
             qjobs.append(qjob)
-            log_message(id,f"Running qpu: {qpus[i]}", "info")
-        
+            log_message(id, f"Running qpu: {qpus[i]}", "info")
+
         results = gather(qjobs)
         log_message(id, f"Results: {results}", "debug")
         counts = [result.counts for result in results]
         return counts
     except Exception as e:
-        log_message(id,f"Error running quantum circuits on QPUs: {e}", "error")
+        log_message(id, f"Error running quantum circuits on QPUs: {e}", "error")
         raise
 
+
 def run_qc(id, qc, shots, n_qpus):
-    
+
     tic_total = time.time()
     if n_qpus == 1:
         try:
             backend = AerSimulator()
-            qjob = backend.run(qc, shots = shots, transpile=False)
-            log_message(id, f"Total time to run the quantum circuit: {time.time()-tic_total}s", "debug")
+            qjob = backend.run(qc, shots=shots, transpile=False)
+            log_message(
+                id,
+                f"Total time to run the quantum circuit: {time.time() - tic_total}s",
+                "debug",
+            )
             return qjob.result().get_counts(qc)
         except Exception as e:
-            log_message(id,f"Error running quantum circuit on QPU: {e}", "error")
+            log_message(id, f"Error running quantum circuit on QPU: {e}", "error")
             raise
     elif n_qpus > 1:
         shots_per_qpu = shots // n_qpus
@@ -223,14 +250,16 @@ def run_qc(id, qc, shots, n_qpus):
             counts = []
             for i in range(n_qpus):
                 qjob = AerSimulator().run(qc, shots=shots_per_qpu, transpile=False)
-                log_message(id, f"Total time to run the quantum circuit: {time.time()-tic_total}s", "debug")
+                log_message(
+                    id,
+                    f"Total time to run the quantum circuit: {time.time() - tic_total}s",
+                    "debug",
+                )
                 counts.append(qjob.result().get_counts(qc))
             counts_sum = dict(sum((Counter(d) for d in counts), Counter()))
             return counts_sum
         except Exception as e:
-            log_message(id,f"Error running quantum circuit on QPU: {e}", "error")
+            log_message(id, f"Error running quantum circuit on QPU: {e}", "error")
             raise
     else:
         raise Exception("n_qpus value not valid!")
-
-

--- a/packages/polypus_python/pyproject.toml
+++ b/packages/polypus_python/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "polypus_python"
 version = "0.0.2"
+requires-python = ">=3.9"
 dependencies = [
     "qiskit>=2.0",
     "qiskit-aer>=0.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "maturin"
 
 [project]
 name = "polypus"
-requires-python = ">=3.8"
+# Floor set by the runtime deps of polypus_python (qiskit>=2.0 needs >=3.9).
+# CI tests the floor and the latest supported version.
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -15,6 +17,21 @@ dynamic = ["version"]
 features = ["extension-module"]
 # The repo is a Cargo workspace; the PyO3 extension crate lives here.
 manifest-path = "crates/polypus/Cargo.toml"
+
+# Python lint + formatting for the whole repo (packages, tests, benchmarks,
+# examples). CI runs `ruff check` and `ruff format --check`.
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+# Default rules (pycodestyle errors + pyflakes) plus import sorting.
+extend-select = ["I"]
+
+[tool.ruff.lint.per-file-ignores]
+# Package roots re-export their public API.
+"**/__init__.py" = ["F401"]
+# Tests import qiskit after a pytest.importorskip guard.
+"tests/**" = ["E402"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,7 @@ qiskit>=2.0
 # Testing
 pytest>=8.0
 
+# Lint/format (config in [tool.ruff] in pyproject.toml; CI enforces both
+# `ruff check` and `ruff format --check`)
+ruff>=0.8
+

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures for polypus tests."""
 
 import pytest
-from qiskit.circuit import QuantumCircuit, ParameterVector
+from qiskit.circuit import ParameterVector, QuantumCircuit
 
 
 @pytest.fixture
@@ -31,6 +31,7 @@ def simple_expectation_fn():
     Passed to polypus.train as the per-bitstring objective. Returns 1.0 for
     the all-ones state, 0.0 otherwise — drives optimisers toward θ = π.
     """
+
     def _fn(bitstring: str) -> float:
         return float(all(b == "1" for b in bitstring))
 
@@ -44,6 +45,7 @@ def simple_variance_fn():
     Returns 0.5 (constant) — sufficient to verify QNG plumbing without
     requiring a real quantum Fisher information matrix computation.
     """
+
     def _fn(theta: list, a: int) -> float:
         return 0.5
 

--- a/tests/python/test_backend_selection.py
+++ b/tests/python/test_backend_selection.py
@@ -14,7 +14,6 @@ import math
 
 import pytest
 
-
 # ─────────────────────────────────────────────────────────────────────────────
 # run_quantum_circuit with the native backend
 # ─────────────────────────────────────────────────────────────────────────────
@@ -147,7 +146,9 @@ def native_ry_circuit():
 @pytest.mark.integration
 @pytest.mark.vqc
 class TestTrainNativeBackend:
-    def test_train_de_with_native_backend(self, native_ry_circuit, simple_expectation_fn):
+    def test_train_de_with_native_backend(
+        self, native_ry_circuit, simple_expectation_fn
+    ):
         import polypus
 
         result = polypus.train(

--- a/tests/python/test_local_run.py
+++ b/tests/python/test_local_run.py
@@ -9,7 +9,6 @@ These tests require qiskit-aer to be installed. They are marked with the
 
 import pytest
 
-
 pytestmark = pytest.mark.integration
 
 
@@ -19,37 +18,55 @@ class TestRunQuantumCircuitSingleQpu:
 
     def test_returns_list(self, bell_circuit):
         import polypus
-        result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
+
+        result = polypus.run_quantum_circuit(
+            bell_circuit, shots=100, infrastructure="local"
+        )
         assert isinstance(result, list), f"Expected list, got {type(result)}"
 
     def test_returns_one_element(self, bell_circuit):
         import polypus
-        result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
+
+        result = polypus.run_quantum_circuit(
+            bell_circuit, shots=100, infrastructure="local"
+        )
         assert len(result) == 1
 
     def test_element_is_dict(self, bell_circuit):
         import polypus
-        result = polypus.run_quantum_circuit(bell_circuit, shots=100, infrastructure="local")
+
+        result = polypus.run_quantum_circuit(
+            bell_circuit, shots=100, infrastructure="local"
+        )
         assert isinstance(result[0], dict)
 
     def test_only_bell_states(self, bell_circuit):
         """A Bell circuit can only produce '00' or '11'."""
         import polypus
-        result = polypus.run_quantum_circuit(bell_circuit, shots=1000, infrastructure="local")
+
+        result = polypus.run_quantum_circuit(
+            bell_circuit, shots=1000, infrastructure="local"
+        )
         assert set(result[0].keys()).issubset({"00", "11"}), (
             f"Unexpected bitstrings in Bell result: {result[0].keys()}"
         )
 
     def test_total_shots(self, bell_circuit):
         import polypus
+
         shots = 512
-        result = polypus.run_quantum_circuit(bell_circuit, shots=shots, infrastructure="local")
+        result = polypus.run_quantum_circuit(
+            bell_circuit, shots=shots, infrastructure="local"
+        )
         assert sum(result[0].values()) == shots
 
     def test_both_bell_states_observed(self, bell_circuit):
         """With 1000 shots both '00' and '11' should appear."""
         import polypus
-        result = polypus.run_quantum_circuit(bell_circuit, shots=1000, infrastructure="local")
+
+        result = polypus.run_quantum_circuit(
+            bell_circuit, shots=1000, infrastructure="local"
+        )
         counts = result[0]
         assert "00" in counts and "11" in counts
 
@@ -60,13 +77,17 @@ class TestRunQuantumCircuitMultipleQpus:
 
     def test_distributed_returns_dict(self, bell_circuit):
         import polypus
+
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=400, infrastructure="local", n_qpus=4
         )
-        assert isinstance(result, dict), f"Expected merged dict for n_qpus>1, got {type(result)}"
+        assert isinstance(result, dict), (
+            f"Expected merged dict for n_qpus>1, got {type(result)}"
+        )
 
     def test_distributed_only_bell_states(self, bell_circuit):
         import polypus
+
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=400, infrastructure="local", n_qpus=4
         )
@@ -76,6 +97,7 @@ class TestRunQuantumCircuitMultipleQpus:
 
     def test_distributed_total_shots(self, bell_circuit):
         import polypus
+
         shots = 400
         result = polypus.run_quantum_circuit(
             bell_circuit, shots=shots, infrastructure="local", n_qpus=4

--- a/tests/python/test_native_circuit.py
+++ b/tests/python/test_native_circuit.py
@@ -13,7 +13,6 @@ import math
 
 import pytest
 
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Construction + QASM export (no backend required)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -22,6 +21,7 @@ import pytest
 class TestCircuitConstruction:
     def test_builder_chains(self):
         import polypus
+
         qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
         assert qc.num_qubits == 2
         assert qc.num_params == 0
@@ -29,16 +29,19 @@ class TestCircuitConstruction:
 
     def test_param_tracking(self):
         import polypus
+
         qc = polypus.Circuit(2).rx(0, polypus.Param(0)).rzz(0, 1, polypus.Param(1))
         assert qc.num_params == 2
 
     def test_fixed_angles_accept_ints_and_floats(self):
         import polypus
+
         qc = polypus.Circuit(1).rx(0, 1).ry(0, 0.5)
         assert qc.num_params == 0
 
     def test_to_qasm2_header_and_gates(self):
         import polypus
+
         qasm = polypus.Circuit(2).h(0).cx(0, 1).measure_all().to_qasm2()
         assert qasm.startswith('OPENQASM 2.0;\ninclude "qelib1.inc";')
         assert "h q[0];" in qasm
@@ -47,16 +50,20 @@ class TestCircuitConstruction:
 
     def test_to_qasm2_binds_params(self):
         import polypus
+
         qc = polypus.Circuit(1).ry(0, polypus.Param(0)).measure_all()
         qasm = qc.to_qasm2([math.pi])
         assert f"ry({math.pi:.12f}) q[0];" in qasm
 
     def test_qiskit_parses_generated_qasm(self):
-        from qiskit import QuantumCircuit
         import polypus
+        from qiskit import QuantumCircuit
+
         qasm = (
             polypus.Circuit(3)
-            .h(0).h(1).h(2)
+            .h(0)
+            .h(1)
+            .h(2)
             .rzz(0, 1, polypus.Param(0))
             .rx(2, polypus.Param(1))
             .measure_all()
@@ -68,12 +75,14 @@ class TestCircuitConstruction:
 
     def test_to_qir_exports_text_module(self):
         import polypus
+
         qir = polypus.Circuit(2).h(0).cx(0, 1).measure_all().to_qir()
         assert qir.startswith("; ModuleID = 'polypus'")
         assert "define void @main()" in qir
 
     def test_to_qir_bitcode_returns_bytes_when_llvm_as_available(self):
         import polypus
+
         try:
             bitcode = polypus.Circuit(2).h(0).cx(0, 1).measure_all().to_qir_bitcode()
         except ValueError as exc:
@@ -86,33 +95,39 @@ class TestCircuitConstruction:
 
     def test_to_qir_bitcode_wrong_param_count_raises_valueerror(self):
         import polypus
+
         qc = polypus.Circuit(1).rx(0, polypus.Param(0))
         with pytest.raises(ValueError, match="wrong number of parameter"):
             qc.to_qir_bitcode([])
 
     def test_qubit_out_of_range_raises_valueerror(self):
         import polypus
+
         with pytest.raises(ValueError, match="out of range"):
             polypus.Circuit(2).h(5)
 
     def test_identical_qubits_raises_valueerror(self):
         import polypus
+
         with pytest.raises(ValueError, match="distinct"):
             polypus.Circuit(2).cx(1, 1)
 
     def test_wrong_param_count_raises_valueerror(self):
         import polypus
+
         qc = polypus.Circuit(1).rx(0, polypus.Param(0))
         with pytest.raises(ValueError, match="wrong number of parameter"):
             qc.to_qasm2([0.1, 0.2])
 
     def test_bad_angle_type_raises_typeerror(self):
         import polypus
+
         with pytest.raises(TypeError):
             polypus.Circuit(1).rx(0, "not-an-angle")
 
     def test_param_repr_and_index(self):
         import polypus
+
         p = polypus.Param(3)
         assert p.index == 3
         assert repr(p) == "Param(3)"
@@ -126,6 +141,7 @@ class TestCircuitConstruction:
 @pytest.fixture
 def native_bell_circuit():
     import polypus
+
     return polypus.Circuit(2).h(0).cx(0, 1).measure_all()
 
 
@@ -133,6 +149,7 @@ def native_bell_circuit():
 class TestRunNativeCircuit:
     def test_native_single_qpu(self, native_bell_circuit):
         import polypus
+
         result = polypus.run_quantum_circuit(
             native_bell_circuit, shots=1000, infrastructure="local"
         )
@@ -143,6 +160,7 @@ class TestRunNativeCircuit:
 
     def test_native_distributed(self, native_bell_circuit):
         import polypus
+
         result = polypus.run_quantum_circuit(
             native_bell_circuit, shots=400, infrastructure="local", n_qpus=4
         )
@@ -152,6 +170,7 @@ class TestRunNativeCircuit:
 
     def test_qasm_string_input(self, native_bell_circuit):
         import polypus
+
         qasm = native_bell_circuit.to_qasm2()
         result = polypus.run_quantum_circuit(qasm, shots=500, infrastructure="local")
         counts = result[0]
@@ -160,13 +179,17 @@ class TestRunNativeCircuit:
 
     def test_unbound_circuit_raises(self):
         import polypus
+
         qc = polypus.Circuit(1).ry(0, polypus.Param(0)).measure_all()
         with pytest.raises(ValueError, match="unbound parameters"):
             polypus.run_quantum_circuit(qc, shots=100, infrastructure="local")
 
-    def test_native_matches_qiskit_distribution(self, native_bell_circuit, bell_circuit):
+    def test_native_matches_qiskit_distribution(
+        self, native_bell_circuit, bell_circuit
+    ):
         """Same Bell circuit, both paths: distributions must agree (~50/50)."""
         import polypus
+
         shots = 4000
         native = polypus.run_quantum_circuit(
             native_bell_circuit, shots=shots, infrastructure="local"
@@ -201,6 +224,7 @@ _TRAIN_KW = dict(
 def native_parametrized_circuit():
     """Native equivalent of the Qiskit `parametrized_circuit` fixture."""
     import polypus
+
     return polypus.Circuit(1).ry(0, polypus.Param(0)).measure_all()
 
 
@@ -209,6 +233,7 @@ def native_parametrized_circuit():
 class TestTrainNativeCircuit:
     def test_train_de(self, native_parametrized_circuit, simple_expectation_fn):
         import polypus
+
         result = polypus.train(
             native_parametrized_circuit,
             polypus.DE(generations=2, population_size=4, tolerance=0.5),
@@ -221,6 +246,7 @@ class TestTrainNativeCircuit:
 
     def test_train_pso(self, native_parametrized_circuit, simple_expectation_fn):
         import polypus
+
         result = polypus.train(
             native_parametrized_circuit,
             polypus.PSO(generations=2, population_size=4, bounds=(0.0, math.pi)),
@@ -230,8 +256,11 @@ class TestTrainNativeCircuit:
         )
         assert isinstance(result, list) and len(result) == 1
 
-    def test_train_qng(self, native_parametrized_circuit, simple_expectation_fn, simple_variance_fn):
+    def test_train_qng(
+        self, native_parametrized_circuit, simple_expectation_fn, simple_variance_fn
+    ):
         import polypus
+
         result = polypus.train(
             native_parametrized_circuit,
             polypus.QNG(simple_variance_fn, max_iters=2, bounds=(0.0, math.pi)),
@@ -241,8 +270,11 @@ class TestTrainNativeCircuit:
         )
         assert isinstance(result, list) and len(result) == 1
 
-    def test_dimension_mismatch_raises_before_training(self, native_parametrized_circuit, simple_expectation_fn):
+    def test_dimension_mismatch_raises_before_training(
+        self, native_parametrized_circuit, simple_expectation_fn
+    ):
         import polypus
+
         kwargs = dict(_TRAIN_KW)
         kwargs["dimensions"] = 3  # circuit has 1 free param
         with pytest.raises(ValueError, match="does not match"):
@@ -259,23 +291,32 @@ class TestTrainNativeCircuit:
     ):
         """RY(θ) with all-ones objective drives θ → π on both paths."""
         import polypus
-        method = lambda: polypus.DE(generations=10, population_size=10, tolerance=1e-9)
+
+        def method():
+            return polypus.DE(generations=10, population_size=10, tolerance=1e-9)
+
         kwargs = dict(_TRAIN_KW)
         kwargs["shots"] = 512
 
         theta_native = polypus.train(
-            native_parametrized_circuit, method(),
+            native_parametrized_circuit,
+            method(),
             expectation_function=simple_expectation_fn,
-            id="test_native_conv", **kwargs,
+            id="test_native_conv",
+            **kwargs,
         )[0]
         theta_qiskit = polypus.train(
-            parametrized_circuit, method(),
+            parametrized_circuit,
+            method(),
             expectation_function=simple_expectation_fn,
-            id="test_qiskit_conv", **kwargs,
+            id="test_qiskit_conv",
+            **kwargs,
         )[0]
 
         # Both must approach θ = π (probability of |1⟩ maximised).
         p1 = math.sin(theta_native / 2) ** 2
         p1_qiskit = math.sin(theta_qiskit / 2) ** 2
-        assert p1 > 0.9, f"native path did not converge: θ={theta_native:.3f}, p1={p1:.3f}"
+        assert p1 > 0.9, (
+            f"native path did not converge: θ={theta_native:.3f}, p1={p1:.3f}"
+        )
         assert p1_qiskit > 0.9, f"qiskit path did not converge: θ={theta_qiskit:.3f}"

--- a/tests/python/test_qasm_import.py
+++ b/tests/python/test_qasm_import.py
@@ -12,7 +12,6 @@ import math
 
 import pytest
 
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Circuit.from_qasm2 (no backend required)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -21,9 +20,12 @@ import pytest
 class TestQasmImport:
     def test_roundtrip_is_byte_stable(self):
         import polypus
+
         qc = (
             polypus.Circuit(3)
-            .h(0).h(1).h(2)
+            .h(0)
+            .h(1)
+            .h(2)
             .rzz(0, 1, polypus.Param(0))
             .rx(2, polypus.Param(1))
             .u(0, 0.1, 0.2, 0.3)
@@ -36,6 +38,7 @@ class TestQasmImport:
 
     def test_import_is_fully_concrete(self):
         import polypus
+
         qasm = polypus.Circuit(1).ry(0, polypus.Param(0)).to_qasm2([math.pi])
         imported = polypus.Circuit.from_qasm2(qasm)
         assert imported.num_params == 0
@@ -44,6 +47,7 @@ class TestQasmImport:
     def test_imports_qiskit_dumps_output(self):
         import polypus
         from qiskit import QuantumCircuit, qasm2
+
         qk = QuantumCircuit(2)
         qk.h(0)
         qk.cx(0, 1)
@@ -58,6 +62,7 @@ class TestQasmImport:
 
     def test_imported_circuit_extends_with_builder(self):
         import polypus
+
         qasm = polypus.Circuit(2).h(0).cx(0, 1).to_qasm2()
         qc = polypus.Circuit.from_qasm2(qasm).rz(1, 0.5).measure_all()
         out = qc.to_qasm2()
@@ -66,17 +71,20 @@ class TestQasmImport:
 
     def test_parse_error_carries_line_number(self):
         import polypus
-        src = 'OPENQASM 2.0;\nqreg q[2];\nccz q[0],q[1];\n'
+
+        src = "OPENQASM 2.0;\nqreg q[2];\nccz q[0],q[1];\n"
         with pytest.raises(ValueError, match=r"line 3.*unsupported gate 'ccz'"):
             polypus.Circuit.from_qasm2(src)
 
     def test_rejects_qasm3(self):
         import polypus
+
         with pytest.raises(ValueError, match="version 2.0"):
             polypus.Circuit.from_qasm2("OPENQASM 3.0;\n")
 
     def test_rejects_out_of_range_index(self):
         import polypus
+
         with pytest.raises(ValueError, match="out of range"):
             polypus.Circuit.from_qasm2("OPENQASM 2.0;\nqreg q[2];\nh q[7];\n")
 
@@ -87,6 +95,7 @@ class TestRunImportedCircuit:
         """from_qasm2(Qiskit Bell) executes with the expected distribution."""
         import polypus
         from qiskit import QuantumCircuit, qasm2
+
         qk = QuantumCircuit(2)
         qk.h(0)
         qk.cx(0, 1)
@@ -125,16 +134,12 @@ class TestAerBatching:
         monkeypatch.setattr(local_mod, "AerSimulator", SpySimulator)
 
         population, generations = 8, 2
-        qc = (
-            polypus.Circuit(2)
-            .ry(0, polypus.Param(0))
-            .cx(0, 1)
-            .measure_all()
-        )
+        qc = polypus.Circuit(2).ry(0, polypus.Param(0)).cx(0, 1).measure_all()
         polypus.train(
             qc,
-            polypus.DE(generations=generations, population_size=population,
-                       tolerance=1e-12),
+            polypus.DE(
+                generations=generations, population_size=population, tolerance=1e-12
+            ),
             shots=128,
             n_qpus=1,
             dimensions=1,

--- a/tests/python/test_smoke.py
+++ b/tests/python/test_smoke.py
@@ -5,14 +5,12 @@ and that all expected public symbols are present and callable/instantiable.
 These tests do NOT execute any quantum circuit; they only check the installation.
 """
 
-import importlib
-import inspect
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # polypus (Rust/PyO3 extension)
 # ---------------------------------------------------------------------------
+
 
 class TestPolypusImport:
     def test_import_polypus(self):
@@ -20,30 +18,36 @@ class TestPolypusImport:
 
     def test_run_quantum_circuit_exists(self):
         import polypus
+
         assert hasattr(polypus, "run_quantum_circuit")
         assert callable(polypus.run_quantum_circuit)
 
     def test_train_exists(self):
         import polypus
+
         assert hasattr(polypus, "train")
         assert callable(polypus.train)
 
     def test_DE_class_exists(self):
         import polypus
+
         assert hasattr(polypus, "DE")
 
     def test_PSO_class_exists(self):
         import polypus
+
         assert hasattr(polypus, "PSO")
 
     def test_QNG_class_exists(self):
         import polypus
+
         assert hasattr(polypus, "QNG")
 
 
 class TestPolypusInstantiation:
     def test_DE_default_instantiation(self):
         import polypus
+
         de = polypus.DE()
         assert de.generations == 100
         assert de.population_size == 50
@@ -51,6 +55,7 @@ class TestPolypusInstantiation:
 
     def test_DE_custom_instantiation(self):
         import polypus
+
         de = polypus.DE(generations=10, population_size=5, tolerance=0.05)
         assert de.generations == 10
         assert de.population_size == 5
@@ -58,12 +63,14 @@ class TestPolypusInstantiation:
 
     def test_PSO_default_instantiation(self):
         import polypus
+
         pso = polypus.PSO()
         assert pso.generations == 100
         assert pso.population_size == 50
 
     def test_PSO_custom_instantiation(self):
         import polypus
+
         pso = polypus.PSO(generations=20, population_size=10, bounds=(-3.14, 3.14))
         assert pso.generations == 20
         assert pso.population_size == 10
@@ -97,46 +104,55 @@ class TestPolypusInstantiation:
 # polypus_python (pure Python wrapper)
 # ---------------------------------------------------------------------------
 
+
 class TestPolypusPythonImport:
     def test_import_polypus_python(self):
         import polypus_python  # noqa: F401
 
     def test_run_qc_in_qpu_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "run_qc_in_qpu")
         assert callable(polypus_python.run_qc_in_qpu)
 
     def test_run_qcs_in_qpu_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "run_qcs_in_qpu")
         assert callable(polypus_python.run_qcs_in_qpu)
 
     def test_serialize_quantum_circuit_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "serialize_quantum_circuit")
         assert callable(polypus_python.serialize_quantum_circuit)
 
     def test_build_qaoa_circuit_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "build_qaoa_circuit")
         assert callable(polypus_python.build_qaoa_circuit)
 
     def test_expectation_value_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "expectation_value")
         assert callable(polypus_python.expectation_value)
 
     def test_expectation_values_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "expectation_values")
         assert callable(polypus_python.expectation_values)
 
     def test_connect_to_infrastructure_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "connect_to_infrastructure")
         assert callable(polypus_python.connect_to_infrastructure)
 
     def test_disconnect_from_infrastructure_exists(self):
         import polypus_python
+
         assert hasattr(polypus_python, "disconnect_from_infrastructure")
         assert callable(polypus_python.disconnect_from_infrastructure)

--- a/tests/python/test_statevector.py
+++ b/tests/python/test_statevector.py
@@ -30,8 +30,7 @@ def _compare(polypus_amps, qc, atol=1e-10):
     ref = Statevector(qc).data
     assert got.shape == ref.shape, f"shape {got.shape} != {ref.shape}"
     assert np.allclose(got, ref, atol=atol), (
-        f"\npolypus = {np.round(got, 4)}"
-        f"\nqiskit  = {np.round(ref, 4)}"
+        f"\npolypus = {np.round(got, 4)}\nqiskit  = {np.round(ref, 4)}"
     )
 
 

--- a/tests/python/test_vqc.py
+++ b/tests/python/test_vqc.py
@@ -13,9 +13,9 @@ Skip all integration tests (including VQC):
     pytest -m "not integration"
 """
 
-import pytest
 import math
 
+import pytest
 
 pytestmark = [pytest.mark.integration, pytest.mark.vqc]
 
@@ -30,6 +30,7 @@ _CORES_PER_QPU = 1
 class TestTrainDE:
     def test_train_returns_list(self, parametrized_circuit, simple_expectation_fn):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.DE(generations=2, population_size=4, tolerance=0.5),
@@ -42,10 +43,13 @@ class TestTrainDE:
             cores_per_qpu=_CORES_PER_QPU,
             id="test_de",
         )
-        assert isinstance(result, list), f"Expected list of parameters, got {type(result)}"
+        assert isinstance(result, list), (
+            f"Expected list of parameters, got {type(result)}"
+        )
 
     def test_train_result_length(self, parametrized_circuit, simple_expectation_fn):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.DE(generations=2, population_size=4, tolerance=0.5),
@@ -60,8 +64,11 @@ class TestTrainDE:
         )
         assert len(result) == _DIMENSIONS
 
-    def test_train_result_contains_floats(self, parametrized_circuit, simple_expectation_fn):
+    def test_train_result_contains_floats(
+        self, parametrized_circuit, simple_expectation_fn
+    ):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.DE(generations=2, population_size=4, tolerance=0.5),
@@ -81,6 +88,7 @@ class TestTrainDE:
 class TestTrainPSO:
     def test_train_returns_list(self, parametrized_circuit, simple_expectation_fn):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.PSO(generations=2, population_size=4, bounds=(0.0, math.pi)),
@@ -97,6 +105,7 @@ class TestTrainPSO:
 
     def test_train_result_length(self, parametrized_circuit, simple_expectation_fn):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.PSO(generations=2, population_size=4, bounds=(0.0, math.pi)),
@@ -117,6 +126,7 @@ class TestTrainQNG:
         self, parametrized_circuit, simple_expectation_fn, simple_variance_fn
     ):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.QNG(
@@ -140,6 +150,7 @@ class TestTrainQNG:
         self, parametrized_circuit, simple_expectation_fn, simple_variance_fn
     ):
         import polypus
+
         result = polypus.train(
             parametrized_circuit,
             polypus.QNG(
@@ -160,8 +171,11 @@ class TestTrainQNG:
 
 
 class TestTrainInvalidMethod:
-    def test_invalid_method_raises_type_error(self, parametrized_circuit, simple_expectation_fn):
+    def test_invalid_method_raises_type_error(
+        self, parametrized_circuit, simple_expectation_fn
+    ):
         import polypus
+
         with pytest.raises(TypeError):
             polypus.train(
                 parametrized_circuit,
@@ -187,6 +201,7 @@ class TestTrainInvalidConfig:
         self, parametrized_circuit, simple_expectation_fn
     ):
         import polypus
+
         with pytest.raises(ValueError):
             polypus.train(
                 parametrized_circuit,
@@ -205,6 +220,7 @@ class TestTrainInvalidConfig:
         self, parametrized_circuit, simple_expectation_fn
     ):
         import polypus
+
         with pytest.raises(ValueError):
             polypus.train(
                 parametrized_circuit,


### PR DESCRIPTION
CI additions (.github/workflows/ci.yml):
- cargo-deny job (advisories, licenses, bans, sources per deny.toml)
- ruff job: Python lint + format check (config in [tool.ruff])
- MSRV job pinned to 1.85 (declared as rust-version in the workspace)
- Python matrix 3.9 + 3.13 in python-tests; build-extension now also runs on macOS and Windows
- docs job checks the whole workspace, not just -p polypus
- read-only token permissions, timeout-minutes on every job
- compile-check of examples/ and benchmarks/ (no __main__ guards, so they are compiled, not executed)
- .github/dependabot.yml keeps the actions up to date

Metadata fixes surfaced by the new checks:
- requires-python floor corrected to >=3.9 (qiskit>=2.0 needs it)
- workspace license normalized to the SPDX id EUPL-1.2 (full text stays in LICENSE); prose form was unparseable by cargo-deny/crates.io
- RUSTSEC-2026-0176/0177 (pyo3 0.24) ignored in deny.toml with documented reasons — neither vulnerable API is used here

Real bugs found by ruff F821 and fixed:
- polypus_python/running_functions.py: three except blocks logged an unbound `e` (NameError on the error path); get_QPUs/gather used without importing them, plus a getQPUs/get_QPUs typo
- polypus_python/connectivity.py: Cunqa used with its import commented out; now lazily imported so the cunqa dep stays optional

Plus ruff format across packages/, tests/, benchmarks/, examples/ and removal of dead locals (F841).