### PR TITLE
fix(bindings): make run_quantum_circuit's auto-generated id unique (#45)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,5 @@ polypus-logger     = { path = "crates/polypus-logger", version = "0.6.0" }
 # `log` is the logging facade every crate emits through; the concrete sink lives
 # in `polypus-logger`, which additionally enables its `std` feature.
 log                = "0.4"
+# UUID v4 for run-id uniqueness (bindings layer); `v4` pulls the RNG feature.
+uuid               = { version = "1", features = ["v4"] }

--- a/crates/polypus/Cargo.toml
+++ b/crates/polypus/Cargo.toml
@@ -39,6 +39,7 @@ ndarray = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = { workspace = true }
+uuid = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "time", "sync", "macros"] }
 # --- optional, only compiled with `--features qmio` ---
 # Pure-Rust ZeroMQ (ZMTP 3.x, interoperable with pyzmq/libzmq); avoids a C

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -30,6 +30,7 @@ use polypus_optimizers::{
     OptimizerError,
 };
 use std::sync::Arc;
+use uuid::Uuid;
 
 /// Result of [`run_quantum_circuit`]: the measurement counts plus the run
 /// manifest that lets a run be logged and replayed (contract C-7).
@@ -409,7 +410,12 @@ pub fn run_quantum_circuit<'py>(
         Some(seed.unwrap_or_else(random_seed))
     };
 
-    let id = format!("run_{}_{}", n_qpus, infrastructure);
+    // Append a UUID v4 so two concurrent calls with identical `n_qpus`/
+    // `infrastructure` never collide: the id names SLURM families/allocations,
+    // temp files and log streams (see ExecutionConfig::id), so a byte-identical
+    // id across runs is a real hazard, not a cosmetic one. The `run_{n}_{infra}`
+    // prefix is kept for human-readable debuggability.
+    let id = format!("run_{}_{}_{}", n_qpus, infrastructure, Uuid::new_v4());
     let backend_config = build_backend_config(
         &infrastructure,
         backend,
@@ -1001,7 +1007,14 @@ mod tests {
             let get = |name: &str| bound.getattr(name).unwrap().extract::<String>().unwrap();
             assert_eq!(get("backend"), "polypus");
             assert_eq!(get("infrastructure"), "local");
-            assert_eq!(get("id"), "run_1_local");
+            // The id keeps the human-readable `run_{n}_{infra}_` prefix but is
+            // suffixed with a per-call UUID (see the uniqueness test below), so
+            // only the stable prefix is asserted here.
+            assert!(
+                get("id").starts_with("run_1_local_"),
+                "id must keep the run_{{n}}_{{infra}}_ prefix, got {}",
+                get("id")
+            );
             assert_eq!(
                 bound
                     .getattr("seed")
@@ -1009,6 +1022,46 @@ mod tests {
                     .extract::<Option<u64>>()
                     .unwrap(),
                 Some(7)
+            );
+        });
+    }
+
+    /// Regression for #45: two runs with identical arguments must not share an
+    /// id. The id names SLURM families/allocations, temp files and log streams,
+    /// so a collision (as with the old `run_{n}_{infra}` format) could make two
+    /// concurrent runs clobber one another. The per-call UUID v4 guarantees
+    /// uniqueness while the `run_1_local_` prefix stays stable for debugging.
+    #[test]
+    fn auto_generated_id_is_unique_per_call() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let qasm = uniform3_qasm();
+            let id_of = || {
+                let qc = PyString::new(py, &qasm).into_any();
+                let result = run_quantum_circuit(
+                    qc,
+                    100,
+                    "local".to_string(),
+                    1,
+                    "automatic",
+                    None,
+                    "polypus",
+                    Some(7),
+                )
+                .expect("native run succeeds");
+                result
+                    .bind(py)
+                    .getattr("id")
+                    .unwrap()
+                    .extract::<String>()
+                    .unwrap()
+            };
+            let id1 = id_of();
+            let id2 = id_of();
+            assert!(id1.starts_with("run_1_local_") && id2.starts_with("run_1_local_"));
+            assert_ne!(
+                id1, id2,
+                "ids from identical calls must differ (unique per run)"
             );
         });
     }

--- a/tests/python/test_seed_reproducibility.py
+++ b/tests/python/test_seed_reproducibility.py
@@ -86,8 +86,25 @@ class TestRunQuantumCircuitSeed:
         assert r.seed == 7
         assert r.backend == "polypus"
         assert r.infrastructure == "local"
-        assert r.id == "run_1_local"
+        # The id keeps the human-readable `run_{n_qpus}_{infra}_` prefix but is
+        # suffixed with a per-call UUID for uniqueness (see test_id_is_unique),
+        # so only the stable prefix is asserted here.
+        assert r.id.startswith("run_1_local_")
         assert isinstance(r.counts, list) and len(r.counts) == 1
+
+    def test_id_is_unique_across_identical_calls(self):
+        # Regression for #45: the auto-generated run id must be unique per call.
+        # Two runs with identical arguments used to collide on `run_{n}_{infra}`,
+        # which names SLURM families/allocations, temp files and log streams.
+        import polypus
+
+        qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
+        kwargs = dict(shots=100, infrastructure="local", backend="polypus", seed=7)
+        r1 = polypus.run_quantum_circuit(qc, **kwargs)
+        r2 = polypus.run_quantum_circuit(qc, **kwargs)
+        assert r1.id.startswith("run_1_local_")
+        assert r2.id.startswith("run_1_local_")
+        assert r1.id != r2.id
 
     def test_seed_rejected_for_qmio(self):
         import polypus


### PR DESCRIPTION
The id is auto-generated as run_{n_qpus}_{infrastructure}, so two calls with identical n_qpus/infrastructure produced byte-identical ids. This id names SLURM families/allocations, temp files and log streams (ExecutionConfig::id), so concurrent runs could collide on a real resource.

Append a UUID v4 (run_{n}_{infra}_{uuid}), keeping the human-readable prefix for debuggability. Add the uuid crate (v4) as a shared workspace dependency, wired into crates/polypus. C-1 freezes only the seam kwarg names/types, not the id content, so no contract edit is needed.