### PR TITLE
fix(evaluation): validate oracle expectation_values length and finiteness (C-5)

### DIFF
--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -34,6 +34,12 @@ pub enum EvaluationError {
     /// A Python callback or conversion on the evaluation path raised. Carried
     /// verbatim so the original exception type is preserved across the FFI.
     Python(PyErr),
+    /// The Python-backed oracle returned a different number of expectation
+    /// values than circuits were submitted in this call (contract C-5).
+    WrongLength { expected: usize, got: usize },
+    /// The Python-backed oracle returned a non-finite expectation value
+    /// (contract C-5 requires every output to be a finite f64).
+    NonFinite { index: usize, value: f64 },
 }
 
 impl fmt::Display for EvaluationError {
@@ -42,6 +48,14 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Backend(err) => write!(f, "{err}"),
             EvaluationError::Binding(err) => write!(f, "circuit binding failed: {err}"),
             EvaluationError::Python(err) => write!(f, "Python evaluation error: {err}"),
+            EvaluationError::WrongLength { expected, got } => write!(
+                f,
+                "oracle returned the wrong number of expectation values: expected {expected} (one per submitted circuit) but got {got} (contract C-5)"
+            ),
+            EvaluationError::NonFinite { index, value } => write!(
+                f,
+                "oracle returned a non-finite expectation value {value} at index {index}; contract C-5 requires every output to be a finite f64"
+            ),
         }
     }
 }
@@ -63,6 +77,43 @@ impl From<EvaluationError> for PyErr {
             }
             // Preserve the original Python exception type raised by the callback.
             EvaluationError::Python(py_err) => py_err,
+            wrong_length @ EvaluationError::WrongLength { .. } => {
+                PyEvaluationError::new_err(wrong_length.to_string())
+            }
+            non_finite @ EvaluationError::NonFinite { .. } => {
+                PyEvaluationError::new_err(non_finite.to_string())
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests are deliberately Python-runtime-free (ENGINEERING.md §3): the
+    // `polypus` crate's test suite runs without an initialized interpreter, so
+    // we exercise `Display` only and never construct a `PyErr` / call `.into()`.
+
+    #[test]
+    fn wrong_length_display_names_both_lengths() {
+        let msg = EvaluationError::WrongLength {
+            expected: 4,
+            got: 2,
+        }
+        .to_string();
+        assert!(msg.contains('4'), "expected length missing from: {msg}");
+        assert!(msg.contains('2'), "got length missing from: {msg}");
+    }
+
+    #[test]
+    fn non_finite_display_names_index_and_value() {
+        let msg = EvaluationError::NonFinite {
+            index: 3,
+            value: f64::NAN,
+        }
+        .to_string();
+        assert!(msg.contains('3'), "offending index missing from: {msg}");
+        assert!(msg.contains("NaN"), "offending value missing from: {msg}");
     }
 }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -176,11 +176,29 @@ pub(crate) fn run_and_evaluate(
         // Python `expectation_values` function. Once expectation computation is
         // also native this round-trip disappears entirely.
         let py_counts = counts.into_pyobject(py).map_err(EvaluationError::Python)?;
-        PyModule::import(py, "polypus_python")
+        let values = PyModule::import(py, "polypus_python")
             .map_err(EvaluationError::Python)?
             .call_method("expectation_values", (py_counts, expectation_fn), None)
             .map_err(EvaluationError::Python)?
             .extract::<Vec<f64>>()
-            .map_err(EvaluationError::Python)
+            .map_err(EvaluationError::Python)?;
+
+        // Contract C-5: the Python-backed oracle must return exactly one finite
+        // f64 per submitted circuit. This is the single choke point that calls
+        // `polypus_python.expectation_values`, so validating here protects every
+        // oracle: a short list would otherwise index out of bounds inside the
+        // pure-Rust optimizer (an uncatchable `PanicException` across the FFI),
+        // and a NaN/inf would silently poison the optimizer and yield a bogus
+        // result with no error at all.
+        if values.len() != qcs.len() {
+            return Err(EvaluationError::WrongLength {
+                expected: qcs.len(),
+                got: values.len(),
+            });
+        }
+        if let Some((index, &value)) = values.iter().enumerate().find(|(_, v)| !v.is_finite()) {
+            return Err(EvaluationError::NonFinite { index, value });
+        }
+        Ok(values)
     })
 }

--- a/crates/polypus/src/evaluation/qml_oracle.rs
+++ b/crates/polypus/src/evaluation/qml_oracle.rs
@@ -139,5 +139,21 @@ fn evaluate_qml_single(
         all_ev.extend(ev);
     }
 
+    // Defense-in-depth (contract C-5): `run_and_evaluate` already guarantees
+    // exactly `chunk.len()` values per chunk, and the chunks partition `bound`
+    // exactly, so this can only ever hold. Unlike `VqcOracle` this function
+    // returns one scalar per *candidate* (the mean over the training circuits),
+    // so the invariant here is `all_ev.len() == bound.len()` (one expectation
+    // per training circuit), not `candidates.len()`. Kept as an explicit,
+    // self-documenting invariant guarding the mean below — do not "simplify" it
+    // away. Reported as a `Result`, never a panic (rule 4; runs under
+    // `OracleErrorSlot`).
+    if all_ev.len() != bound.len() {
+        return Err(EvaluationError::WrongLength {
+            expected: bound.len(),
+            got: all_ev.len(),
+        });
+    }
+
     Ok(all_ev.iter().sum::<f64>() / all_ev.len() as f64)
 }

--- a/crates/polypus/src/evaluation/vqc_oracle.rs
+++ b/crates/polypus/src/evaluation/vqc_oracle.rs
@@ -74,6 +74,21 @@ impl VqcOracle {
             )?;
             results.extend(ev);
         }
+
+        // Defense-in-depth (contract C-5): `run_and_evaluate` already guarantees
+        // exactly `chunk.len()` values per chunk, and the chunks partition
+        // `bound` (== `candidates`) exactly, so this can only ever hold. It is
+        // kept as an explicit, self-documenting invariant at the point where the
+        // per-candidate results are finally assembled — do not "simplify" it away
+        // on the assumption the centralized check is enough. As with that path,
+        // report it as a `Result` rather than panicking (rule 4: FFI errors are
+        // `PyErr`/`Result`, and this runs under `OracleErrorSlot`).
+        if results.len() != candidates.len() {
+            return Err(EvaluationError::WrongLength {
+                expected: candidates.len(),
+                got: results.len(),
+            });
+        }
         Ok(results)
     }
 }

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -24,7 +24,7 @@ Rules of the road:
 | C-2 | Gate vocabulary symmetry | `polypus-circuit` + `polypus-sim` `tests/contracts.rs` | ✅ present | — |
 | C-3 | Measurement counts format | shot-conservation + last-write-wins | ✅ present | shots dropped on uneven distribution (C6) |
 | C-4 | Terminal measurement placement | `polypus-circuit` + `polypus-sim` `tests/contracts.rs` | ✅ present | — |
-| C-5 | Optimizer ↔ oracle | invariant test, multi-seed | ✅ present | DE `best_fitness` mismatch (C4) |
+| C-5 | Optimizer ↔ oracle | invariant test, multi-seed + `tests/python/test_oracle_contract.py` | ✅ present | DE `best_fitness` mismatch (C4) |
 | C-6 | Version coherence | `hygiene.yml` version step | ✅ present | tag/Cargo diverged at 0.6.0 |
 | C-7 | Seeding & run manifest | `tests/python/test_seed_reproducibility.py` + bindings/native Rust tests | ✅ present | repeated runs byte-identical / `train` seed hardcoded `None` (#34) |
 
@@ -210,7 +210,14 @@ and `crates/polypus-sim/tests/contracts.rs` (simulator).
   the returned `best_params`** (audit C4).
 
 **Enforcing test:** invariant test with multiple seeds in
-`crates/polypus-optimizers/tests/`.
+`crates/polypus-optimizers/tests/` (the pure-Rust optimizer↔oracle invariant),
+**plus** `tests/python/test_oracle_contract.py` for the Python-backed length and
+finiteness guarantee: the Rust invariant test never exercises the
+`polypus_python.expectation_values` return path, so it covers only one half of
+the contract. The Python test forces a short return list and a non-finite value
+through `polypus.train` and asserts each surfaces as a typed
+`polypus.EvaluationError` (naming both lengths, or the offending index/value),
+never a `pyo3_runtime.PanicException` and never a silently-poisoned result.
 
 ---
 

--- a/tests/python/test_oracle_contract.py
+++ b/tests/python/test_oracle_contract.py
@@ -1,0 +1,162 @@
+"""
+Enforcing test for contract C-5 (optimizer ↔ oracle) at the Rust↔Python seam.
+
+C-5 requires ``EvaluationOracle::evaluate_batch`` to return exactly
+``candidates.len()`` **finite** ``f64`` values, and states explicitly that
+"Python-backed oracles must validate length before returning across the FFI".
+The single choke point that calls ``polypus_python.expectation_values`` lives in
+``crates/polypus/src/evaluation/mod.rs`` (``run_and_evaluate``); this test drives
+both failure modes through the public ``polypus.train`` entry point and locks in
+that they surface as a typed ``polypus.EvaluationError`` — never a
+``pyo3_runtime.PanicException`` and never a silently-poisoned result:
+
+* a **short** return list would otherwise index out of bounds inside the
+  pure-Rust optimizer → panic → uncatchable ``PanicException`` across the FFI
+  (the failure mode #35 / PR #58 eliminated elsewhere);
+* a **non-finite** return value would otherwise silently poison the optimizer
+  and let ``train`` return a bogus ``TrainResult`` with no error at all.
+
+It mirrors the structure and panic-safety style of ``test_seam_contract.py``
+(C-1): monkeypatch the ``polypus_python`` seam to force the failure, then assert
+on the surfaced exception type.
+"""
+
+import math
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.vqc]
+
+# Shared training parameters — kept minimal for speed, matching test_vqc.py.
+_SHOTS = 256
+_N_QPUS = 1
+_DIMENSIONS = 1
+_NODES = 1
+_CORES_PER_QPU = 1
+_POPULATION = 4
+
+
+class TestOracleContractC5:
+    def test_wrong_length_raises_evaluation_error(
+        self, parametrized_circuit, simple_expectation_fn, monkeypatch
+    ):
+        """A short expectation_values list → typed EvaluationError, never a panic.
+
+        Monkeypatch the seam (same pattern as test_seam_contract.py's run_qcs
+        patches) to return one *fewer* value than circuits submitted, so the
+        length mismatch is triggered regardless of how the backend batches.
+        """
+        import polypus
+        import polypus_python
+
+        def short_expectation_values(array_counts, _bitstring_to_obj):
+            # Deliberately drop one value: length != len(array_counts).
+            return [0.0] * (len(array_counts) - 1)
+
+        monkeypatch.setattr(
+            polypus_python, "expectation_values", short_expectation_values
+        )
+
+        with pytest.raises(polypus.EvaluationError):
+            polypus.train(
+                parametrized_circuit,
+                polypus.DE(generations=2, population_size=_POPULATION, tolerance=0.5),
+                shots=_SHOTS,
+                n_qpus=_N_QPUS,
+                dimensions=_DIMENSIONS,
+                expectation_function=simple_expectation_fn,
+                infrastructure="local",
+                nodes=_NODES,
+                cores_per_qpu=_CORES_PER_QPU,
+                id="test_oracle_wrong_length",
+            )
+
+    def test_wrong_length_is_never_a_panic_exception(
+        self, parametrized_circuit, simple_expectation_fn, monkeypatch
+    ):
+        """Whatever the length mismatch does, the caller never sees PanicException.
+
+        Same assertion style as test_seam_contract.py's
+        test_seam_failure_is_never_a_panic_exception.
+        """
+        import polypus
+        import polypus_python
+
+        def short_expectation_values(array_counts, _bitstring_to_obj):
+            return [0.0] * (len(array_counts) - 1)
+
+        monkeypatch.setattr(
+            polypus_python, "expectation_values", short_expectation_values
+        )
+
+        try:
+            polypus.train(
+                parametrized_circuit,
+                polypus.DE(generations=2, population_size=_POPULATION, tolerance=0.5),
+                shots=_SHOTS,
+                n_qpus=_N_QPUS,
+                dimensions=_DIMENSIONS,
+                expectation_function=simple_expectation_fn,
+                infrastructure="local",
+                nodes=_NODES,
+                cores_per_qpu=_CORES_PER_QPU,
+                id="test_oracle_wrong_length_no_panic",
+            )
+        except BaseException as exc:  # noqa: BLE001 - we assert on the type below
+            assert type(exc).__name__ != "PanicException", (
+                "an oracle length violation must not surface as a Rust panic"
+            )
+            assert isinstance(exc, polypus.EvaluationError)
+        else:
+            pytest.fail("expected the short expectation_values list to raise")
+
+    def test_non_finite_value_raises_evaluation_error(self, parametrized_circuit):
+        """A NaN expectation value → typed EvaluationError, not a silent result.
+
+        Deliberately does NOT monkeypatch the seam: the expectation_function
+        returns NaN for every bitstring so the NaN flows through the *real*
+        polypus_python.qaoa_utils.expectation_values averaging code, exactly as
+        it would in production.
+        """
+        import polypus
+
+        def nan_expectation_fn(_bitstring: str) -> float:
+            return float("nan")
+
+        with pytest.raises(polypus.EvaluationError):
+            polypus.train(
+                parametrized_circuit,
+                polypus.DE(generations=2, population_size=_POPULATION, tolerance=0.5),
+                shots=_SHOTS,
+                n_qpus=_N_QPUS,
+                dimensions=_DIMENSIONS,
+                expectation_function=nan_expectation_fn,
+                infrastructure="local",
+                nodes=_NODES,
+                cores_per_qpu=_CORES_PER_QPU,
+                id="test_oracle_non_finite",
+            )
+
+    def test_correct_length_finite_path_still_trains(
+        self, parametrized_circuit, simple_expectation_fn
+    ):
+        """Regression guard: the valid path (correct length, finite values) still
+        trains successfully — the added validation must not break test_vqc.py."""
+        import polypus
+
+        result = polypus.train(
+            parametrized_circuit,
+            polypus.DE(generations=2, population_size=_POPULATION, tolerance=0.5),
+            shots=_SHOTS,
+            n_qpus=_N_QPUS,
+            dimensions=_DIMENSIONS,
+            expectation_function=simple_expectation_fn,
+            infrastructure="local",
+            nodes=_NODES,
+            cores_per_qpu=_CORES_PER_QPU,
+            id="test_oracle_valid_path",
+        )
+        assert isinstance(result.best_params, list)
+        assert len(result.best_params) == _DIMENSIONS
+        assert isinstance(result.best_fitness, float)
+        assert math.isfinite(result.best_fitness)


### PR DESCRIPTION
Fixes #72.

Problem
Contract C-5 requires EvaluationOracle::evaluate_batch to return exactly candidates.len() finite f64 values, and states that "Python-backed oracles must validate length before returning across the FFI." Neither the length nor the finiteness of what polypus_python.expectation_values returns was checked anywhere on the Rust side:

A short return list indexed out of bounds inside the pure-Rust optimizer → panic → uncatchable pyo3_runtime.PanicException crossing the FFI (the exact failure mode #35 / #58 eliminated elsewhere).
A NaN/inf return silently poisoned the optimizer, and train returned a bogus TrainResult with no error at all.
Change
Centralized both checks in run_and_evaluate (evaluation/mod.rs) — the single choke point that calls polypus_python.expectation_values, so every oracle is protected. It validates values.len() == qcs.len() and rejects the first non-finite value.
Two new EvaluationError variants — WrongLength { expected, got } and NonFinite { index, value } — following the existing Binding pattern (and CircuitError::WrongNumberOfParams / NonFiniteParam naming). Both map to the already-registered polypus.EvaluationError; no new Python exception class. Display names both lengths / the offending index and value.
Redundant defense-in-depth length assertions where VqcOracle and QmlOracle finish assembling their per-candidate results — mathematically redundant given the centralized check, kept as explicit self-documenting invariants, and returning Result rather than panic! (they run under OracleErrorSlot).
Tests
Rust unit tests in error.rs verifying the two Display outputs — Python-runtime-free (ENGINEERING §3): Display only, no PyErr construction.
New tests/python/test_oracle_contract.py (mirrors test_seam_contract.py): short-list and real-NaN-through-averaging paths both driven through polypus.train, asserting a typed polypus.EvaluationError and explicitly not PanicException, plus a regression guard that the valid path still trains.
docs/CONTRACTS.md C-5 row updated in the same change set to reference the new test alongside the Rust invariant test (which never exercised the Python-backed path).
Verification
cargo fmt --all --check · cargo clippy --workspace --all-targets -- -D warnings · pure-crate tests --all-features · cargo test -p polypus · maturin develop --release --features extension-module · pytest tests/python → 127 passed, no regressions.