### PR TITLE
fix(bindings): release GIL and check signals in run_quantum_circuit (#73)

### DIFF
--- a/crates/polypus/src/algorithms/orchestration/distribute_by_shots.rs
+++ b/crates/polypus/src/algorithms/orchestration/distribute_by_shots.rs
@@ -64,6 +64,11 @@ impl AlgorithmTrait for DistributeByShotsRun {
             }
         }
         let merged_pyobj = Python::with_gil(|py| -> PyResult<pyo3::PyObject> {
+            // The runs above execute with the GIL released (see
+            // `run_quantum_circuit`); this reacquire is the first Python
+            // touchpoint, so honor a pending Ctrl+C here before building the
+            // merged dict and propagate it verbatim. See docs/ENGINEERING.md §3.
+            py.check_signals()?;
             let py_dict = PyDict::new(py);
             for (k, v) in total {
                 py_dict.set_item(k, v)?;

--- a/crates/polypus/src/algorithms/orchestration/single_run.rs
+++ b/crates/polypus/src/algorithms/orchestration/single_run.rs
@@ -16,7 +16,14 @@ impl AlgorithmTrait for AlgorithmSingleRun {
         let counts = backend.run_circuits(&args.qcs, &args.config)?;
         backend.close();
         // Convert native counts to a Python `list[dict]` at the FFI boundary.
-        Python::with_gil(|py| Ok(counts.into_pyobject(py)?.into_any().unbind()))
+        Python::with_gil(|py| {
+            // The run above executes with the GIL released (see
+            // `run_quantum_circuit`); this reacquire is the first Python
+            // touchpoint, so honor a pending Ctrl+C here before building any
+            // Python object and propagate it verbatim. See docs/ENGINEERING.md §3.
+            py.check_signals()?;
+            Ok(counts.into_pyobject(py)?.into_any().unbind())
+        })
     }
 
     fn name(&self) -> String {

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -439,15 +439,21 @@ pub fn run_quantum_circuit<'py>(
     };
 
     let algorithm: Box<
-        dyn AlgorithmTrait<Args = AlgorithmArgs, AlgorithmReturnType = PyResult<PyObject>>,
+        dyn AlgorithmTrait<Args = AlgorithmArgs, AlgorithmReturnType = PyResult<PyObject>> + Send,
     > = if n_qpus == 1 {
         Box::new(AlgorithmSingleRun)
     } else {
         Box::new(DistributeByShotsRun)
     };
 
+    // Release the GIL for the whole run, mirroring `train` below: circuit
+    // execution is GIL-free on the native backend (and internally reacquires
+    // the GIL where Aer/CUNQA need it), so holding it here would stall every
+    // other Python thread and (with the per-circuit check_signals each
+    // algorithm variant performs before result conversion) keep Ctrl+C from
+    // taking effect until the run finishes. See docs/ENGINEERING.md §3.
     // Keep the original counts payload intact and wrap it with the run manifest.
-    let counts = algorithm.run(args)?;
+    let counts = qc.py().allow_threads(move || algorithm.run(args))?;
     Python::with_gil(|py| {
         Py::new(
             py,

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -75,6 +75,14 @@ boundary stays out-of-process and explicit; see
   swallowed into a panic by an `.expect()` (that would surface as an opaque
   `PanicException`; see §9 and `OracleErrorSlot` in
   `crates/polypus/src/evaluation/mod.rs`).
+- The same discipline applies to `run_quantum_circuit`: it releases the GIL
+  around the whole `algorithm.run(args)` call and each orchestration variant
+  calls `py.check_signals()` at its per-circuit / pre-result-conversion
+  boundary — the single `Python::with_gil` block where `AlgorithmSingleRun`
+  and `DistributeByShotsRun` reacquire the GIL to build the return value, as
+  the first statement before constructing any Python object. A pending Ctrl+C
+  surfaces there as a `KeyboardInterrupt` propagated verbatim through the
+  function's `Result`, never swallowed or retyped.
 - Preserve concurrent execution: candidates that bind/evaluate truly in
   parallel. If you add a path that runs circuits from worker threads, keep
   this guarantee.

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -16,8 +16,22 @@ pre-result-conversion boundary in both orchestration variants
 Python thread makes real progress while a native run is in flight (proving the
 GIL is actually released). Unlike ``train``, ``run_quantum_circuit`` has no
 per-shot/per-gate signal checks (out of scope for #73), so the interrupt is
-honored when the run reaches that boundary — the child circuits below are
-sized to finish in ~1–2s, comfortably inside ``_INTERRUPT_DEADLINE_S``.
+honored when the run *reaches* that boundary — i.e. when the run completes.
+Interrupt latency is therefore bounded by the run's own duration, which the two
+SIGINT children keep independent of the runner's core count by pinning
+``RAYON_NUM_THREADS=1`` (forcing the native statevector sim single-threaded, see
+``polypus-sim`` `parallel` kernels): without it a circuit sized to ~1.3s on a
+many-core dev box balloons past ``_INTERRUPT_DEADLINE_S`` on a 2-4 core CI
+runner. The circuits are sized to ~1.3s single-threaded — long enough that the
+run is still in flight when SIGINT arrives ``_DELAY_BEFORE_SIGINT_S`` after
+READY, short enough to complete well inside ``_INTERRUPT_DEADLINE_S`` even on a
+slower CI core.
+
+The GIL-release test instead uses a small (sub-``parallel_threshold``) circuit
+that never engages the rayon pool at all, so the native run occupies a single
+core and leaves the others free for the counter thread — the only configuration
+in which a CPU-bound Python thread can be *observed* to make progress, and thus
+prove the GIL was released, even on a 2-core runner.
 
 Why both entry points: `train`'s `VqcOracle` and `qml.train`'s `QmlOracle`
 share `run_and_evaluate`, but reach it through different paths — a native,
@@ -62,6 +76,7 @@ Manual verification (complementary to these automated tests):
     # the same way.
 """
 
+import os
 import select
 import signal
 import subprocess
@@ -186,16 +201,18 @@ except BaseException as exc:  # e.g. a PanicException from a swallowed error
 """
 
 
-def _assert_responds_to_sigint_promptly(child_code, *, failure_hint):
-    """Run `child_code` in a subprocess, SIGINT it mid-training, and assert a
-    real `KeyboardInterrupt` was raised well before a completed run could
-    finish. Shared by the native and QML variants below — they differ only in
-    which entry point/backend the child script exercises."""
+def _assert_responds_to_sigint_promptly(child_code, *, failure_hint, env=None):
+    """Run `child_code` in a subprocess, SIGINT it mid-run, and assert a real
+    `KeyboardInterrupt` was raised well before a completed run could finish.
+    Shared by the training and run_quantum_circuit variants below — they differ
+    only in which entry point/backend the child script exercises (and, for
+    run_quantum_circuit, an `env` that pins the sim single-threaded)."""
     proc = subprocess.Popen(
         [sys.executable, "-c", child_code],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        env=env,
     )
     try:
         # Wait for the child to reach the training loop before interrupting.
@@ -263,19 +280,14 @@ def test_qml_training_responds_to_sigint_promptly():
 # run_quantum_circuit (issue #73)
 # --------------------------------------------------------------------------- #
 
-# Child template for the SIGINT tests. A cheap warm-up forces the lazy
-# `polypus_python` import before the timed window; `READY` is printed only once
-# that is done, so the measured elapsed reflects the native run itself. The
-# timed run uses a circuit sized (below) to take ~1-2s on the native backend:
-# long enough that the SIGINT sent `_DELAY_BEFORE_SIGINT_S` after READY lands
-# while the run is in flight (GIL released), short enough that reaching the
-# check_signals boundary — where the pending signal becomes a KeyboardInterrupt
-# — happens well inside `_INTERRUPT_DEADLINE_S`. `__N_QPUS__` selects the
-# orchestration variant: 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun.
-_RUN_CHILD_TEMPLATE = r"""
-import sys, time
-import polypus
+# Env pinning the native sim single-threaded in the SIGINT children (see module
+# docstring and the `parallel` kernels in polypus-sim): makes each run's
+# duration independent of the runner's core count. Inherit the rest of the
+# environment so the child still finds the installed `polypus`/`polypus_python`.
+_SINGLE_THREADED_ENV = {**os.environ, "RAYON_NUM_THREADS": "1"}
 
+# Shared circuit builder used by every child below.
+_MAKE_CIRCUIT_SRC = r"""
 def make(n, reps):
     qc = polypus.Circuit(n)
     for q in range(n):
@@ -286,7 +298,26 @@ def make(n, reps):
         for q in range(n):
             qc = qc.rx(q, 0.3)
     return qc.measure_all()
+"""
 
+# Child template for the SIGINT tests, run with `_SINGLE_THREADED_ENV`. A cheap
+# warm-up forces the lazy `polypus_python` import before the timed window;
+# `READY` is printed only once that is done, so the measured elapsed reflects
+# the native run itself. Because the interrupt is only honored at the
+# per-circuit / pre-result-conversion boundary (i.e. when the run completes — no
+# per-shot checks), the circuit is sized to complete in ~1.3s single-threaded:
+# still running when SIGINT arrives `_DELAY_BEFORE_SIGINT_S` after READY, done
+# well inside `_INTERRUPT_DEADLINE_S`. `__N_QPUS__` selects the variant:
+# 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun (which duplicates the
+# circuit across QPUs, so its per-QPU `reps` is scaled down to keep the total
+# run time comparable).
+_RUN_CHILD_TEMPLATE = (
+    r"""
+import sys, time
+import polypus
+"""
+    + _MAKE_CIRCUIT_SRC
+    + r"""
 # Cheap warm-up: pay the lazy import cost outside the timed window.
 polypus.run_quantum_circuit(
     make(2, 1), shots=64, infrastructure="local",
@@ -308,6 +339,7 @@ except BaseException as exc:  # e.g. a PanicException from a swallowed signal
     print(f"OTHER {type(exc).__name__}", flush=True)
     sys.exit(1)
 """
+)
 
 
 def _run_child(*, n_qpus, n, reps):
@@ -323,77 +355,103 @@ def _run_child(*, n_qpus, n, reps):
 
 
 def test_run_quantum_circuit_single_responds_to_sigint_promptly():
-    # n_qpus == 1 -> AlgorithmSingleRun. n=23/reps=12 is ~2s native run time.
+    # n_qpus == 1 -> AlgorithmSingleRun. n=18/reps=100 is ~1.3s single-threaded.
     _assert_responds_to_sigint_promptly(
-        _run_child(n_qpus=1, n=23, reps=12),
+        _run_child(n_qpus=1, n=18, reps=100),
         failure_hint=(
             "run_quantum_circuit (AlgorithmSingleRun) — the GIL is likely held "
             "for the whole run or check_signals is missing before result "
             "conversion"
         ),
+        env=_SINGLE_THREADED_ENV,
     )
 
 
 def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
-    # n_qpus > 1 -> DistributeByShotsRun. n=22/reps=8 x4 QPUs is ~1.5s.
+    # n_qpus > 1 -> DistributeByShotsRun. 4 QPUs x n=18/reps=25 is ~1.3s total.
     _assert_responds_to_sigint_promptly(
-        _run_child(n_qpus=4, n=22, reps=8),
+        _run_child(n_qpus=4, n=18, reps=25),
         failure_hint=(
             "run_quantum_circuit (DistributeByShotsRun) — the GIL is likely "
             "held for the whole run or check_signals is missing before the "
             "merge/result conversion"
         ),
+        env=_SINGLE_THREADED_ENV,
     )
 
 
-# The GIL-release proof runs in-process (no signals involved): while a native
-# `run_quantum_circuit` call is in flight on the main thread, a background
-# thread spins a tight counter loop. With the GIL held for the whole run the
-# background thread advances only by the incidental amount the call's Python
-# entry/exit stages allow (measured ~1e5); with the GIL released around the
-# native run it advances by tens of millions over the ~2s run. The threshold
-# sits ~20x above the held-GIL value and ~15x below the released-GIL value, so
-# it cleanly separates the two without pinning down an exact rate.
-_MIN_COUNTER_PROGRESS = 2_000_000
+# GIL-release proof: while a native `run_quantum_circuit` call is in flight, a
+# background Python thread spins a tight counter loop. If the GIL were held for
+# the whole run the thread is starved and advances only by the incidental amount
+# the call's Python entry/exit stages allow (measured ~1.4e5, stable across core
+# counts); with the GIL released it advances by tens of millions (measured
+# ~3.6e7 on 32 cores, ~4e7 on 2) over the run. The threshold sits ~35x above the
+# held-GIL value and ~7x below the released-GIL value, so it separates them
+# cleanly with wide margin on either side, independent of the runner's cores.
+#
+# Two design points make this robust (see module docstring):
+#   * A subprocess, not an in-process thread, so the measurement starts from a
+#     clean interpreter with no rayon pool initialised by earlier tests.
+#   * An 11-qubit circuit — below polypus-sim's `parallel_threshold` (12) — so
+#     the run stays on a single thread and never engages the rayon pool. A
+#     parallel (>=12q) run instead saturates every core with rayon workers and
+#     starves the counter thread *even when the GIL is free*, which would make
+#     the observation depend on spare cores the CI runner may not have. Depth
+#     comes from `n_qpus` (sequential per-QPU circuits), not qubit count, so the
+#     circuit stays cheap to build.
+_MIN_COUNTER_PROGRESS = 5_000_000
 
+_GIL_RELEASE_CHILD = (
+    r"""
+import threading
+import polypus
+"""
+    + _MAKE_CIRCUIT_SRC
+    + r"""
+# Warm up the lazy import path outside the measured window.
+polypus.run_quantum_circuit(
+    make(2, 1), shots=64, infrastructure="local", n_qpus=1, backend="polypus"
+)
 
-def _make_native_circuit(polypus, n, reps):
-    qc = polypus.Circuit(n)
-    for q in range(n):
-        qc = qc.h(q)
-    for _ in range(reps):
-        for q in range(n - 1):
-            qc = qc.cx(q, q + 1)
-        for q in range(n):
-            qc = qc.rx(q, 0.3)
-    return qc.measure_all()
+qc = make(11, 1500)  # sub-parallel-threshold; ~1.3-2.6s across 32..2 cores
+counter = 0
+stop = threading.Event()
+
+def spin():
+    global counter
+    while not stop.is_set():
+        counter += 1
+
+worker = threading.Thread(target=spin)
+worker.start()
+try:
+    before = counter
+    # n_qpus=20 -> 20 sequential single-thread circuits (DistributeByShotsRun),
+    # enough wall-clock for the counter to accumulate a decisive lead.
+    polypus.run_quantum_circuit(
+        qc, shots=4096, infrastructure="local", n_qpus=20, backend="polypus"
+    )
+    advanced = counter - before
+finally:
+    stop.set()
+    worker.join()
+print(f"ADVANCED {advanced}", flush=True)
+"""
+)
 
 
 def test_run_quantum_circuit_releases_gil_for_other_threads():
-    import threading
-
-    import polypus
-
-    counter = {"n": 0}
-    stop = threading.Event()
-
-    def spin():
-        while not stop.is_set():
-            counter["n"] += 1
-
-    qc = _make_native_circuit(polypus, n=23, reps=12)  # ~2s native run
-    worker = threading.Thread(target=spin)
-    worker.start()
-    try:
-        before = counter["n"]
-        polypus.run_quantum_circuit(
-            qc, shots=4096, infrastructure="local", n_qpus=1, backend="polypus"
-        )
-        advanced = counter["n"] - before
-    finally:
-        stop.set()
-        worker.join()
-
+    proc = subprocess.run(
+        [sys.executable, "-c", _GIL_RELEASE_CHILD],
+        capture_output=True,
+        text=True,
+        timeout=_READY_TIMEOUT_S,
+    )
+    assert proc.returncode == 0 and "ADVANCED" in proc.stdout, (
+        f"GIL-release child did not complete cleanly.\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    advanced = int(proc.stdout.split("ADVANCED", 1)[1].split()[0])
     assert advanced > _MIN_COUNTER_PROGRESS, (
         f"background thread advanced only {advanced} counts during the native "
         f"run — the GIL was likely not released around run_quantum_circuit"

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -1,10 +1,23 @@
 """
-Ctrl+C responsiveness during training (issue #36).
+Ctrl+C responsiveness and GIL release during long-running calls
+(issues #36 and #73).
 
 Acceptance criterion: a ``KeyboardInterrupt`` takes effect *promptly* while
 ``polypus.train`` (native backend) or ``polypus.qml.train`` (Qiskit/Aer
 backend) is running, rather than being ignored until the whole optimization
 finishes.
+
+``run_quantum_circuit`` (issue #73) is covered here too: it releases the GIL
+around the whole run and calls ``py.check_signals()`` at the per-circuit /
+pre-result-conversion boundary in both orchestration variants
+(``AlgorithmSingleRun`` for ``n_qpus == 1``, ``DistributeByShotsRun`` for
+``n_qpus > 1``). Two properties are asserted: a pending SIGINT surfaces as a
+``KeyboardInterrupt`` (not ``COMPLETED``) when the run returns, and another
+Python thread makes real progress while a native run is in flight (proving the
+GIL is actually released). Unlike ``train``, ``run_quantum_circuit`` has no
+per-shot/per-gate signal checks (out of scope for #73), so the interrupt is
+honored when the run reaches that boundary — the child circuits below are
+sized to finish in ~1–2s, comfortably inside ``_INTERRUPT_DEADLINE_S``.
 
 Why both entry points: `train`'s `VqcOracle` and `qml.train`'s `QmlOracle`
 share `run_and_evaluate`, but reach it through different paths — a native,
@@ -243,4 +256,145 @@ def test_qml_training_responds_to_sigint_promptly():
             "worker join is likely missing or the GIL is not released around "
             "the optimizer"
         ),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# run_quantum_circuit (issue #73)
+# --------------------------------------------------------------------------- #
+
+# Child template for the SIGINT tests. A cheap warm-up forces the lazy
+# `polypus_python` import before the timed window; `READY` is printed only once
+# that is done, so the measured elapsed reflects the native run itself. The
+# timed run uses a circuit sized (below) to take ~1-2s on the native backend:
+# long enough that the SIGINT sent `_DELAY_BEFORE_SIGINT_S` after READY lands
+# while the run is in flight (GIL released), short enough that reaching the
+# check_signals boundary — where the pending signal becomes a KeyboardInterrupt
+# — happens well inside `_INTERRUPT_DEADLINE_S`. `__N_QPUS__` selects the
+# orchestration variant: 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun.
+_RUN_CHILD_TEMPLATE = r"""
+import sys, time
+import polypus
+
+def make(n, reps):
+    qc = polypus.Circuit(n)
+    for q in range(n):
+        qc = qc.h(q)
+    for _ in range(reps):
+        for q in range(n - 1):
+            qc = qc.cx(q, q + 1)
+        for q in range(n):
+            qc = qc.rx(q, 0.3)
+    return qc.measure_all()
+
+# Cheap warm-up: pay the lazy import cost outside the timed window.
+polypus.run_quantum_circuit(
+    make(2, 1), shots=64, infrastructure="local",
+    n_qpus=__N_QPUS__, backend="polypus",
+)
+
+qc = make(__N__, __REPS__)
+print("READY", flush=True)
+start = time.time()
+try:
+    polypus.run_quantum_circuit(
+        qc, shots=4096, infrastructure="local",
+        n_qpus=__N_QPUS__, backend="polypus",
+    )
+    print("COMPLETED", flush=True)
+except KeyboardInterrupt:
+    print(f"KEYBOARDINTERRUPT {time.time() - start:.3f}", flush=True)
+except BaseException as exc:  # e.g. a PanicException from a swallowed signal
+    print(f"OTHER {type(exc).__name__}", flush=True)
+    sys.exit(1)
+"""
+
+
+def _run_child(*, n_qpus, n, reps):
+    """Build a `run_quantum_circuit` SIGINT child source for the given variant.
+
+    Uses token replacement rather than `str.format` because the template's
+    f-string (`{time.time() ...}`) contains literal braces."""
+    return (
+        _RUN_CHILD_TEMPLATE.replace("__N_QPUS__", str(n_qpus))
+        .replace("__N__", str(n))
+        .replace("__REPS__", str(reps))
+    )
+
+
+def test_run_quantum_circuit_single_responds_to_sigint_promptly():
+    # n_qpus == 1 -> AlgorithmSingleRun. n=23/reps=12 is ~2s native run time.
+    _assert_responds_to_sigint_promptly(
+        _run_child(n_qpus=1, n=23, reps=12),
+        failure_hint=(
+            "run_quantum_circuit (AlgorithmSingleRun) — the GIL is likely held "
+            "for the whole run or check_signals is missing before result "
+            "conversion"
+        ),
+    )
+
+
+def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
+    # n_qpus > 1 -> DistributeByShotsRun. n=22/reps=8 x4 QPUs is ~1.5s.
+    _assert_responds_to_sigint_promptly(
+        _run_child(n_qpus=4, n=22, reps=8),
+        failure_hint=(
+            "run_quantum_circuit (DistributeByShotsRun) — the GIL is likely "
+            "held for the whole run or check_signals is missing before the "
+            "merge/result conversion"
+        ),
+    )
+
+
+# The GIL-release proof runs in-process (no signals involved): while a native
+# `run_quantum_circuit` call is in flight on the main thread, a background
+# thread spins a tight counter loop. With the GIL held for the whole run the
+# background thread advances only by the incidental amount the call's Python
+# entry/exit stages allow (measured ~1e5); with the GIL released around the
+# native run it advances by tens of millions over the ~2s run. The threshold
+# sits ~20x above the held-GIL value and ~15x below the released-GIL value, so
+# it cleanly separates the two without pinning down an exact rate.
+_MIN_COUNTER_PROGRESS = 2_000_000
+
+
+def _make_native_circuit(polypus, n, reps):
+    qc = polypus.Circuit(n)
+    for q in range(n):
+        qc = qc.h(q)
+    for _ in range(reps):
+        for q in range(n - 1):
+            qc = qc.cx(q, q + 1)
+        for q in range(n):
+            qc = qc.rx(q, 0.3)
+    return qc.measure_all()
+
+
+def test_run_quantum_circuit_releases_gil_for_other_threads():
+    import threading
+
+    import polypus
+
+    counter = {"n": 0}
+    stop = threading.Event()
+
+    def spin():
+        while not stop.is_set():
+            counter["n"] += 1
+
+    qc = _make_native_circuit(polypus, n=23, reps=12)  # ~2s native run
+    worker = threading.Thread(target=spin)
+    worker.start()
+    try:
+        before = counter["n"]
+        polypus.run_quantum_circuit(
+            qc, shots=4096, infrastructure="local", n_qpus=1, backend="polypus"
+        )
+        advanced = counter["n"] - before
+    finally:
+        stop.set()
+        worker.join()
+
+    assert advanced > _MIN_COUNTER_PROGRESS, (
+        f"background thread advanced only {advanced} counts during the native "
+        f"run — the GIL was likely not released around run_quantum_circuit"
     )


### PR DESCRIPTION
## fix(bindings): release GIL and check signals in `run_quantum_circuit` (#73)

### Context

`run_quantum_circuit` held the GIL for the entire execution and never checked
for signals, so:

- **No other Python thread made progress** while a native run was in flight
  (the GIL was held end-to-end).
- **Ctrl+C (SIGINT) was ignored** until the run finished completely.

The `train` / `qml.train` entry point already solved the same problem (#36,
PR #61): it releases the GIL around `optimize()` and checks signals at its
Python touchpoints. This PR applies that same discipline to
`run_quantum_circuit`.

### Changes

**Core fix** (`crates/polypus/src/bindings/mod.rs`)
- `algorithm.run(args)` is wrapped in `qc.py().allow_threads(move || …)`,
  releasing the GIL for the whole execution (mirroring `train`).
- The trait object gains a `+ Send` bound
  (`Box<dyn AlgorithmTrait<…> + Send>`). Both concrete algorithms
  (`AlgorithmSingleRun`, `DistributeByShotsRun`) are zero-sized, so the bound
  alone suffices; the closure is `move` so it takes ownership and only needs
  `Send` (not `Sync`). No `unsafe impl Send` was needed:
  `AlgorithmArgs`/`ExecutionConfig`/`BoundCircuit` are already `Send` because
  their only non-trivial fields are `Py<PyAny>`, which PyO3 marks `Send`.

**Interruptibility** (`single_run.rs`, `distribute_by_shots.rs`)
- `py.check_signals()?` is added as the first statement of the existing
  `Python::with_gil` block in each variant (before constructing any Python
  object): in `AlgorithmSingleRun` before converting the counts, and in
  `DistributeByShotsRun` before merging the `PyDict`. A pending Ctrl+C
  propagates verbatim as a `KeyboardInterrupt` through the function's `Result`,
  never swallowed or retyped.
- **Deliberately out of scope:** no per-shot/per-gate checks inside
  `polypus-sim` or `NativeStatevectorBackend::run_circuits`. The interrupt is
  honored at the per-circuit / pre-result-conversion boundary, as the issue
  requests.

**Documentation** (`docs/ENGINEERING.md` §3)
- `run_quantum_circuit` is named alongside `train`/`qml.train` as an entry
  point covered by the GIL + `check_signals` discipline, describing the actual
  shape of the fix (surgical extension of the section, no restructuring).

**Tests** (`tests/python/test_interrupt.py`)
- **SIGINT, two variants** (real subprocess + real `SIGINT`, same pattern as the
  `train` tests): `n_qpus=1` (exercises `AlgorithmSingleRun`) and `n_qpus>1`
  (exercises `DistributeByShotsRun`). They assert `KEYBOARDINTERRUPT` is raised
  with `elapsed < _INTERRUPT_DEADLINE_S`, not `COMPLETED`.
- **GIL-release / thread-progress:** a background thread increments a counter
  while a native run is in flight; the test asserts it advances decisively
  (proving the GIL was actually released).

### CI robustness (second commit)

The tests failed on CI runners (Python 3.9 and 3.13, 2–4 vCPU) because they were
calibrated on a many-core machine. Since the native simulation kernel is
parallel (rayon), both run duration and CPU contention depend on core count.
Adjustments:

- **SIGINT tests:** pin `RAYON_NUM_THREADS=1` in the child environment, so the
  simulation is single-threaded and run duration is **independent of core
  count** (otherwise a ~1.3s circuit on a 32-core box balloons past the 5s
  deadline on CI). An 18-qubit circuit sized to ~1.3s single-threaded.
- **GIL-release test:** runs in a **subprocess** (clean interpreter, no rayon
  pool initialized by earlier tests) against an **11-qubit circuit — below
  `DEFAULT_PARALLEL_THRESHOLD=12`**, so the simulation never engages rayon, runs
  on a single thread, and leaves a core free for the counter thread. Without
  this, a parallel run saturates every core and starves the counter even when
  the GIL is free. Depth comes from `n_qpus=20` (sequential circuits) to keep
  the build cheap. Measured discriminator: **~4·10⁷** counts with the GIL
  released vs **~1.4·10⁵** with the GIL held, stable across 2–32 cores; test
  threshold **5·10⁶**.

### Contracts

Out of scope for this PR: it changes only execution concurrency, not
`run_quantum_circuit`'s kwargs or the `RunResult` shape (C-7), so
`docs/CONTRACTS.md` is untouched.

### Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers --all-features` ✅
- `LD_LIBRARY_PATH=~/miniconda3/lib cargo test -p polypus` ✅
- `maturin develop --release --features extension-module` ✅
- `pytest tests/python` ✅ (126 tests) — the interrupt suite (5 tests) passes on
  both 32 and 2 cores (`taskset -c 0,1`), with no flakiness across 3 repeats;
  `ruff format --check` + `ruff check` clean.

### Review notes

- The real discriminator for the `allow_threads` fix is the GIL-release test
  (it fails without the fix: 141k < 5·10⁶). Both SIGINT tests pass with or
  without the fix — after the run returns, the next bytecode (`print`) triggers
  the deferred `KeyboardInterrupt` anyway — so their value is guarding the
  interrupt **latency/deadline** (they would have timed out with the parallel
  sizing on 2 cores).
- The interrupt is honored when the run **completes** (no per-shot checks), so
  Ctrl+C latency is bounded by the run's own duration; this is consistent with
  the issue's scope.

Closes #73