### PR TITLE
fix(bindings): validate cunqa nodes/cores_per_qpu instead of hardcoding nodes=0 (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Set `n_qpus > 1` to split the shots across available QPUs and reduce execution t
 result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10)
 ```
 
+When `infrastructure="cunqa"`, two optional kwargs size the SLURM allocation for the distributed QPUs:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `nodes` | `1` | Number of SLURM nodes to request (`>= 1`) |
+| `cores_per_qpu` | `2` | CPU cores allocated per QPU (`>= 1`) |
+
+```python
+result = polypus.run_quantum_circuit(
+    qc, shots=NUM_SHOTS, infrastructure="cunqa", n_qpus=10, nodes=2, cores_per_qpu=4
+)
+```
+
+Both must be `>= 1` for `"cunqa"` (a `0` reaching SLURM is rejected with a `ValueError`). They are ignored by `infrastructure="local"` and `"qmio"`, so those calls omit them.
+
 Both calls return a `RunResult`: `result.counts` holds the measurement payload — a `list[dict[str, int]]` for a single QPU, or a single merged `dict[str, int]` when `n_qpus > 1`. The manifest fields `result.id`, `result.seed`, `result.backend` and `result.infrastructure` record the run for logging and replay. Pass `seed=...` to `run_quantum_circuit()` for reproducible shot noise on every simulated backend (native `"polypus"`, Aer, and CUNQA's simulated QPUs); `result.seed` reports the effective seed used (`None` only for the `"qmio"` infrastructure, which is real hardware and rejects an explicit seed).
 
 ### Training Variational Circuits

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -304,6 +304,31 @@ fn validate_shots_and_qpus(shots: u32, n_qpus: u32) -> PyResult<()> {
     Ok(())
 }
 
+/// Validate the CUNQA allocation parameters at the Python-facing boundary. Only
+/// the `"cunqa"` infrastructure consumes `nodes`/`cores_per_qpu` (they flow to
+/// SLURM's `qraise` as the C-1 kwargs `n_nodes`/`cores_per_qpu` via
+/// `CunqaBackend`); the `local` and `qmio` match arms of `build_backend_config`
+/// ignore them, so validating unconditionally would reject harmless non-cunqa
+/// calls. A zero for either value has no sane meaning once it reaches SLURM, so
+/// reject it here before any seam call rather than forward it. Shared by every
+/// entry point rather than duplicated per function.
+fn validate_cunqa_allocation(infrastructure: &str, nodes: u32, cores_per_qpu: u32) -> PyResult<()> {
+    if infrastructure != "cunqa" {
+        return Ok(());
+    }
+    if nodes < 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "nodes must be >= 1 for the 'cunqa' infrastructure, got {nodes}"
+        )));
+    }
+    if cores_per_qpu < 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "cores_per_qpu must be >= 1 for the 'cunqa' infrastructure, got {cores_per_qpu}"
+        )));
+    }
+    Ok(())
+}
+
 /// Interpret the `qc` argument of an entry point as a parameterised circuit
 /// template. A `polypus.Circuit` becomes [`CircuitSource::Native`] (binding
 /// will run GIL-free); any other object is assumed to be a Qiskit
@@ -350,9 +375,16 @@ fn extract_bound_circuit(qc: &Bound<'_, PyAny>) -> PyResult<BoundCircuit> {
 /// runs give genuinely independent noise. Passing a `seed` with
 /// `infrastructure="qmio"` raises `ValueError` rather than silently ignoring
 /// it, since that infrastructure is real hardware and cannot be seeded.
+///
+/// `nodes` and `cores_per_qpu` size the SLURM allocation and are meaningful
+/// only for `infrastructure="cunqa"` (they become CUNQA's `qraise` parameters);
+/// the `local` and `qmio` infrastructures ignore them. For `cunqa` both must be
+/// `>= 1` — a zero has no sane meaning once it reaches SLURM and is rejected.
+/// They default to `nodes=1, cores_per_qpu=2`.
+///
 /// Returns a [`RunResult`] carrying the counts plus a manifest (`id`,
 /// effective `seed`, `backend`, `infrastructure`) for logging and replay.
-#[pyfunction(signature=(qc, shots, infrastructure, n_qpus=1, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
+#[pyfunction(signature=(qc, shots, infrastructure, n_qpus=1, nodes=1, cores_per_qpu=2, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
 // Rich FFI entry point mirroring a many-kwarg Python API; same rationale and
 // convention as `train`/`qml_train` below.
 #[allow(clippy::too_many_arguments)]
@@ -361,6 +393,8 @@ pub fn run_quantum_circuit<'py>(
     shots: u32,
     infrastructure: String,
     n_qpus: u32,
+    nodes: u32,
+    cores_per_qpu: u32,
     sim_method: &str,
     noise_model: Option<Bound<'py, PyAny>>,
     backend: &str,
@@ -373,6 +407,7 @@ pub fn run_quantum_circuit<'py>(
          infrastructure: {infrastructure}, n_qpus: {n_qpus}, backend: {backend}, seed: {seed:?}"
     );
     validate_shots_and_qpus(shots, n_qpus)?;
+    validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
     let bound_qc = extract_bound_circuit(&qc)?;
     if is_native_backend(backend) {
         if let BoundCircuit::Qiskit(_) = &bound_qc {
@@ -421,8 +456,8 @@ pub fn run_quantum_circuit<'py>(
         backend,
         sim_method,
         noise_model.map(|nm| nm.unbind()),
-        0,
-        2,
+        nodes,
+        cores_per_qpu,
     )?;
     let config = ExecutionConfig {
         id: id.clone(),
@@ -479,6 +514,10 @@ pub fn run_quantum_circuit<'py>(
 /// waiting for the run to finish. An exception raised by
 /// `expectation_function` propagates the same way, as itself.
 ///
+/// `nodes` and `cores_per_qpu` size the SLURM allocation and are consumed only
+/// by `infrastructure="cunqa"`; `local`/`qmio` accept but ignore them. For
+/// `cunqa` both must be `>= 1` (a zero is meaningless to SLURM and rejected).
+///
 /// Example:
 ///
 /// ```ignore
@@ -508,6 +547,7 @@ pub fn train<'py>(
     seed: Option<u64>,
 ) -> PyResult<PyObject> {
     validate_shots_and_qpus(shots, n_qpus)?;
+    validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
     // Resolve the seed that drives the optimizer's RNG (contract C-7): explicit
     // kwarg > optimizer object's `seed` field > fresh OS entropy. Unlike
     // `run_quantum_circuit`, a seed is always meaningful here — it seeds the
@@ -673,6 +713,10 @@ pub fn train<'py>(
 /// finish, and an exception raised by `expectation_function` propagates as
 /// itself.
 ///
+/// `nodes` and `cores_per_qpu` size the SLURM allocation and are consumed only
+/// by `infrastructure="cunqa"`; `local`/`qmio` accept but ignore them. For
+/// `cunqa` both must be `>= 1` (a zero is meaningless to SLURM and rejected).
+///
 /// Example:
 ///
 /// ```ignore
@@ -705,6 +749,7 @@ pub fn qml_train<'py>(
     seed: Option<u64>,
 ) -> PyResult<PyObject> {
     validate_shots_and_qpus(shots, n_qpus)?;
+    validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
     // Same seed precedence as `train` (contract C-7): kwarg > optimizer field >
     // OS entropy. qml.train always runs on a Qiskit/Aer path (native rejected
     // below); this seed governs the optimizer's RNG and, since it's threaded
@@ -932,6 +977,8 @@ mod tests {
             500,
             "local".to_string(),
             1,
+            1,
+            2,
             "automatic",
             None,
             "polypus",
@@ -997,6 +1044,8 @@ mod tests {
                 100,
                 "local".to_string(),
                 1,
+                1,
+                2,
                 "automatic",
                 None,
                 "polypus",
@@ -1043,6 +1092,8 @@ mod tests {
                     100,
                     "local".to_string(),
                     1,
+                    1,
+                    2,
                     "automatic",
                     None,
                     "polypus",
@@ -1080,6 +1131,8 @@ mod tests {
                 100,
                 "qmio".to_string(),
                 1,
+                1,
+                2,
                 "automatic",
                 None,
                 "aer",

--- a/tests/python/test_backend_selection.py
+++ b/tests/python/test_backend_selection.py
@@ -140,6 +140,67 @@ class TestShotsQpusValidation:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Boundary validation of the CUNQA allocation params (issue #74)
+#
+# `nodes`/`cores_per_qpu` size the SLURM allocation and are consumed only by
+# `infrastructure="cunqa"` (they reach CUNQA's `qraise`). A zero for either has
+# no sane SLURM meaning, so it must be rejected at the boundary — before any
+# `raise_qpus`/`connect_to_infrastructure` seam call, exactly like the zero
+# shots/qpus guards above, so these need no real CUNQA/SLURM environment. The
+# `local`/`qmio` paths ignore both params, so their validation is gated on
+# `cunqa` and non-cunqa calls that omit them keep working unchanged.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCunqaAllocationValidation:
+    def test_zero_nodes_rejected_for_cunqa(self):
+        import polypus
+
+        qc = polypus.Circuit(1).h(0).measure_all()
+        with pytest.raises(ValueError, match="nodes must be >= 1"):
+            polypus.run_quantum_circuit(
+                qc, shots=100, infrastructure="cunqa", nodes=0
+            )
+
+    def test_zero_cores_per_qpu_rejected_for_cunqa(self):
+        import polypus
+
+        qc = polypus.Circuit(1).h(0).measure_all()
+        with pytest.raises(ValueError, match="cores_per_qpu must be >= 1"):
+            polypus.run_quantum_circuit(
+                qc, shots=100, infrastructure="cunqa", cores_per_qpu=0
+            )
+
+    def test_local_ignores_allocation_defaults(self):
+        """Non-cunqa calls omit nodes/cores_per_qpu; the inert defaults must not
+        trip the cunqa-only validation, proving backward compatibility."""
+        import polypus
+
+        qc = polypus.Circuit(1).h(0).measure_all()
+        result = polypus.run_quantum_circuit(qc, shots=128, infrastructure="local")
+        assert sum(result.counts[0].values()) == 128
+
+    def test_zero_nodes_rejected_in_train(self, simple_expectation_fn):
+        """The same guard protects the train() entry point for cunqa."""
+        import polypus
+
+        qc = polypus.Circuit(1).ry(0, polypus.Param(0)).measure_all()
+        with pytest.raises(ValueError, match="nodes must be >= 1"):
+            polypus.train(
+                qc,
+                polypus.DE(generations=2, population_size=4),
+                shots=100,
+                n_qpus=1,
+                dimensions=1,
+                expectation_function=simple_expectation_fn,
+                infrastructure="cunqa",
+                nodes=0,
+                cores_per_qpu=2,
+                id="test_train_zero_nodes",
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Native vs Aer equivalence on the same native circuit
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/python/test_backend_selection.py
+++ b/tests/python/test_backend_selection.py
@@ -158,9 +158,7 @@ class TestCunqaAllocationValidation:
 
         qc = polypus.Circuit(1).h(0).measure_all()
         with pytest.raises(ValueError, match="nodes must be >= 1"):
-            polypus.run_quantum_circuit(
-                qc, shots=100, infrastructure="cunqa", nodes=0
-            )
+            polypus.run_quantum_circuit(qc, shots=100, infrastructure="cunqa", nodes=0)
 
     def test_zero_cores_per_qpu_rejected_for_cunqa(self):
         import polypus


### PR DESCRIPTION
Closes #74

## Context

`run_quantum_circuit` called `build_backend_config(..., 0, 2)` with the
`nodes=0`/`cores_per_qpu=2` literals hardcoded. For `infrastructure="cunqa"` this
produced `BackendConfig::Cunqa { nodes: 0, cores_per_qpu: 2 }`, forwarded unvalidated
as the C-1 kwarg `n_nodes=0` all the way to CUNQA's `qraise` in SLURM — with no way for
a caller to override it and with `n_nodes=0` never verified to mean anything sane.
`train` and `qml_train` already exposed `nodes`/`cores_per_qpu` but did not validate
them either (same latent bug).

## Changes

- **New shared validator** `validate_cunqa_allocation(infrastructure, nodes,
  cores_per_qpu)` next to `validate_shots_and_qpus`. It is a no-op unless
  `infrastructure == "cunqa"`; in that case it rejects `nodes < 1` and
  `cores_per_qpu < 1` with `ValueError`, in the same message style as the existing
  validator.
- **`run_quantum_circuit`**: `nodes` and `cores_per_qpu` become **optional** kwargs with
  defaults `nodes=1, cores_per_qpu=2` (the `2` preserves the previous value; only `nodes`
  changes from the buggy `0` to `1`). They are validated right after
  `validate_shots_and_qpus` and passed through to `build_backend_config` instead of
  `0, 2`.
- **`train` / `qml_train`**: the same validation call is added (their signatures already
  included both parameters).
- Doc comments on all three entry points updated; `README.md` documents the kwargs as
  optional, meaningful only for `infrastructure="cunqa"`, with their defaults and the
  `>= 1` requirement.

## Design decisions

- Parameters are **optional** (not required as in `train`) so existing `local`/`qmio`
  call sites in README/examples/tests don't have to start passing values that are
  meaningless for those infrastructures.
- **Both** fields are validated (not just `nodes`): `cores_per_qpu=0` is equally
  ambiguous to SLURM and travels the same code path.
- Validation is **gated** on `cunqa` because the `local`/`qmio` arms of
  `build_backend_config` ignore these values; validating unconditionally would reject
  currently-valid inert calls.
- `docs/CONTRACTS.md` C-1 is unchanged: the Python-side kwargs (`n_nodes`,
  `cores_per_qpu`) and the seam are identical; the only new thing is the Rust-side
  validation before the seam call.

## Tests

New `TestCunqaAllocationValidation` class in `tests/python/test_backend_selection.py`
(no real CUNQA/SLURM environment needed, since validation happens before any seam call):

- `run_quantum_circuit(..., infrastructure="cunqa", nodes=0)` → `ValueError`.
- `run_quantum_circuit(..., infrastructure="cunqa", cores_per_qpu=0)` → `ValueError`.
- `run_quantum_circuit(..., infrastructure="local")` with no `nodes`/`cores_per_qpu`
  still works (proves the gating and backward compatibility).
- `train(..., infrastructure="cunqa", nodes=0, ...)` → `ValueError`.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p polypus --features qmio`
- `pytest tests/python` → 127 passed