### PR TITLE
fix(bindings): validate qml.train row/dimension symmetry upfront (#79)

### DIFF
--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -719,6 +719,18 @@ pub fn qml_train<'py>(
 			 and ansätze are Qiskit circuits); use backend=\"aer\"",
         ));
     }
+    // The optimizer searches a `dimensions`-wide vector and binds it to the
+    // ansatz's free parameters; a mismatch surfaces later as a cryptic Qiskit
+    // binding error inside the oracle. Catch it upfront, mirroring how `train`
+    // validates `dimensions` against the circuit's parameter count (contract
+    // C-8). `len()` calls `__len__`, working on Qiskit's ParameterView the same
+    // as on a list.
+    let num_ansatz_params = ansatz.getattr("parameters")?.len()?;
+    if num_ansatz_params != dimensions as usize {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "dimensions ({dimensions}) does not match the ansatz's free parameters ({num_ansatz_params})"
+        )));
+    }
     let py = feature_map.py();
 
     // 1. Compose feature_map + ansatz
@@ -741,8 +753,22 @@ pub fn qml_train<'py>(
     //    parameters unbound for the optimizer to fill in later.
     let kwargs_assign = [("inplace", false)].into_py_dict(py)?;
     let mut qcs: Vec<Py<PyAny>> = Vec::new();
-    for row_result in x_train.try_iter()? {
+    // Each row must supply exactly one value per feature-map parameter. Zipping
+    // the two iterators would stop at the shorter one — a longer row silently
+    // drops features, a shorter row leaves feature-map parameters unbound and
+    // fails later as a cryptic Qiskit error inside the oracle. Materialize both
+    // lengths and reject a mismatch upfront with the row index and both lengths
+    // (contract C-8).
+    let fm_len = fm_params_list.len()?;
+    for (row_idx, row_result) in x_train.try_iter()?.enumerate() {
         let row = row_result?;
+        let row_len = row.len()?;
+        if row_len != fm_len {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "x_train row {row_idx} has {row_len} features, but feature_map expects {fm_len} \
+                 (len(feature_map.parameters))"
+            )));
+        }
         let param_dict = PyDict::new(py);
         for (param, val) in fm_params_list.try_iter()?.zip(row.try_iter()?) {
             param_dict.set_item(param?, val?)?;

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -27,6 +27,7 @@ Rules of the road:
 | C-5 | Optimizer ↔ oracle | invariant test, multi-seed | ✅ present | DE `best_fitness` mismatch (C4) |
 | C-6 | Version coherence | `hygiene.yml` version step | ✅ present | tag/Cargo diverged at 0.6.0 |
 | C-7 | Seeding & run manifest | `tests/python/test_seed_reproducibility.py` + bindings/native Rust tests | ✅ present | repeated runs byte-identical / `train` seed hardcoded `None` (#34) |
+| C-8 | qml.train row/dimension symmetry | `tests/python/test_qml_train_validation.py` | ✅ present | silent row truncation / late Qiskit error (#79) |
 
 ⏳ contracts are specified but not yet mechanically enforced; treat them as
 review-enforced until the test lands. Each known break has a public issue
@@ -310,3 +311,37 @@ anywhere in this project's CI or dev sandboxes (unlike Aer) — so, unlike the
 Aer path, it has never actually been run. Treat CUNQA's `seed` support as
 unverified until the CUNQA integration follow-up confirms it against a real
 install.
+
+---
+
+## C-8 · qml.train row/dimension symmetry (Python entry point)
+
+`polypus.qml.train` composes a Qiskit `feature_map` with an `ansatz`, pre-binds
+each row of `x_train` to the feature-map parameters, and hands the resulting
+circuits to the optimizer, which searches a `dimensions`-wide vector and binds
+it to the ansatz's free parameters. Two shape agreements must hold, and both are
+validated **upfront** with a clear `ValueError` — before any circuit is composed
+or executed — rather than surfacing as a silent truncation or a cryptic Qiskit
+binding error deep inside the oracle.
+
+- **Row width.** Every row of `x_train` must have **exactly
+  `len(feature_map.parameters)`** elements. A longer row would silently drop the
+  extra features (the pre-binding zip stops at the shorter iterator); a shorter
+  row would leave feature-map parameters unbound and fail later as a cryptic
+  Qiskit error inside the oracle. Either case is a `ValueError` reporting the
+  offending **0-based** row index and both lengths (row features vs.
+  `len(feature_map.parameters)`), consistent with how `x_train` is indexed as an
+  array/list on the Python side.
+- **Dimensions.** `dimensions` must be **exactly `len(ansatz.parameters)`**. This
+  mirrors `train`, which validates `dimensions` against the circuit's free
+  parameter count (`circuit_source.num_params()`); that symmetry was documented
+  only implicitly (in `train`'s docstring) and was missing entirely from
+  `qml.train`, which is precisely why it now earns an explicit contract. A
+  mismatch is a `ValueError` naming both `dimensions` and the ansatz's free
+  parameter count.
+
+A row whose length cannot be read (e.g. a generator with no `__len__`) is a
+legitimate type error and propagates as-is; it is not masked into the messages
+above.
+
+**Enforcing test:** `tests/python/test_qml_train_validation.py`.

--- a/tests/python/test_qml_train_validation.py
+++ b/tests/python/test_qml_train_validation.py
@@ -1,0 +1,72 @@
+"""
+qml.train row/dimension symmetry — upfront-validation tests (contract C-8).
+
+These cover issue #79: ``qml.train`` used to zip each ``x_train`` row against
+the feature-map parameters, so a row with too many features silently dropped
+data and a row with too few left feature-map parameters unbound (surfacing
+later as a cryptic Qiskit error inside the oracle). It also never validated
+``dimensions`` against ``len(ansatz.parameters)``, unlike ``train``.
+
+Both agreements are now enforced **upfront** with a clear ``ValueError`` before
+any circuit is executed, so these tests never reach a real backend — the
+failures are raised during argument validation, so no optimizer/backend mocking
+is needed.
+"""
+
+import pytest
+
+
+def _feature_map_ansatz():
+    from qiskit.circuit.library import real_amplitudes, zz_feature_map
+
+    # feature_dimension=2 ⇒ len(feature_map.parameters) == 2.
+    feature_map = zz_feature_map(feature_dimension=2, reps=1)
+    ansatz = real_amplitudes(num_qubits=2, reps=1)
+    return feature_map, ansatz
+
+
+def _qml_train(feature_map, ansatz, x_train, dimensions):
+    import polypus
+
+    return polypus.qml.train(
+        feature_map,
+        ansatz,
+        x_train,
+        polypus.DE(generations=3, population_size=6, tolerance=1e-12),
+        shots=64,
+        n_qpus=1,
+        dimensions=dimensions,
+        expectation_function=lambda b: sum(int(c) for c in b) / len(b),
+        infrastructure="local",
+        nodes=1,
+        cores_per_qpu=1,
+        id="qml_validation",
+        seed=7,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.vqc
+class TestQmlTrainRowDimensionSymmetry:
+    def test_row_longer_than_feature_map_raises(self):
+        feature_map, ansatz = _feature_map_ansatz()
+        # feature_map expects 2 features; this row supplies 3.
+        x_train = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        with pytest.raises(ValueError, match=r"row 0 has 3 features.*expects 2"):
+            _qml_train(feature_map, ansatz, x_train, len(ansatz.parameters))
+
+    def test_row_shorter_than_feature_map_raises(self):
+        feature_map, ansatz = _feature_map_ansatz()
+        # feature_map expects 2 features; this row supplies 1.
+        x_train = [[0.1], [0.2]]
+        with pytest.raises(ValueError, match=r"row 0 has 1 features.*expects 2"):
+            _qml_train(feature_map, ansatz, x_train, len(ansatz.parameters))
+
+    def test_dimensions_mismatch_raises(self):
+        feature_map, ansatz = _feature_map_ansatz()
+        # An otherwise-valid x_train (2 features per row) isolates the failure to
+        # the dimensions/ansatz mismatch rather than the row width.
+        x_train = [[0.1, 0.2], [0.3, 0.4]]
+        wrong_dimensions = len(ansatz.parameters) + 1
+        with pytest.raises(ValueError, match="does not match"):
+            _qml_train(feature_map, ansatz, x_train, wrong_dimensions)


### PR DESCRIPTION
Summary
qml.train had two validation gaps that produced silent data loss or late, cryptic failures. This PR closes both with early, explicit ValueErrors and codifies the agreement as a new inter-layer contract (C-8).

Fixes [#79].

Problem
Silent row truncation. The loop pre-binding each x_train row to the feature-map parameters used fm_params_list.zip(row), which stops at the shorter iterator. A row with more features than the feature map has parameters silently dropped the extras; a row with fewer left feature-map parameters unbound, surfacing later as an opaque Qiskit binding error deep inside the oracle.
Unvalidated dimensions. Unlike train — which checks dimensions against circuit_source.num_params() and raises early — qml.train never validated dimensions against len(ansatz.parameters), so a mismatch also failed late and cryptically.
Changes
crates/polypus/src/bindings/mod.rs (qml_train only):
Added a dimensions vs len(ansatz.parameters) check right after the native-backend rejection and before composing the circuit, mirroring train's message style.
Rewrote the row-binding loop to materialize fm_len once and each row_len, rejecting a mismatch upfront with a ValueError naming the 0-based row index and both lengths. A row without __len__ (e.g. a generator) propagates its own type error unchanged — no masking.
docs/CONTRACTS.md: new C-8 · qml.train row/dimension symmetry section and its Status at a glance row.
tests/python/test_qml_train_validation.py (new): three tests — row longer than the feature map, row shorter, and dimensions != len(ansatz.parameters) — asserting via pytest.raises(ValueError, match=…) on stable message fragments. All fail during upfront validation, so no backend is touched.
Verification
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p polypus
maturin develop --release --features extension-module
pytest tests/python/test_qml_train_validation.py -v — 3 passed