### PR TITLE
Documentation problems solved

### DIFF
--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -384,8 +384,11 @@ fn extract_bound_circuit(qc: &Bound<'_, PyAny>) -> PyResult<BoundCircuit> {
 /// Function to run a quantum circuit called from Python.
 ///
 /// `qc` may be a Qiskit `QuantumCircuit`, a `polypus.Circuit` (fully bound),
-/// or an OpenQASM 2.0 string. `backend` selects the local device: `"aer"`
-/// (default) or the pure-Rust `"polypus"` statevector simulator.
+/// or an OpenQASM 2.0 string. The meaning of `backend` depends on
+/// `infrastructure`: for `"local"` it selects the device — `"aer"` (default)
+/// or the pure-Rust `"polypus"` statevector simulator; for `"qmio"` it
+/// instead selects the program format submitted to the QPU (`"openqasm"`
+/// (default), `"qir"`, or `"qir_bitcode"`); CUNQA ignores it.
 ///
 /// `seed` controls shot sampling (contract C-7) on every simulated backend —
 /// native, Aer (`infrastructure="local"`) and CUNQA's simulated QPUs

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -58,8 +58,10 @@ impl OracleErrorSlot {
 /// - [`Qiskit`](CircuitSource::Qiskit): `assign_parameters` is called on the
 ///   Python object — requires the GIL for every candidate.
 /// - [`Native`](CircuitSource::Native): binding + OpenQASM 2.0 generation run
-///   in pure Rust — **no GIL**, so candidates can be bound truly in parallel
-///   and the only remaining Python touchpoint is the simulator call itself.
+///   in pure Rust — **no GIL**, so candidates can be bound without holding the
+///   interpreter lock (binding itself is still sequential today, not
+///   parallel — see `VqcOracle::try_evaluate`) and the only remaining Python
+///   touchpoint is the simulator call itself.
 pub enum CircuitSource {
     /// A Qiskit `QuantumCircuit` with unbound `Parameter`s.
     Qiskit(Py<PyAny>),

--- a/crates/polypus/src/infrastructure/execution_config.rs
+++ b/crates/polypus/src/infrastructure/execution_config.rs
@@ -37,15 +37,18 @@ pub struct ExecutionConfig {
     pub opt_level: OptLevel,
     /// Explicit RNG seed for shot sampling.
     ///
-    /// Only the native statevector backend
+    /// Consumed by every backend that samples shots itself: the native
+    /// statevector backend
     /// ([`NativeStatevectorBackend`](crate::infrastructure::NativeStatevectorBackend))
-    /// consumes this: it seeds the per-circuit sampling stream, making counts
-    /// reproducible. The Python-facing layer resolves it to `Some` whenever the
-    /// native backend runs (user-supplied value or a fresh OS-entropy draw), so
-    /// the effective seed can be reported back in the run manifest (contract
-    /// C-7). Every other backend ignores it; `None` means "no explicit seed"
-    /// and the native backend falls back to a fresh OS-entropy draw. Decoupled
-    /// from [`id`](Self::id), which is only a logging/temp-file/SLURM label.
+    /// seeds its per-circuit sampling stream directly, while [`Local`](BackendConfig::Local)
+    /// and [`Cunqa`](BackendConfig::Cunqa) forward it to the underlying Aer
+    /// (`seed_simulator`) and CUNQA `run(..., seed=...)` calls respectively.
+    /// The Python-facing layer resolves it to `Some` whenever a seed-consuming
+    /// backend runs (user-supplied value or a fresh OS-entropy draw), so the
+    /// effective seed can be reported back in the run manifest (contract
+    /// C-7). `None` means "no explicit seed", and each backend falls back to
+    /// its own unseeded default. Decoupled from [`id`](Self::id), which is
+    /// only a logging/temp-file/SLURM label.
     pub seed: Option<u64>,
 }
 
@@ -106,7 +109,7 @@ pub enum BackendConfig {
         endpoint: String,
         /// Representation of the program submitted to the QPU.
         program_format: QmioProgramFormat,
-        /// Tket optimisation level (`0`/`1`/`2` → Tket `$value` `1`/`18`/`30`).
+        /// Tket optimisation level (`0`/`1`/`2`/`3` → Tket `$value` `0`/`1`/`18`/`30`).
         optimization: u8,
         /// Repetition period (`None` = server default).
         repetition_period: Option<f64>,

--- a/crates/polypus/src/infrastructure/qmio.rs
+++ b/crates/polypus/src/infrastructure/qmio.rs
@@ -22,10 +22,10 @@
 //!     `qat.purr.compiler.config.CompilerConfig` via `$type`/`$data`/`$value`
 //!     tags. `qat` does **not** need to be installed; we build it by hand with
 //!     `serde_json` (see [`build_config_json`]).
-//! - **Reply** = a pickle of a Python `dict` with the results (the live QPU
-//!   pickles the dict directly; some builds may instead pickle a JSON string).
-//!   Decode path: `recv` bytes → `serde_pickle` → `dict`/`String` →
-//!   `serde_json::Value` → per-bitstring counts.
+//! - **Reply** = a pickle of the results (the live QPU pickles a JSON string;
+//!   a server that pickles a `dict` directly instead is also accepted as a
+//!   defensive fallback). Decode path: `recv` bytes → `serde_pickle` →
+//!   `String`/`dict` → `serde_json::Value` → per-bitstring counts.
 //!
 //! ## Security
 //!
@@ -203,8 +203,9 @@ pub struct QmioBackend {
 impl QmioBackend {
     /// Create a backend targeting `endpoint`.
     ///
-    /// Timeouts and retry limits can be overridden via the `QMIO_RECV_TIMEOUT_MS`
-    /// and `QMIO_MAX_RETRIES` environment variables (sensible defaults otherwise).
+    /// Timeouts and retry behaviour can be overridden via the `QMIO_RECV_TIMEOUT_MS`,
+    /// `QMIO_MAX_RETRIES` and `QMIO_RETRY_BACKOFF_MS` environment variables
+    /// (sensible defaults otherwise).
     pub fn new(
         endpoint: String,
         program_format: QmioProgramFormat,

--- a/crates/polypus/src/lib.rs
+++ b/crates/polypus/src/lib.rs
@@ -5,9 +5,13 @@
 //! Polypus is a distributed quantum computing library designed to optimize the execution of quantum algorithms by distributing computation
 //! across available hardware resources. The core is written in Rust; Python bindings are provided via PyO3.
 //!
-//! Polypus is agnostic to the underlying hardware infrastructure. Currently two backends are supported:
-//! - **local**: Runs on local infrastructure using Qiskit AerSimulator.
+//! Polypus is agnostic to the underlying hardware infrastructure. Currently three
+//! `infrastructure` values are supported:
+//! - **local**: Runs on local infrastructure. Defaults to Qiskit AerSimulator
+//!   (`backend="aer"`); pass `backend="polypus"` to run instead on the noiseless
+//!   statevector simulator implemented natively in Rust (no Qiskit, no GIL).
 //! - **cunqa**: Distributed QPU platform developed by CESGA (<https://github.com/CESGA-Quantum-Spain/cunqa>).
+//! - **qmio**: CESGA's real QPU, reached directly over its ZeroMQ wire protocol (`--features qmio`).
 //!
 //! ## Features
 //! - Run a quantum circuit on one or multiple QPUs.


### PR DESCRIPTION
execution_config.rs — the seed doc now says Local and Cunqa also consume it (forwarded to seed_simulator/CUNQA run(seed=...)), not just the native backend.
execution_config.rs:112 — Tket mapping corrected to 0/1/2/3 → 0/1/18/30.
lib.rs:8-12 — now lists all three infrastructure values (local, cunqa, qmio) and mentions the native polypus backend within local.
qmio.rs:25-28 — module doc now matches parse_counts: the real QPU pickles a JSON string; the direct dict is the defensive fallback.
qmio.rs:206 — added QMIO_RETRY_BACKOFF_MS to the QmioBackend::new docstring.
evaluation/mod.rs:60-64 — softened the "truly parallel" claim to "GIL-free", noting that binding is still sequential today.
bindings/mod.rs:387 — documented that under infrastructure="qmio", backend selects the program format (openqasm/qir/qir_bitcode), not the device.