### PR TITLE
81 result extraction failures are misclassified as seam errors qml rust side failures surface as bare runtimeerror

### DIFF
--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -39,6 +39,11 @@ pub enum EvaluationError {
     /// `JoinError`). Never a Python exception, so unlike `Python` it must not be
     /// re-raised verbatim.
     Runtime(String),
+    /// Converting data across the Rust↔Python boundary on the evaluation path
+    /// failed (e.g. `expectation_values`'s return value isn't `list[float]`).
+    /// Unlike `Python`, this never originated in a raised Python exception, so
+    /// it must not be re-raised verbatim.
+    Conversion(String),
 }
 
 impl fmt::Display for EvaluationError {
@@ -48,6 +53,9 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Binding(err) => write!(f, "circuit binding failed: {err}"),
             EvaluationError::Python(err) => write!(f, "Python evaluation error: {err}"),
             EvaluationError::Runtime(m) => write!(f, "QML evaluation runtime error: {m}"),
+            EvaluationError::Conversion(m) => {
+                write!(f, "data conversion across the Python boundary failed: {m}")
+            }
         }
     }
 }
@@ -72,6 +80,9 @@ impl From<EvaluationError> for PyErr {
             // A Rust-side infrastructure failure: surface as the typed
             // polypus.EvaluationError, not PyO3's generic RuntimeError.
             EvaluationError::Runtime(m) => PyEvaluationError::new_err(m),
+            // A Rust-side data-conversion failure: surface as the typed
+            // polypus.EvaluationError, not the TypeError PyO3's extract() emits.
+            EvaluationError::Conversion(m) => PyEvaluationError::new_err(m),
         }
     }
 }
@@ -79,7 +90,7 @@ impl From<EvaluationError> for PyErr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::exceptions::PyRuntimeError;
+    use pyo3::exceptions::{PyRuntimeError, PyTypeError};
     use pyo3::types::PyAnyMethods;
     use pyo3::Python;
 
@@ -108,6 +119,34 @@ mod tests {
             );
             assert!(
                 err.to_string().contains("worker panicked"),
+                "the descriptive message must be preserved"
+            );
+        });
+    }
+
+    /// A wrong-shaped `expectation_values` return value is modelled by
+    /// [`EvaluationError::Conversion`]: a Rust-side data-conversion failure, not
+    /// a raised Python exception. It must cross the FFI as the typed
+    /// `polypus.EvaluationError`, never as the generic `TypeError` that PyO3's
+    /// `extract()` would otherwise emit. (End-to-end coverage lives in the
+    /// Python suite; this pins the mapping in isolation.)
+    #[test]
+    fn conversion_variant_maps_to_typed_evaluation_error() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let err: PyErr = EvaluationError::Conversion("not list[float]".to_string()).into();
+            assert!(
+                err.value(py).is_instance_of::<PyEvaluationError>(),
+                "Conversion must surface as polypus.EvaluationError"
+            );
+            // ...and specifically not the plain TypeError that extract() emits,
+            // which is what the pre-fix code let through verbatim.
+            assert!(
+                !err.value(py).is_instance_of::<PyTypeError>(),
+                "Conversion must not surface as the generic TypeError"
+            );
+            assert!(
+                err.to_string().contains("not list[float]"),
                 "the descriptive message must be preserved"
             );
         });

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -34,6 +34,11 @@ pub enum EvaluationError {
     /// A Python callback or conversion on the evaluation path raised. Carried
     /// verbatim so the original exception type is preserved across the FFI.
     Python(PyErr),
+    /// A Rust-originated infrastructure failure on the QML evaluation path
+    /// (Tokio runtime construction, or a worker task panic surfaced as a
+    /// `JoinError`). Never a Python exception, so unlike `Python` it must not be
+    /// re-raised verbatim.
+    Runtime(String),
 }
 
 impl fmt::Display for EvaluationError {
@@ -42,6 +47,7 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Backend(err) => write!(f, "{err}"),
             EvaluationError::Binding(err) => write!(f, "circuit binding failed: {err}"),
             EvaluationError::Python(err) => write!(f, "Python evaluation error: {err}"),
+            EvaluationError::Runtime(m) => write!(f, "QML evaluation runtime error: {m}"),
         }
     }
 }
@@ -63,6 +69,47 @@ impl From<EvaluationError> for PyErr {
             }
             // Preserve the original Python exception type raised by the callback.
             EvaluationError::Python(py_err) => py_err,
+            // A Rust-side infrastructure failure: surface as the typed
+            // polypus.EvaluationError, not PyO3's generic RuntimeError.
+            EvaluationError::Runtime(m) => PyEvaluationError::new_err(m),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::exceptions::PyRuntimeError;
+    use pyo3::types::PyAnyMethods;
+    use pyo3::Python;
+
+    /// A QML infrastructure failure (Tokio runtime construction or a
+    /// `spawn_blocking` worker panic surfaced as a `JoinError`) is modelled by
+    /// [`EvaluationError::Runtime`]. Forcing either condition deterministically
+    /// from a test is neither viable nor portable — OS resource exhaustion for
+    /// the runtime, and `evaluate_qml_single` is deliberately written not to
+    /// panic — so instead we pin the *mapping*: `Runtime` must cross the FFI as
+    /// the typed `polypus.EvaluationError`, never PyO3's generic
+    /// `RuntimeError`. (Scope decision documented in the PR for issue #81.)
+    #[test]
+    fn runtime_variant_maps_to_typed_evaluation_error() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let err: PyErr = EvaluationError::Runtime("worker panicked".to_string()).into();
+            assert!(
+                err.value(py).is_instance_of::<PyEvaluationError>(),
+                "Runtime must surface as polypus.EvaluationError"
+            );
+            // ...and specifically not PyO3's generic RuntimeError, which is what
+            // the pre-fix code raised for this Rust-side infrastructure failure.
+            assert!(
+                !err.value(py).is_instance_of::<PyRuntimeError>(),
+                "Runtime must not surface as the generic RuntimeError"
+            );
+            assert!(
+                err.to_string().contains("worker panicked"),
+                "the descriptive message must be preserved"
+            );
+        });
     }
 }

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -44,6 +44,12 @@ pub enum EvaluationError {
     /// Unlike `Python`, this never originated in a raised Python exception, so
     /// it must not be re-raised verbatim.
     Conversion(String),
+    /// The Python-backed oracle returned a different number of expectation
+    /// values than circuits were submitted in this call (contract C-5).
+    WrongLength { expected: usize, got: usize },
+    /// The Python-backed oracle returned a non-finite expectation value
+    /// (contract C-5 requires every output to be a finite f64).
+    NonFinite { index: usize, value: f64 },
 }
 
 impl fmt::Display for EvaluationError {
@@ -56,6 +62,14 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Conversion(m) => {
                 write!(f, "data conversion across the Python boundary failed: {m}")
             }
+            EvaluationError::WrongLength { expected, got } => write!(
+                f,
+                "oracle returned the wrong number of expectation values: expected {expected} (one per submitted circuit) but got {got} (contract C-5)"
+            ),
+            EvaluationError::NonFinite { index, value } => write!(
+                f,
+                "oracle returned a non-finite expectation value {value} at index {index}; contract C-5 requires every output to be a finite f64"
+            ),
         }
     }
 }
@@ -83,10 +97,13 @@ impl From<EvaluationError> for PyErr {
             // A Rust-side data-conversion failure: surface as the typed
             // polypus.EvaluationError, not the TypeError PyO3's extract() emits.
             EvaluationError::Conversion(m) => PyEvaluationError::new_err(m),
+            wrong_length @ EvaluationError::WrongLength { .. } => {
+                PyEvaluationError::new_err(wrong_length.to_string())
+            }
+            non_finite @ EvaluationError::NonFinite { .. } => {
+                PyEvaluationError::new_err(non_finite.to_string())
+            }
         }
-        .to_string();
-        assert!(msg.contains('3'), "offending index missing from: {msg}");
-        assert!(msg.contains("NaN"), "offending value missing from: {msg}");
     }
 }
 
@@ -153,5 +170,27 @@ mod tests {
                 "the descriptive message must be preserved"
             );
         });
+    }
+
+    #[test]
+    fn wrong_length_display_names_both_lengths() {
+        let msg = EvaluationError::WrongLength {
+            expected: 4,
+            got: 2,
+        }
+        .to_string();
+        assert!(msg.contains('4'), "expected length missing from: {msg}");
+        assert!(msg.contains('2'), "got length missing from: {msg}");
+    }
+
+    #[test]
+    fn non_finite_display_names_index_and_value() {
+        let msg = EvaluationError::NonFinite {
+            index: 3,
+            value: f64::NAN,
+        }
+        .to_string();
+        assert!(msg.contains('3'), "offending index missing from: {msg}");
+        assert!(msg.contains("NaN"), "offending value missing from: {msg}");
     }
 }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -151,9 +151,12 @@ pub use polypus_optimizers::EvaluationOracle;
 /// `polypus_python.expectation_values`, eliminating the duplication that
 /// previously existed across DE, PSO, QNG, and the orchestration layer.
 ///
-/// Returns an [`EvaluationError`] on any failure: a backend error is wrapped,
-/// and a Python error (import, `expectation_values`, extraction) is carried
-/// verbatim — never a panic.
+/// Returns an [`EvaluationError`] on any failure: a backend error is wrapped;
+/// a raised Python exception (import, a pending `KeyboardInterrupt`, or one
+/// thrown by `expectation_values` / the user callback) is carried verbatim; and
+/// a wrong-shaped `expectation_values` return value — a Rust-side conversion
+/// failure, not a raised exception — becomes [`EvaluationError::Conversion`].
+/// Never a panic.
 pub(crate) fn run_and_evaluate(
     backend: &dyn QuantumBackend,
     qcs: &[BoundCircuit],
@@ -180,7 +183,13 @@ pub(crate) fn run_and_evaluate(
             .map_err(EvaluationError::Python)?
             .call_method("expectation_values", (py_counts, expectation_fn), None)
             .map_err(EvaluationError::Python)?
+            // `expectation_values` returned successfully; a wrong-shaped value
+            // is a Rust-side conversion failure, not a raised Python exception.
             .extract::<Vec<f64>>()
-            .map_err(EvaluationError::Python)
+            .map_err(|e| {
+                EvaluationError::Conversion(format!(
+                    "expected expectation_values() to return list[float]: {e}"
+                ))
+            })
     })
 }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -192,6 +192,24 @@ pub(crate) fn run_and_evaluate(
                 EvaluationError::Conversion(format!(
                     "expected expectation_values() to return list[float]: {e}"
                 ))
-            })
+            })?;
+
+        // Contract C-5: the Python-backed oracle must return exactly one finite
+        // f64 per submitted circuit. This is the single choke point that calls
+        // `polypus_python.expectation_values`, so validating here protects every
+        // oracle: a short list would otherwise index out of bounds inside the
+        // pure-Rust optimizer (an uncatchable `PanicException` across the FFI),
+        // and a NaN/inf would silently poison the optimizer and yield a bogus
+        // result with no error at all.
+        if values.len() != qcs.len() {
+            return Err(EvaluationError::WrongLength {
+                expected: qcs.len(),
+                got: values.len(),
+            });
+        }
+        if let Some((index, &value)) = values.iter().enumerate().find(|(_, v)| !v.is_finite()) {
+            return Err(EvaluationError::NonFinite { index, value });
+        }
+        Ok(values)
     })
 }

--- a/crates/polypus/src/evaluation/qml_oracle.rs
+++ b/crates/polypus/src/evaluation/qml_oracle.rs
@@ -50,9 +50,9 @@ impl QmlOracle {
     /// yield finite sentinels while the entry point re-raises it.
     fn try_evaluate(&self, candidates: &[Vec<f64>]) -> Result<Vec<f64>, EvaluationError> {
         let rt = crate::utils::tokio_runtime().map_err(|e| {
-            EvaluationError::Python(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            EvaluationError::Runtime(format!(
                 "failed to start the Tokio runtime for QML evaluation: {e}"
-            )))
+            ))
         })?;
 
         let handles: Vec<_> = candidates
@@ -89,9 +89,7 @@ impl QmlOracle {
                         // A `JoinError` means the worker task itself panicked;
                         // turn it into a typed error rather than re-panicking.
                         let single = h.await.map_err(|e| {
-                            EvaluationError::Python(pyo3::exceptions::PyRuntimeError::new_err(
-                                format!("QML evaluation task failed: {e}"),
-                            ))
+                            EvaluationError::Runtime(format!("QML evaluation task failed: {e}"))
                         })?;
                         out.push(single?);
                     }

--- a/crates/polypus/src/infrastructure/cunqa.rs
+++ b/crates/polypus/src/infrastructure/cunqa.rs
@@ -84,9 +84,13 @@ impl QuantumBackend for CunqaBackend {
                     log::error!("CUNQA circuit execution failed: {e}");
                     BackendError::Seam(e)
                 })?;
-            result
-                .extract::<Vec<HashMap<String, u64>>>()
-                .map_err(BackendError::Seam)
+            // `run_qcs` returned successfully; a wrong-shaped value is a
+            // Rust-side conversion failure, not a seam exception (contract C-1).
+            result.extract::<Vec<HashMap<String, u64>>>().map_err(|e| {
+                BackendError::Conversion(format!(
+                    "expected run_qcs() to return list[dict[str, int]] (contract C-1): {e}"
+                ))
+            })
         })
     }
 

--- a/crates/polypus/src/infrastructure/local.rs
+++ b/crates/polypus/src/infrastructure/local.rs
@@ -60,7 +60,13 @@ impl QuantumBackend for LocalBackend {
                     log::error!("local infrastructure connection failed: {e}");
                     BackendError::Seam(e)
                 })?;
-            let connection_str = connection.extract::<String>().map_err(BackendError::Seam)?;
+            // The call above succeeded; a wrong-shaped return value is our
+            // Rust-side conversion failure, not a seam exception (contract C-1).
+            let connection_str = connection.extract::<String>().map_err(|e| {
+                BackendError::Conversion(format!(
+                    "expected connect_to_infrastructure(\"local\") to return str: {e}"
+                ))
+            })?;
 
             let kwargs = PyDict::new(py);
             let conv = |e: PyErr| BackendError::Conversion(e.to_string());
@@ -89,9 +95,13 @@ impl QuantumBackend for LocalBackend {
                     log::error!("local circuit execution failed: {e}");
                     BackendError::Seam(e)
                 })?;
-            result
-                .extract::<Vec<HashMap<String, u64>>>()
-                .map_err(BackendError::Seam)
+            // As above: `run_qcs` returned successfully, so a wrong-shaped
+            // value is a Rust-side conversion failure, not a seam exception.
+            result.extract::<Vec<HashMap<String, u64>>>().map_err(|e| {
+                BackendError::Conversion(format!(
+                    "expected run_qcs() to return list[dict[str, int]] (contract C-1): {e}"
+                ))
+            })
         })
     }
 }

--- a/tests/python/test_evaluation_extraction.py
+++ b/tests/python/test_evaluation_extraction.py
@@ -1,0 +1,85 @@
+"""
+Result-extraction failures on the evaluation path (issue #81 follow-up).
+
+``run_and_evaluate`` is the single caller of ``polypus_python.expectation_values``
+(used by ``polypus.train`` via ``VqcOracle`` and ``polypus.qml.train`` via
+``QmlOracle``). When ``expectation_values`` *succeeds* but returns a value whose
+shape isn't ``list[float]``, converting it Rust-side fails — that is a
+``EvaluationError::Conversion``, surfaced as ``polypus.EvaluationError``, not the
+bare ``TypeError`` PyO3's ``extract()`` emits and not a verbatim Python
+exception (which is reserved for a genuinely *raised* callback/seam error).
+
+This mirrors the ``test_seam_extraction.py`` tests for the ``run_qcs`` /
+``connect_to_infrastructure`` seam. It exercises the shortest reachable path,
+``polypus.train`` with ``infrastructure="local"`` (no SLURM), and monkeypatches
+``expectation_values`` so the wrong shape is forced deterministically.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.vqc]
+
+
+def _train(parametrized_circuit, simple_expectation_fn, run_id):
+    import polypus
+
+    return polypus.train(
+        parametrized_circuit,
+        polypus.DE(generations=2, population_size=4, tolerance=0.5),
+        shots=64,
+        n_qpus=1,
+        dimensions=1,
+        expectation_function=simple_expectation_fn,
+        infrastructure="local",
+        nodes=1,
+        cores_per_qpu=1,
+        id=run_id,
+    )
+
+
+def test_expectation_values_returning_scalar_is_evaluation_error(
+    monkeypatch, parametrized_circuit, simple_expectation_fn
+):
+    # expectation_values succeeds but returns a bare float instead of
+    # list[float]. The Rust-side extraction failure must be EvaluationError,
+    # not the plain TypeError extract() would surface pre-fix.
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "expectation_values", lambda *a, **k: 0.5)
+    with pytest.raises(polypus.EvaluationError) as excinfo:
+        _train(parametrized_circuit, simple_expectation_fn, "eval_extract_scalar")
+    assert not isinstance(excinfo.value, TypeError), (
+        "a wrong-shaped return value must not be reported as the plain "
+        "TypeError that PyO3's extract() emits"
+    )
+
+
+def test_expectation_values_returning_none_is_evaluation_error(
+    monkeypatch, parametrized_circuit, simple_expectation_fn
+):
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "expectation_values", lambda *a, **k: None)
+    with pytest.raises(polypus.EvaluationError):
+        _train(parametrized_circuit, simple_expectation_fn, "eval_extract_none")
+
+
+def test_expectation_callback_exception_propagates_verbatim(
+    monkeypatch, parametrized_circuit
+):
+    # Negative case: when the user's expectation_function *raises* (rather than
+    # returning a wrong shape), that genuine Python exception must propagate
+    # verbatim as itself, not be reclassified as polypus.EvaluationError.
+    import polypus
+
+    def exploding_expectation(_bitstring):
+        raise ValueError("user callback blew up")
+
+    with pytest.raises(ValueError, match="user callback blew up") as excinfo:
+        _train(parametrized_circuit, exploding_expectation, "eval_callback_raises")
+    assert not isinstance(excinfo.value, polypus.EvaluationError), (
+        "a genuine raised callback exception must not be reclassified as "
+        "polypus.EvaluationError"
+    )

--- a/tests/python/test_qml_error_propagation.py
+++ b/tests/python/test_qml_error_propagation.py
@@ -1,0 +1,66 @@
+"""
+QML evaluation-path error classification (issue #81, Change 2).
+
+``EvaluationError::Runtime`` (Tokio runtime construction, or a ``spawn_blocking``
+worker panic surfaced as a ``JoinError``) is a Rust-side infrastructure failure
+and now surfaces as ``polypus.EvaluationError`` rather than a bare
+``RuntimeError`` — pinned by the Rust unit test in
+``crates/polypus/src/evaluation/error.rs`` (forcing those OS-level conditions
+deterministically from Python is neither viable nor portable; see the PR).
+
+This test guards the *other* side of that change: a genuine Python exception
+raised by the user's ``expectation_function`` callback must still propagate
+**verbatim** (as itself), never be reclassified as ``polypus.EvaluationError``.
+It runs on the ``local`` path with a mocked backend, so no SLURM/hardware.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.vqc]
+
+
+def _patch_deterministic_backend(monkeypatch):
+    import polypus_python
+
+    def fake_run_qcs(infrastructure, **kwargs):
+        return [{"1": kwargs["shots"]} for _ in kwargs["qcs"]]
+
+    monkeypatch.setattr(polypus_python, "run_qcs", fake_run_qcs)
+
+
+def test_qml_callback_exception_propagates_verbatim(monkeypatch):
+    import numpy as np
+    import polypus
+    from qiskit.circuit.library import real_amplitudes, zz_feature_map
+
+    _patch_deterministic_backend(monkeypatch)
+
+    def exploding_expectation(_bitstring):
+        raise ValueError("user callback blew up")
+
+    feature_map = zz_feature_map(feature_dimension=2, reps=1)
+    ansatz = real_amplitudes(num_qubits=2, reps=1)
+    x_train = np.zeros((2, 2))
+
+    # The user's callback raises ValueError; contract C-1 / ENGINEERING.md §9
+    # require it to reach the caller as that same ValueError, not wrapped in
+    # polypus.EvaluationError.
+    with pytest.raises(ValueError, match="user callback blew up") as excinfo:
+        polypus.qml.train(
+            feature_map,
+            ansatz,
+            x_train,
+            polypus.DE(generations=2, population_size=4, tolerance=0.5),
+            shots=64,
+            n_qpus=1,
+            dimensions=len(ansatz.parameters),
+            expectation_function=exploding_expectation,
+            infrastructure="local",
+            nodes=1,
+            cores_per_qpu=1,
+            id="qml_verbatim_error",
+        )
+    assert not isinstance(excinfo.value, polypus.EvaluationError), (
+        "a genuine Python callback exception must not be reclassified as "
+        "polypus.EvaluationError"
+    )

--- a/tests/python/test_seam_extraction.py
+++ b/tests/python/test_seam_extraction.py
@@ -1,0 +1,68 @@
+"""
+Result-extraction failures at the ``polypus_python`` seam (issue #81).
+
+Contract C-1 re-raises a failure *thrown by the Python seam* verbatim (e.g.
+``ValueError`` for an unknown infrastructure, ``TypeError`` for a bad kwarg).
+But a seam call that *succeeds* and returns a value of the wrong shape is a
+Rust-side data-conversion failure, not a seam exception, so it must surface as
+``polypus.BackendError`` (mapped from ``BackendError::Conversion``), not as a
+bare ``TypeError`` from PyO3's extraction.
+
+These tests monkeypatch the seam (no SLURM / hardware needed), mirroring the
+style of ``test_seam_contract.py``. They exercise the ``local`` path: a real
+``connect_to_infrastructure("local")`` with a mocked ``run_qcs`` for the
+run-result case, and a mocked ``connect_to_infrastructure`` for the handle case.
+"""
+
+import pytest
+
+
+def _native_qc():
+    import polypus
+
+    return polypus.Circuit(1).h(0).measure_all()
+
+
+def _run_local():
+    import polypus
+
+    return polypus.run_quantum_circuit(
+        _native_qc(), shots=10, infrastructure="local", backend="aer"
+    )
+
+
+def test_run_qcs_returning_non_list_of_dicts_is_backend_error(monkeypatch):
+    # run_qcs succeeds but returns list[str] instead of list[dict[str, int]].
+    # The extraction failure is Rust-side, so it must be BackendError, not the
+    # raw TypeError that C-1 reserves for a genuine bad-kwarg seam failure.
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "run_qcs", lambda *a, **k: ["not", "dicts"])
+    with pytest.raises(polypus.BackendError) as excinfo:
+        _run_local()
+    assert not isinstance(excinfo.value, TypeError), (
+        "a wrong-shaped return value must not be reported as the plain "
+        "TypeError that C-1 uses for a bad kwarg"
+    )
+
+
+def test_run_qcs_returning_none_is_backend_error(monkeypatch):
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "run_qcs", lambda *a, **k: None)
+    with pytest.raises(polypus.BackendError):
+        _run_local()
+
+
+def test_connect_returning_non_str_is_backend_error(monkeypatch):
+    # connect_to_infrastructure succeeds but returns an int instead of a str
+    # connection handle: again a Rust-side extraction failure => BackendError.
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "connect_to_infrastructure", lambda *a, **k: 42)
+    with pytest.raises(polypus.BackendError) as excinfo:
+        _run_local()
+    assert not isinstance(excinfo.value, TypeError)


### PR DESCRIPTION
Problem
Contract C-1 draws a line between two kinds of failure at the Rust↔Python seam:

A failure thrown by the Python seam (polypus_python) is re-raised verbatim — e.g. ValueError for an unknown infrastructure, TypeError for a bad kwarg.
A failure that originates in the Rust layer — including a Rust↔Python data conversion that fails because the seam returned the wrong shape — must surface as a typed polypus.* class (docs/ENGINEERING.md §9, crates/polypus/src/exceptions.rs).
Several sites violated that line: a seam call would succeed, and the subsequent Rust-side .extract() of its return value would fail, but the failure was mapped to a "seam" error (re-raised verbatim) or to PyO3's generic exception, rather than to a typed polypus.* class.

Changes
1. Backend result-extraction failures → BackendError::Conversion (commit e7754ce)

In crates/polypus/src/infrastructure/local.rs and cunqa.rs, the .extract() calls over values already returned successfully by connect_to_infrastructure / run_qcs now map to BackendError::Conversion (→ polypus.BackendError), with messages naming the expected shape (e.g. expected run_qcs() to return list[dict[str, int]] (contract C-1)). The lines that map the call failure itself remain BackendError::Seam — legitimately verbatim per C-1.

2. QML Rust-side infrastructure failures → polypus.EvaluationError (commit e7754ce)

In crates/polypus/src/evaluation/qml_oracle.rs, Tokio runtime construction failures and spawn_blocking worker panics (JoinError) were wrapped as EvaluationError::Python(PyRuntimeError::new_err(...)), surfacing as a bare RuntimeError. A new EvaluationError::Runtime(String) variant makes them surface as the typed polypus.EvaluationError. The genuine-Python uses (py.check_signals() KeyboardInterrupt, the user's expectation_function callback) stay verbatim.

3. expectation_values shape mismatch → EvaluationError::Conversion (commit 20642a1)

A related site found while implementing the above, not mentioned in the original issue: run_and_evaluate (crates/polypus/src/evaluation/mod.rs) is the single caller of polypus_python.expectation_values (used by polypus.train via VqcOracle and polypus.qml.train via QmlOracle). Its final .extract::<Vec<f64>>() mapped to EvaluationError::Python, so a successful call returning something that isn't list[float] surfaced as PyO3's bare TypeError. A new EvaluationError::Conversion(String) variant (kept distinct from Runtime) now classifies it as polypus.EvaluationError. check_signals and the expectation_values call itself remain verbatim.

Tests
tests/python/test_seam_extraction.py — run_qcs / connect_to_infrastructure returning the wrong shape → polypus.BackendError (and explicitly not TypeError).
tests/python/test_evaluation_extraction.py — expectation_values returning a scalar / None → polypus.EvaluationError (and not TypeError); plus a negative test that a genuinely-raised callback ValueError still propagates verbatim.
tests/python/test_qml_error_propagation.py — a genuinely-raised QML callback exception propagates verbatim, not reclassified.
Rust unit tests in crates/polypus/src/evaluation/error.rs pin the Runtime and Conversion → polypus.EvaluationError mappings in isolation. Forcing a real Tokio-runtime exhaustion or a worker panic deterministically from a test is neither viable nor portable (and the code is deliberately written not to panic on that path), so the mapping is pinned directly instead.
Contract C-1 behavior is intact: test_seam_contract.py stays green with no changes to its assertions.
Out of scope (follow-up finding)
counts.into_pyobject(py) in run_and_evaluate is the same Rust-side-conversion pattern, but on a Vec<HashMap<String, u64>> it cannot fail except under memory exhaustion and is in no issue — flagged here for a possible separate follow-up, not changed.

Verification
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
LD_LIBRARY_PATH=~/miniconda3/lib cargo test -p polypus
maturin develop --release --features extension-module
pytest tests/python          # 136 passed