### PR TITLE
perf(infrastructure): skip clone and QASM round-trip for identity transpiler (#83)

### DIFF
--- a/crates/polypus/src/infrastructure/mod.rs
+++ b/crates/polypus/src/infrastructure/mod.rs
@@ -203,6 +203,17 @@ impl BoundCircuit {
     ///   circuits internally, and rewriting one here would require reading its
     ///   gates through the GIL, crossing the deliberate native/Python boundary.
     pub fn transpiled(&self, transpiler: &dyn Transpiler, opts: &TranspileOptions) -> BoundCircuit {
+        // A guaranteed no-op transpiler changes nothing, so skip the parse →
+        // transpile → re-emit round trip (Qasm2) and the trait-dispatch clone
+        // (Native) entirely, keeping only the cheap representation-preserving
+        // copy. `Qiskit` is already a passthrough via `duplicate`.
+        if transpiler.is_identity() {
+            return match self {
+                BoundCircuit::Native(cc) => BoundCircuit::Native(cc.clone()),
+                BoundCircuit::Qasm2(qasm) => BoundCircuit::Qasm2(qasm.clone()),
+                BoundCircuit::Qiskit(_) => self.duplicate(),
+            };
+        }
         match self {
             BoundCircuit::Native(cc) => BoundCircuit::Native(transpiler.transpile(cc, opts)),
             BoundCircuit::Qasm2(qasm) => {

--- a/crates/polypus/src/infrastructure/native.rs
+++ b/crates/polypus/src/infrastructure/native.rs
@@ -13,6 +13,7 @@ use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Tr
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use polypus_circuit::{ConcreteCircuit, ParameterizedCircuit};
 use polypus_sim::StatevectorSimulator;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -72,17 +73,24 @@ impl NativeStatevectorBackend {
         seed: u64,
         opts: &TranspileOptions,
     ) -> Result<HashMap<String, u64>, BackendError> {
-        // Obtain a ConcreteCircuit without touching Python.
-        let concrete: ConcreteCircuit = match circuit {
-            BoundCircuit::Native(cc) => cc.clone(),
-            BoundCircuit::Qasm2(qasm) => ParameterizedCircuit::from_qasm2(qasm)
-                .and_then(|pc| pc.assign_parameters(&[]))
-                .map_err(|e| {
-                    log::error!("native backend could not parse OpenQASM 2.0: {e}");
-                    BackendError::NativeCircuit(format!(
-                        "native backend could not parse OpenQASM 2.0: {e}"
-                    ))
-                })?,
+        // Obtain a borrow of the source ConcreteCircuit without touching Python.
+        // `parsed_from_qasm` owns the parsed circuit for the Qasm2 case so that
+        // `source` can borrow it for the rest of the function (parsing is
+        // unavoidable to simulate QASM natively).
+        let parsed_from_qasm;
+        let source: &ConcreteCircuit = match circuit {
+            BoundCircuit::Native(cc) => cc,
+            BoundCircuit::Qasm2(qasm) => {
+                parsed_from_qasm = ParameterizedCircuit::from_qasm2(qasm)
+                    .and_then(|pc| pc.assign_parameters(&[]))
+                    .map_err(|e| {
+                        log::error!("native backend could not parse OpenQASM 2.0: {e}");
+                        BackendError::NativeCircuit(format!(
+                            "native backend could not parse OpenQASM 2.0: {e}"
+                        ))
+                    })?;
+                &parsed_from_qasm
+            }
             BoundCircuit::Qiskit(_) => {
                 return Err(BackendError::UnsupportedCircuit(
                     "the native statevector backend cannot execute a Qiskit QuantumCircuit; \
@@ -92,13 +100,19 @@ impl NativeStatevectorBackend {
             }
         };
 
-        // Transpile the native circuit (GIL-free) before simulating. With the
-        // default IdentityTranspiler this is a clone and changes nothing.
-        let concrete = self.transpiler.transpile(&concrete, opts);
+        // Transpile the native circuit (GIL-free) before simulating. When the
+        // transpiler is a guaranteed no-op, borrow the source directly and skip
+        // the trait-dispatch clone entirely (the default hot path).
+        let concrete: Cow<'_, ConcreteCircuit> = if self.transpiler.is_identity() {
+            Cow::Borrowed(source)
+        } else {
+            Cow::Owned(self.transpiler.transpile(source, opts))
+        };
+        let concrete = concrete.as_ref();
 
         let raw = self
             .simulator
-            .run_and_sample(&concrete, shots as usize, seed)
+            .run_and_sample(concrete, shots as usize, seed)
             .map_err(|e| {
                 log::error!("native statevector simulation failed: {e}");
                 BackendError::NativeCircuit(format!("native statevector simulation failed: {e}"))
@@ -290,6 +304,41 @@ mod tests {
         assert_eq!(native, qasm);
     }
 
+    /// Regression (issue #83): under the identity transpiler, the `Qasm2` path
+    /// of `transpiled` returns the *exact input bytes* without parsing and
+    /// re-serializing. The input carries a comment (dropped on parse) and
+    /// non-canonical spacing, so a parse + re-emit round trip provably changes
+    /// the bytes — asserting byte-identity therefore proves the parse was
+    /// skipped, not merely that the QASM happens to be stable.
+    #[test]
+    fn qasm2_identity_path_returns_input_bytes_without_reserializing() {
+        let original = "OPENQASM 2.0;\n\
+             include \"qelib1.inc\";\n\
+             // this comment is dropped when the QASM is parsed\n\
+             qreg q[2];\n\
+             h q[0];\n\
+             cx q[0], q[1];\n"
+            .to_string();
+
+        // Premise check: a naive parse + re-emit really would change the bytes,
+        // so the byte-identity assertion below is meaningful.
+        let reserialized = ParameterizedCircuit::from_qasm2(&original)
+            .and_then(|pc| pc.assign_parameters(&[]))
+            .unwrap()
+            .to_qasm2();
+        assert_ne!(
+            reserialized, original,
+            "test premise: this QASM must not round-trip byte-identically"
+        );
+
+        let out = BoundCircuit::Qasm2(original.clone())
+            .transpiled(&IdentityTranspiler, &TranspileOptions::default());
+        match out {
+            BoundCircuit::Qasm2(text) => assert_eq!(text, original),
+            _ => panic!("expected the original Qasm2 variant to be preserved"),
+        }
+    }
+
     /// An unparseable / unsupported QASM string is passed through untouched by
     /// the transpile helper instead of panicking (best-effort contract).
     #[test]
@@ -393,6 +442,120 @@ mod tests {
         assert_ne!(
             a, b,
             "no-seed runs with the same id must produce independent noise"
+        );
+    }
+
+    /// Micro-benchmark (perf evidence for issue #83, not a correctness check —
+    /// hence `#[ignore]`d and assertion-free). It isolates the exact cost the
+    /// identity-transpiler fix eliminates, side by side within one binary, so
+    /// there is no build-to-build noise and no reliance on the pre-fix code
+    /// still existing on disk.
+    ///
+    /// The full-training benchmarks (`bench_native_vs_qiskit.py`,
+    /// `bench_batching.py`) can't detect this fix: at 4–8 qubits through a DE
+    /// loop, GIL crossings, Aer/Qiskit overhead and optimizer bookkeeping dwarf
+    /// one or two `ConcreteCircuit` clones. This benchmark never calls the
+    /// simulator (qubit count stays at 8); gate *count* — which drives clone and
+    /// QASM cost — is what we scale.
+    ///
+    /// Run with:
+    /// ```text
+    /// LD_LIBRARY_PATH=~/miniconda3/lib cargo test -p polypus --lib \
+    ///   infrastructure::native::tests::bench_identity_path_avoids_clone_and_qasm_roundtrip \
+    ///   -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "perf micro-benchmark: prints timings, run explicitly with --ignored --nocapture"]
+    fn bench_identity_path_avoids_clone_and_qasm_roundtrip() {
+        use std::borrow::Cow;
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        /// Gate *count* (not qubit count) drives clone/QASM cost, so we keep
+        /// qubits small and pile on gates.
+        fn big_circuit(n_gates: usize) -> ConcreteCircuit {
+            let mut pc = ParameterizedCircuit::new(8);
+            for i in 0..n_gates {
+                pc = pc.h(i % 8).cx(i % 8, (i + 1) % 8).rz(i % 8, 0.123);
+            }
+            pc.assign_parameters(&[]).unwrap()
+        }
+
+        const N: usize = 500;
+        const N_GATES: usize = 20_000;
+        let opts = TranspileOptions::default();
+        let circuit = big_circuit(N_GATES);
+        let qasm = circuit.to_qasm2();
+
+        // --- Native path: two clones (old) vs. borrow (new) ---
+        let t0 = Instant::now();
+        for _ in 0..N {
+            // Exactly what `simulate_one` used to do: clone up front, then the
+            // IdentityTranspiler clones again inside `transpile`.
+            let a = circuit.clone();
+            let b = IdentityTranspiler.transpile(&a, &opts);
+            black_box(&b);
+        }
+        let native_old_us = t0.elapsed().as_secs_f64() * 1e6 / N as f64;
+
+        let t0 = Instant::now();
+        for _ in 0..N {
+            // The `is_identity()` branch: borrow, zero clones.
+            let c: Cow<'_, ConcreteCircuit> = if IdentityTranspiler.is_identity() {
+                Cow::Borrowed(&circuit)
+            } else {
+                Cow::Owned(IdentityTranspiler.transpile(&circuit, &opts))
+            };
+            black_box(c.as_ref());
+        }
+        let native_new_us = t0.elapsed().as_secs_f64() * 1e6 / N as f64;
+
+        // --- Qasm2 path: parse+transpile+re-emit (old) vs. String clone (new) ---
+        let t0 = Instant::now();
+        for _ in 0..N {
+            // Exactly what `BoundCircuit::transpiled` used to do for Qasm2.
+            let parsed = ParameterizedCircuit::from_qasm2(&qasm)
+                .and_then(|pc| pc.assign_parameters(&[]))
+                .unwrap();
+            let out = IdentityTranspiler.transpile(&parsed, &opts).to_qasm2();
+            black_box(&out);
+        }
+        let qasm_old_us = t0.elapsed().as_secs_f64() * 1e6 / N as f64;
+
+        let t0 = Instant::now();
+        for _ in 0..N {
+            // The `is_identity()` short-circuit: a cheap String clone.
+            let out = qasm.clone();
+            black_box(&out);
+        }
+        let qasm_new_us = t0.elapsed().as_secs_f64() * 1e6 / N as f64;
+
+        // Extrapolation to the training scale used by bench_native_vs_qiskit.py
+        // (pop=20, gens=10 => 200 candidate submissions per run).
+        const SUBMISSIONS_PER_RUN: f64 = 200.0;
+        let native_saved_ms = (native_old_us - native_new_us) * SUBMISSIONS_PER_RUN / 1e3;
+        let qasm_saved_ms = (qasm_old_us - qasm_new_us) * SUBMISSIONS_PER_RUN / 1e3;
+
+        println!(
+            "\nissue #83 identity-path micro-benchmark \
+             ({N_GATES} gates, 8 qubits, mean over {N} calls):"
+        );
+        println!(
+            "  native clone+transpile (old): {native_old_us:8.2} us/call\n\
+             native borrow          (new): {native_new_us:8.2} us/call\n\
+             speedup                     : {:8.1}x",
+            native_old_us / native_new_us
+        );
+        println!(
+            "  qasm parse+transpile+emit (old): {qasm_old_us:8.2} us/call\n\
+             qasm String clone         (new): {qasm_new_us:8.2} us/call\n\
+             speedup                        : {:8.1}x",
+            qasm_old_us / qasm_new_us
+        );
+        println!(
+            "  extrapolated saved per training run ({} submissions): \
+             native {native_saved_ms:.2} ms, qasm {qasm_saved_ms:.2} ms",
+            SUBMISSIONS_PER_RUN as u64
         );
     }
 }

--- a/crates/polypus/src/infrastructure/native.rs
+++ b/crates/polypus/src/infrastructure/native.rs
@@ -12,7 +12,7 @@ use crate::infrastructure::error::BackendError;
 use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Transpiler};
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use polypus_circuit::{ConcreteCircuit, ParameterizedCircuit};
-use polypus_sim::StatevectorSimulator;
+use polypus_sim::{sample_projected, Simulator, StatevectorSimulator};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -66,29 +66,33 @@ impl NativeStatevectorBackend {
     /// [`simulate_one`](Self::simulate_one) and
     /// [`run_shots_distributed`](Self::run_shots_distributed) so both paths
     /// handle the `Native`/`Qasm2`/`Qiskit` variants and transpile identically.
-    fn concrete_circuit(
+    ///
+    /// Returns a borrow of `circuit` whenever possible instead of an owned
+    /// clone: the `Native` variant borrows directly, and when the transpiler
+    /// is a guaranteed no-op ([`Transpiler::is_identity`]) that borrow is
+    /// returned as-is, skipping the trait-dispatch clone entirely (the default
+    /// hot path). Only the `Qasm2` variant (which must be parsed into a local)
+    /// and a non-identity transpiler (which must produce a new circuit) force
+    /// an owned result.
+    fn concrete_circuit<'a>(
         &self,
-        circuit: &BoundCircuit,
+        circuit: &'a BoundCircuit,
         opts: &TranspileOptions,
-    ) -> Result<HashMap<String, u64>, BackendError> {
-        // Obtain a borrow of the source ConcreteCircuit without touching Python.
-        // `parsed_from_qasm` owns the parsed circuit for the Qasm2 case so that
-        // `source` can borrow it for the rest of the function (parsing is
-        // unavoidable to simulate QASM natively).
-        let parsed_from_qasm;
-        let source: &ConcreteCircuit = match circuit {
-            BoundCircuit::Native(cc) => cc,
-            BoundCircuit::Qasm2(qasm) => {
-                parsed_from_qasm = ParameterizedCircuit::from_qasm2(qasm)
+    ) -> Result<Cow<'a, ConcreteCircuit>, BackendError> {
+        // Obtain a ConcreteCircuit without touching Python, borrowing the
+        // source directly for the Native variant.
+        let source: Cow<'a, ConcreteCircuit> = match circuit {
+            BoundCircuit::Native(cc) => Cow::Borrowed(cc),
+            BoundCircuit::Qasm2(qasm) => Cow::Owned(
+                ParameterizedCircuit::from_qasm2(qasm)
                     .and_then(|pc| pc.assign_parameters(&[]))
                     .map_err(|e| {
                         log::error!("native backend could not parse OpenQASM 2.0: {e}");
                         BackendError::NativeCircuit(format!(
                             "native backend could not parse OpenQASM 2.0: {e}"
                         ))
-                    })?;
-                &parsed_from_qasm
-            }
+                    })?,
+            ),
             BoundCircuit::Qiskit(_) => {
                 return Err(BackendError::UnsupportedCircuit(
                     "the native statevector backend cannot execute a Qiskit QuantumCircuit; \
@@ -99,14 +103,14 @@ impl NativeStatevectorBackend {
         };
 
         // Transpile the native circuit (GIL-free) before simulating. When the
-        // transpiler is a guaranteed no-op, borrow the source directly and skip
-        // the trait-dispatch clone entirely (the default hot path).
-        let concrete: Cow<'_, ConcreteCircuit> = if self.transpiler.is_identity() {
-            Cow::Borrowed(source)
+        // transpiler is a guaranteed no-op, keep the borrow and skip the
+        // trait-dispatch clone entirely.
+        if self.transpiler.is_identity() {
+            Ok(source)
         } else {
-            Cow::Owned(self.transpiler.transpile(source, opts))
-        };
-        let concrete = concrete.as_ref();
+            Ok(Cow::Owned(self.transpiler.transpile(source.as_ref(), opts)))
+        }
+    }
 
     /// Run one bound circuit and return Aer-compatible bitstring counts.
     ///
@@ -123,12 +127,12 @@ impl NativeStatevectorBackend {
         let concrete = self.concrete_circuit(circuit, opts)?;
         let raw = self
             .simulator
-            .run_and_sample(concrete, shots as usize, seed)
+            .run_and_sample(concrete.as_ref(), shots as usize, seed)
             .map_err(|e| {
                 log::error!("native statevector simulation failed: {e}");
                 BackendError::NativeCircuit(format!("native statevector simulation failed: {e}"))
             })?;
-        Ok(format_counts(&concrete, raw))
+        Ok(format_counts(concrete.as_ref(), raw))
     }
 }
 
@@ -191,7 +195,7 @@ impl QuantumBackend for NativeStatevectorBackend {
         // Evolve the shared circuit exactly once; the statevector is reused for
         // every batch's sampling.
         let concrete = self.concrete_circuit(qc, &opts)?;
-        let sv = self.simulator.run(&concrete).map_err(|e| {
+        let sv = self.simulator.run(concrete.as_ref()).map_err(|e| {
             log::error!("native statevector simulation failed: {e}");
             BackendError::NativeCircuit(format!("native statevector simulation failed: {e}"))
         })?;
@@ -206,8 +210,8 @@ impl QuantumBackend for NativeStatevectorBackend {
             .enumerate()
             .map(|(i, &shots)| {
                 let seed = self.base_seed.wrapping_add(start).wrapping_add(i as u64);
-                let raw = sample_projected(&concrete, &sv, shots as usize, seed);
-                Ok(format_counts(&concrete, raw))
+                let raw = sample_projected(concrete.as_ref(), &sv, shots as usize, seed);
+                Ok(format_counts(concrete.as_ref(), raw))
             })
             .collect()
     }

--- a/crates/polypus/src/infrastructure/transpiler.rs
+++ b/crates/polypus/src/infrastructure/transpiler.rs
@@ -82,6 +82,15 @@ pub trait Transpiler: Send + Sync {
     /// Rewrite `circuit` into an equivalent one valid for the backend's target,
     /// honoring `opts` (e.g. optimization [`OptLevel`]).
     fn transpile(&self, circuit: &ConcreteCircuit, opts: &TranspileOptions) -> ConcreteCircuit;
+
+    /// Whether [`transpile`](Self::transpile) is guaranteed to be a no-op
+    /// (returns a circuit equal to its input) regardless of `opts`. Callers on
+    /// hot paths use this to skip calling `transpile` — and any clone/parse
+    /// leading up to it — entirely. Default `false` (conservative: only opt in
+    /// when it's actually true for every [`TranspileOptions`]).
+    fn is_identity(&self) -> bool {
+        false
+    }
 }
 
 /// No-op transpiler: returns the circuit unchanged, ignoring `opts`.
@@ -95,6 +104,11 @@ impl Transpiler for IdentityTranspiler {
     #[inline]
     fn transpile(&self, circuit: &ConcreteCircuit, _opts: &TranspileOptions) -> ConcreteCircuit {
         circuit.clone()
+    }
+
+    #[inline]
+    fn is_identity(&self) -> bool {
+        true
     }
 }
 
@@ -199,5 +213,29 @@ mod tests {
             out.gates.last(),
             Some(GateInstruction::Barrier(_))
         ));
+    }
+
+    /// `IdentityTranspiler` advertises itself as a guaranteed no-op, while a
+    /// custom `Transpiler` that does not override the default (even one that
+    /// happens to return the circuit unchanged) reports `false` — the hint is
+    /// opt-in, so callers only skip `transpile` when it is provably safe.
+    #[test]
+    fn is_identity_true_only_for_identity_transpiler() {
+        // A custom strategy that never overrides `is_identity`, keeping the
+        // conservative default. It even returns the circuit unchanged, proving
+        // the hint is about the opt-in, not the observed behavior.
+        struct DefaultingPassthrough;
+        impl Transpiler for DefaultingPassthrough {
+            fn transpile(
+                &self,
+                circuit: &ConcreteCircuit,
+                _opts: &TranspileOptions,
+            ) -> ConcreteCircuit {
+                circuit.clone()
+            }
+        }
+
+        assert!(IdentityTranspiler.is_identity());
+        assert!(!DefaultingPassthrough.is_identity());
     }
 }


### PR DESCRIPTION
## Summary

The default `IdentityTranspiler` path was paying for rewrites it never
actually did:

- `NativeStatevectorBackend::simulate_one` cloned the `ConcreteCircuit` once
  to obtain it from `BoundCircuit::Native`, then cloned it *again* inside
  `IdentityTranspiler::transpile` — two full clones per circuit, per
  submission, on the default path.
- `BoundCircuit::transpiled` (used by `LocalBackend`/`CunqaBackend` on every
  submission) parsed the `Qasm2` variant into a `ConcreteCircuit`, transpiled
  it, and re-serialized it back to OpenQASM 2.0 — a full parse + re-emit
  round trip that changes nothing under the identity transpiler.

This is paid per candidate, per generation, during training, so it's a real
hot path.

## Change

- Added `Transpiler::is_identity(&self) -> bool` as a default (`false`)
  trait method, overridden `true` on `IdentityTranspiler`. Non-breaking:
  existing `Transpiler` implementations (including the test-only
  `RecordingTranspiler`/`BarrierTranspiler`) don't need any change.
- `NativeStatevectorBackend::simulate_one` now borrows the source
  `ConcreteCircuit` instead of cloning it up front, and uses
  `Cow<'_, ConcreteCircuit>` to skip `transpile` entirely — zero clones —
  when `is_identity()` is true. Non-identity transpilers go through the
  exact same call as before.
- `BoundCircuit::transpiled` short-circuits before the `Qasm2`/`Native`
  match when `is_identity()` is true, returning `qasm.clone()` directly
  instead of parse → transpile → `to_qasm2()`.

No changes to the `Transpiler::transpile` public signature, to
`docs/CONTRACTS.md` (this isn't a seam contract), or to any file outside
`crates/polypus/src/infrastructure/`.

## Acceptance criteria

- [x] Default (identity) path no longer parses/re-emits QASM nor
      double-clones native circuits.
- [x] Non-identity transpilers behave exactly as before — existing
      `RecordingTranspiler`/`BarrierTranspiler` tests green, unmodified.
- [x] Benchmark before/after included below.

## Benchmark

The two benchmarks the issue suggested, `bench_native_vs_qiskit.py` and
`bench_batching.py`, **can't detect this fix**: at 4–8 qubits through a full
DE training loop, GIL crossings, Aer/Qiskit overhead, and optimizer
bookkeeping dwarf the cost of one or two `ConcreteCircuit` clones — before
and after numbers there are statistically indistinguishable (both scripts,
3 runs each way, both sides varied only within pre-existing run-to-run
noise).

Added a targeted micro-benchmark instead:
`bench_identity_path_avoids_clone_and_qasm_roundtrip` in
`crates/polypus/src/infrastructure/native.rs` (`#[test] #[ignore]`, prints
only — not a correctness check). It measures the old vs. new pattern side
by side in the same binary (no build-to-build noise), on a synthetic
20,000-gate / 8-qubit circuit (gate count, not qubit count, drives
clone/QASM cost; the simulator is never invoked):
```
cargo test --release -p polypus --lib
infrastructure::native::tests::bench_identity_path_avoids_clone_and_qasm_roundtrip
-- --ignored --nocapture
```

Median of 3 release runs (500 calls each):
| Path             | Before (old pattern)     | After (new pattern) |
|------------------|---------------------------|----------------------|
| Native clone+transpile | ~494 µs/call | sub-microsecond (borrow, no clone) |
| Qasm2 parse+transpile+emit | ~27.9 ms/call | ~22 µs/call (~1,260x) |
Extrapolated to one training run at the population/generation scale used by
`bench_native_vs_qiskit.py` (population=20, generations=10 → 200 candidate
submissions): **~99 ms saved** on the native path, **~5.6 s saved** on the
Qasm2 path, per run. (Debug builds show the same relative pattern with
absolute numbers inflated ~10–50x; release numbers above are the
representative ones.)
## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers --all-features`
- [x] `cargo test -p polypus` — all green, including the 5 pre-existing
      tests named in the issue (`identity_default_matches_explicit_identity`,
      `qasm2_path_matches_native_path`, `opt_level_reaches_transpiler`,
      `injected_strategy_runs_through_run_circuits`,
      `unparseable_qasm_passes_through_without_panic`) plus 2 new regression
      tests (`is_identity_true_only_for_identity_transpiler`,
      `qasm2_identity_path_returns_input_bytes_without_reserializing`)
- [x] `pytest tests/python/test_native_circuit.py tests/python/test_qasm_import.py tests/python/test_backend_selection.py tests/python/test_seed_reproducibility.py` (67 passed)