### PR TITLE
fix(orchestration): reject invalid qcs length and add native single-evolution fast path in DistributeByShotsRun

### DIFF
--- a/crates/polypus-sim/src/lib.rs
+++ b/crates/polypus-sim/src/lib.rs
@@ -53,7 +53,7 @@ mod statevector;
 
 pub use error::SimError;
 pub use rng::SplitMix64;
-pub use simulator::{Simulator, StatevectorSimulator};
+pub use simulator::{sample_projected, Simulator, StatevectorSimulator};
 pub use statevector::Statevector;
 
 /// Maximum number of qubits the statevector backend will allocate.

--- a/crates/polypus-sim/src/simulator.rs
+++ b/crates/polypus-sim/src/simulator.rs
@@ -59,43 +59,65 @@ impl StatevectorSimulator {
         seed: u64,
     ) -> Result<HashMap<usize, u64>, SimError> {
         let sv = self.run(circuit)?;
-        let mut rng = SplitMix64::new(seed);
-        let raw = sv.sample(shots, &mut rng);
-
-        // Collect the qubit → classical-bit mapping declared by the circuit.
-        let mut measured: Vec<(usize, usize)> = Vec::new();
-        let mut measure_all = false;
-        for gate in &circuit.gates {
-            match gate {
-                GateInstruction::Measure { qubit, cbit } => measured.push((*qubit, *cbit)),
-                GateInstruction::MeasureAll => measure_all = true,
-                _ => {}
-            }
-        }
-
-        // No measurements: report the full basis state directly.
-        if !measure_all && measured.is_empty() {
-            return Ok(raw);
-        }
-        if measure_all {
-            for q in 0..sv.num_qubits() {
-                measured.push((q, q));
-            }
-        }
-
-        // Project each sampled basis state onto the classical register.
-        let mut counts = HashMap::new();
-        for (state, c) in raw {
-            let mut key = 0usize;
-            for &(qubit, cbit) in &measured {
-                if (state >> qubit) & 1 == 1 {
-                    key |= 1usize << cbit;
-                }
-            }
-            *counts.entry(key).or_insert(0) += c;
-        }
-        Ok(counts)
+        Ok(sample_projected(circuit, &sv, shots, seed))
     }
+}
+
+/// Draw `shots` measurements from an already-evolved statevector `sv`, seeded by
+/// `seed`, and project each sampled basis state onto `circuit`'s classical
+/// register (the qubit → classical-bit mapping declared by its `Measure` /
+/// `MeasureAll` instructions; a circuit that measures nothing reports the full
+/// basis state, matching the "measure all" convention).
+///
+/// This is the sampling half of [`StatevectorSimulator::run_and_sample`],
+/// factored out so a caller that evolves a circuit **once** can sample it many
+/// times — each batch with its own `seed` — without repeating the (identical,
+/// deterministic) state evolution. For a given `sv` and `seed` the result is
+/// byte-identical to `run_and_sample`, which is what lets shot batches be
+/// distributed across replicas from a single evolution while preserving
+/// per-seed reproducibility.
+pub fn sample_projected(
+    circuit: &ConcreteCircuit,
+    sv: &Statevector,
+    shots: usize,
+    seed: u64,
+) -> HashMap<usize, u64> {
+    let mut rng = SplitMix64::new(seed);
+    let raw = sv.sample(shots, &mut rng);
+
+    // Collect the qubit → classical-bit mapping declared by the circuit.
+    let mut measured: Vec<(usize, usize)> = Vec::new();
+    let mut measure_all = false;
+    for gate in &circuit.gates {
+        match gate {
+            GateInstruction::Measure { qubit, cbit } => measured.push((*qubit, *cbit)),
+            GateInstruction::MeasureAll => measure_all = true,
+            _ => {}
+        }
+    }
+
+    // No measurements: report the full basis state directly.
+    if !measure_all && measured.is_empty() {
+        return raw;
+    }
+    if measure_all {
+        for q in 0..sv.num_qubits() {
+            measured.push((q, q));
+        }
+    }
+
+    // Project each sampled basis state onto the classical register.
+    let mut counts = HashMap::new();
+    for (state, c) in raw {
+        let mut key = 0usize;
+        for &(qubit, cbit) in &measured {
+            if (state >> qubit) & 1 == 1 {
+                key |= 1usize << cbit;
+            }
+        }
+        *counts.entry(key).or_insert(0) += c;
+    }
+    counts
 }
 
 impl Simulator for StatevectorSimulator {

--- a/crates/polypus/src/algorithms/orchestration/distribute_by_shots.rs
+++ b/crates/polypus/src/algorithms/orchestration/distribute_by_shots.rs
@@ -1,5 +1,5 @@
 use crate::algorithms::{AlgorithmArgs, AlgorithmTrait};
-use crate::infrastructure::Infrastructure;
+use crate::infrastructure::{BackendError, Infrastructure};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -12,7 +12,22 @@ impl AlgorithmTrait for DistributeByShotsRun {
     type Args = AlgorithmArgs;
     type AlgorithmReturnType = PyResult<pyo3::PyObject>;
 
-    fn run(&self, mut args: AlgorithmArgs) -> PyResult<pyo3::PyObject> {
+    fn run(&self, args: AlgorithmArgs) -> PyResult<pyo3::PyObject> {
+        // This algorithm operates on exactly one circuit: it replicates that
+        // single circuit across `n_qpus` and splits the shots between the
+        // replicas. Reject any other count with a typed error instead of
+        // panicking on `args.qcs[0]` (empty `qcs`) or silently dropping the
+        // extras (`qcs[1..]`). `n_qpus >= 1` and `shots >= 1` are guaranteed by
+        // the Python-facing boundary; the circuit count is not, so this is the
+        // sole place that contract is enforced — before any backend is built.
+        if args.qcs.len() != 1 {
+            return Err(BackendError::InvalidCircuitCount {
+                expected: 1,
+                got: args.qcs.len(),
+            }
+            .into());
+        }
+
         let backend = Infrastructure::create_backend(&args.config)?;
 
         // Distribute shots across QPUs, conserving the total (contract C-3): the
@@ -21,11 +36,11 @@ impl AlgorithmTrait for DistributeByShotsRun {
         // are guaranteed by the Python-facing boundary validation, so no guard is
         // duplicated here.
         //
-        // `ExecutionConfig::shots` applies uniformly to a whole `run_circuits`
-        // batch, so we submit at most two uniform-shots batches: `remainder`
-        // circuits at `base + 1` shots, and the remaining `n_qpus - remainder`
-        // circuits at `base` shots. When `shots < n_qpus` the base is `0`; that
-        // group is skipped so no zero-shot circuits are ever submitted.
+        // `shot_batches[i]` is replica `i`'s shot count (`base + 1` for the first
+        // `remainder` replicas, `base` for the rest). The backend runs the single
+        // circuit once per batch via `run_shots_distributed`; the native backend
+        // overrides that to evolve the statevector once and sample each batch,
+        // while other backends fall back to replicating + `run_circuits`.
         let shots = args.config.shots;
         let n_qpus = args.config.n_qpus;
         let base = shots / n_qpus;
@@ -40,21 +55,11 @@ impl AlgorithmTrait for DistributeByShotsRun {
             base
         );
 
-        // Run — native counts, one dict per QPU. Replicating the circuit is cheap
-        // (refcount bump or string/struct clone).
-        let mut counts_vec: Vec<HashMap<String, u64>> = Vec::new();
-        if remainder > 0 {
-            let qcs: Vec<_> = (0..remainder).map(|_| args.qcs[0].duplicate()).collect();
-            args.config.shots = base + 1;
-            counts_vec.extend(backend.run_circuits(&qcs, &args.config)?);
-        }
-        if base > 0 {
-            let qcs: Vec<_> = (0..n_qpus - remainder)
-                .map(|_| args.qcs[0].duplicate())
-                .collect();
-            args.config.shots = base;
-            counts_vec.extend(backend.run_circuits(&qcs, &args.config)?);
-        }
+        let shot_batches: Vec<u32> = (0..n_qpus)
+            .map(|i| if i < remainder { base + 1 } else { base })
+            .collect();
+        let counts_vec =
+            backend.run_shots_distributed(&args.qcs[0], &shot_batches, &args.config)?;
 
         // Merge counts from all QPUs into a single dict
         let mut total: HashMap<String, u64> = HashMap::new();

--- a/crates/polypus/src/infrastructure/error.rs
+++ b/crates/polypus/src/infrastructure/error.rs
@@ -45,6 +45,18 @@ pub enum BackendError {
         /// The rejected infrastructure string.
         name: String,
     },
+    /// An algorithm was handed a number of circuits it cannot operate on
+    /// (e.g. `DistributeByShotsRun` requires exactly one circuit: it replicates
+    /// that circuit across the QPUs and splits the shots, so an empty `qcs`
+    /// would panic on `qcs[0]` and extra circuits would be silently dropped).
+    /// Input-parameter validation, so it surfaces as `ValueError` — the same
+    /// mapping as [`UnknownInfrastructure`](Self::UnknownInfrastructure).
+    InvalidCircuitCount {
+        /// The exact number of circuits the algorithm requires.
+        expected: usize,
+        /// The number of circuits actually supplied.
+        got: usize,
+    },
     /// A backend was asked to run a circuit representation it cannot execute
     /// (e.g. a Qiskit `QuantumCircuit` on a GIL-free backend).
     UnsupportedCircuit(String),
@@ -76,6 +88,9 @@ impl fmt::Display for BackendError {
             BackendError::UnknownInfrastructure { name } => {
                 write!(f, "unknown infrastructure '{name}'")
             }
+            BackendError::InvalidCircuitCount { expected, got } => {
+                write!(f, "expected exactly {expected} circuit(s), got {got}")
+            }
             BackendError::UnsupportedCircuit(m) => write!(f, "{m}"),
             BackendError::NativeCircuit(m) => write!(f, "{m}"),
             BackendError::Cunqa(m) => write!(f, "CUNQA backend error: {m}"),
@@ -100,6 +115,9 @@ impl From<BackendError> for PyErr {
             BackendError::UnknownInfrastructure { name } => PyValueError::new_err(format!(
                 "unknown infrastructure '{name}'; expected \"local\", \"cunqa\" or \"qmio\""
             )),
+            BackendError::InvalidCircuitCount { expected, got } => {
+                PyValueError::new_err(format!("expected exactly {expected} circuit(s), got {got}"))
+            }
             BackendError::UnsupportedCircuit(m) => PyNativeCircuitError::new_err(m),
             BackendError::NativeCircuit(m) => PyNativeCircuitError::new_err(m),
             BackendError::Cunqa(m) => PyCunqaError::new_err(m),

--- a/crates/polypus/src/infrastructure/execution_config.rs
+++ b/crates/polypus/src/infrastructure/execution_config.rs
@@ -11,7 +11,7 @@ use crate::infrastructure::transpiler::OptLevel;
 /// Passed to [`crate::infrastructure::QuantumBackend::run_circuits`] alongside
 /// the circuits, so the backend knows *how* and *where* to run them without
 /// coupling to algorithm logic.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExecutionConfig {
     /// Unique identifier for this run (logging, temp files, SLURM job names).
     pub id: String,
@@ -113,6 +113,56 @@ pub enum BackendConfig {
         /// Results format requested from the server (`"binary_count"` by default).
         res_format: String,
     },
+}
+
+/// Manual [`Clone`]: the only non-`Clone` field is `BackendConfig::Local`'s
+/// optional Qiskit `NoiseModel`, whose reference count must be bumped under the
+/// GIL via `clone_ref` (the same pattern
+/// [`Infrastructure::create_backend`](crate::infrastructure::Infrastructure::create_backend)
+/// uses). Cloning a config is what lets an orchestration algorithm derive a
+/// per-batch config that differs only in `shots` without mutating the caller's.
+impl Clone for BackendConfig {
+    fn clone(&self) -> Self {
+        match self {
+            BackendConfig::Local {
+                backend,
+                sim_method,
+                noise_model,
+            } => BackendConfig::Local {
+                backend: backend.clone(),
+                sim_method: sim_method.clone(),
+                noise_model: noise_model
+                    .as_ref()
+                    .map(|nm| Python::with_gil(|py| nm.clone_ref(py))),
+            },
+            BackendConfig::LocalNative => BackendConfig::LocalNative,
+            BackendConfig::Cunqa {
+                backend,
+                sim_method,
+                nodes,
+                cores_per_qpu,
+            } => BackendConfig::Cunqa {
+                backend: backend.clone(),
+                sim_method: sim_method.clone(),
+                nodes: *nodes,
+                cores_per_qpu: *cores_per_qpu,
+            },
+            #[cfg(feature = "qmio")]
+            BackendConfig::Qmio {
+                endpoint,
+                program_format,
+                optimization,
+                repetition_period,
+                res_format,
+            } => BackendConfig::Qmio {
+                endpoint: endpoint.clone(),
+                program_format: *program_format,
+                optimization: *optimization,
+                repetition_period: *repetition_period,
+                res_format: res_format.clone(),
+            },
+        }
+    }
 }
 
 /// Representation of the program sent to the QMIO QPU.

--- a/crates/polypus/src/infrastructure/mod.rs
+++ b/crates/polypus/src/infrastructure/mod.rs
@@ -256,8 +256,7 @@ pub trait QuantumBackend: Send + Sync {
     ///
     /// The method exists so a backend that can *reuse* one circuit evolution
     /// across many shot batches can override it and avoid re-simulating the
-    /// identical circuit once per replica (see
-    /// [`NativeStatevectorBackend`](crate::infrastructure::NativeStatevectorBackend)).
+    /// identical circuit once per replica (see [`NativeStatevectorBackend`]).
     /// This **default** reproduces the historical behaviour for backends that
     /// cannot: it replicates `qc` and forwards it to
     /// [`run_circuits`](Self::run_circuits), grouping consecutive replicas that

--- a/crates/polypus/src/infrastructure/mod.rs
+++ b/crates/polypus/src/infrastructure/mod.rs
@@ -246,6 +246,53 @@ pub trait QuantumBackend: Send + Sync {
         config: &ExecutionConfig,
     ) -> Result<Vec<HashMap<String, u64>>, BackendError>;
 
+    /// Run a single circuit `qc` under a per-replica shot distribution,
+    /// returning one counts map per entry of `shot_batches` (replica `i` runs
+    /// `shot_batches[i]` shots). The caller has already apportioned the shots —
+    /// e.g. [`DistributeByShotsRun`](crate::algorithms::DistributeByShotsRun)
+    /// splitting a total across `n_qpus`, one extra shot on the first
+    /// `shots % n_qpus` replicas — so the summed counts conserve the total
+    /// exactly (contract C-3).
+    ///
+    /// The method exists so a backend that can *reuse* one circuit evolution
+    /// across many shot batches can override it and avoid re-simulating the
+    /// identical circuit once per replica (see
+    /// [`NativeStatevectorBackend`](crate::infrastructure::NativeStatevectorBackend)).
+    /// This **default** reproduces the historical behaviour for backends that
+    /// cannot: it replicates `qc` and forwards it to
+    /// [`run_circuits`](Self::run_circuits), grouping consecutive replicas that
+    /// request the same shot count into one uniform-shots batch — Aer/CUNQA
+    /// submit a whole batch per call and re-seed per call, so this grouping
+    /// leaves their per-run results unchanged (contract C-7). A zero-shot entry
+    /// submits nothing and yields an empty map, so no zero-shot circuit is ever
+    /// sent and the total is still conserved.
+    fn run_shots_distributed(
+        &self,
+        qc: &BoundCircuit,
+        shot_batches: &[u32],
+        config: &ExecutionConfig,
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError> {
+        let mut out: Vec<HashMap<String, u64>> = Vec::with_capacity(shot_batches.len());
+        let mut i = 0;
+        while i < shot_batches.len() {
+            let shots = shot_batches[i];
+            let mut j = i + 1;
+            while j < shot_batches.len() && shot_batches[j] == shots {
+                j += 1;
+            }
+            if shots > 0 {
+                let qcs: Vec<BoundCircuit> = (i..j).map(|_| qc.duplicate()).collect();
+                let mut cfg = config.clone();
+                cfg.shots = shots;
+                out.extend(self.run_circuits(&qcs, &cfg)?);
+            } else {
+                out.extend((i..j).map(|_| HashMap::new()));
+            }
+            i = j;
+        }
+        Ok(out)
+    }
+
     /// Maximum number of circuits to submit per [`run_circuits`](Self::run_circuits)
     /// call, given the `total` circuits to evaluate.
     ///

--- a/crates/polypus/src/infrastructure/native.rs
+++ b/crates/polypus/src/infrastructure/native.rs
@@ -12,7 +12,7 @@ use crate::infrastructure::error::BackendError;
 use crate::infrastructure::transpiler::{IdentityTranspiler, TranspileOptions, Transpiler};
 use crate::infrastructure::{BoundCircuit, ExecutionConfig, QuantumBackend};
 use polypus_circuit::{ConcreteCircuit, ParameterizedCircuit};
-use polypus_sim::StatevectorSimulator;
+use polypus_sim::{sample_projected, Simulator, StatevectorSimulator};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -60,18 +60,16 @@ impl NativeStatevectorBackend {
         }
     }
 
-    /// Run one bound circuit and return Aer-compatible bitstring counts.
-    ///
-    /// The bitstring width and bit order match Qiskit's: little-endian qubit
-    /// indexing with the highest classical bit on the left, so the counts are
-    /// interchangeable with those from the Aer backend.
-    fn simulate_one(
+    /// Derive the executable [`ConcreteCircuit`] from a [`BoundCircuit`] and
+    /// apply the injected transpiler — all GIL-free. Shared by
+    /// [`simulate_one`](Self::simulate_one) and
+    /// [`run_shots_distributed`](Self::run_shots_distributed) so both paths
+    /// handle the `Native`/`Qasm2`/`Qiskit` variants and transpile identically.
+    fn concrete_circuit(
         &self,
         circuit: &BoundCircuit,
-        shots: u32,
-        seed: u64,
         opts: &TranspileOptions,
-    ) -> Result<HashMap<String, u64>, BackendError> {
+    ) -> Result<ConcreteCircuit, BackendError> {
         // Obtain a ConcreteCircuit without touching Python.
         let concrete: ConcreteCircuit = match circuit {
             BoundCircuit::Native(cc) => cc.clone(),
@@ -94,8 +92,22 @@ impl NativeStatevectorBackend {
 
         // Transpile the native circuit (GIL-free) before simulating. With the
         // default IdentityTranspiler this is a clone and changes nothing.
-        let concrete = self.transpiler.transpile(&concrete, opts);
+        Ok(self.transpiler.transpile(&concrete, opts))
+    }
 
+    /// Run one bound circuit and return Aer-compatible bitstring counts.
+    ///
+    /// The bitstring width and bit order match Qiskit's: little-endian qubit
+    /// indexing with the highest classical bit on the left, so the counts are
+    /// interchangeable with those from the Aer backend.
+    fn simulate_one(
+        &self,
+        circuit: &BoundCircuit,
+        shots: u32,
+        seed: u64,
+        opts: &TranspileOptions,
+    ) -> Result<HashMap<String, u64>, BackendError> {
+        let concrete = self.concrete_circuit(circuit, opts)?;
         let raw = self
             .simulator
             .run_and_sample(&concrete, shots as usize, seed)
@@ -103,18 +115,22 @@ impl NativeStatevectorBackend {
                 log::error!("native statevector simulation failed: {e}");
                 BackendError::NativeCircuit(format!("native statevector simulation failed: {e}"))
             })?;
-
-        // Bitstring length = classical register width (qubit count when the
-        // circuit has no measurements, mirroring a full-register read-out).
-        let width = match concrete.num_clbits() {
-            0 => concrete.num_qubits,
-            c => c,
-        };
-        Ok(raw
-            .into_iter()
-            .map(|(state, count)| (format!("{:0w$b}", state, w = width), count))
-            .collect())
+        Ok(format_counts(&concrete, raw))
     }
+}
+
+/// Format raw basis-state counts as Aer-compatible bitstrings: little-endian
+/// qubit indexing with the highest classical bit on the left. The width is the
+/// classical-register size, or the qubit count for a measurement-free circuit
+/// (a full-register read-out).
+fn format_counts(concrete: &ConcreteCircuit, raw: HashMap<usize, u64>) -> HashMap<String, u64> {
+    let width = match concrete.num_clbits() {
+        0 => concrete.num_qubits,
+        c => c,
+    };
+    raw.into_iter()
+        .map(|(state, count)| (format!("{:0w$b}", state, w = width), count))
+        .collect()
 }
 
 impl QuantumBackend for NativeStatevectorBackend {
@@ -135,6 +151,50 @@ impl QuantumBackend for NativeStatevectorBackend {
             .map(|(i, qc)| {
                 let seed = self.base_seed.wrapping_add(start).wrapping_add(i as u64);
                 self.simulate_one(qc, config.shots, seed, &opts)
+            })
+            .collect()
+    }
+
+    /// Single-evolution fast path: `polypus-sim` separates evolution from
+    /// sampling, so the shared circuit is evolved **once** and every shot batch
+    /// samples from that same statevector — instead of re-running the identical
+    /// evolution once per replica as the default (via `run_circuits`) would.
+    ///
+    /// Reproducibility is preserved exactly (contract C-7): the per-batch seeds
+    /// come from the *same* contiguous-block scheme `run_circuits` uses
+    /// (`counter.fetch_add` + `base_seed.wrapping_add`), and
+    /// [`sample_projected`] with a given seed yields byte-identical counts to a
+    /// full `run_and_sample`. Shot conservation is preserved too (contract
+    /// C-3): a zero-shot batch samples nothing and returns an empty map.
+    fn run_shots_distributed(
+        &self,
+        qc: &BoundCircuit,
+        shot_batches: &[u32],
+        config: &ExecutionConfig,
+    ) -> Result<Vec<HashMap<String, u64>>, BackendError> {
+        let opts = TranspileOptions {
+            level: config.opt_level,
+        };
+        // Evolve the shared circuit exactly once; the statevector is reused for
+        // every batch's sampling.
+        let concrete = self.concrete_circuit(qc, &opts)?;
+        let sv = self.simulator.run(&concrete).map_err(|e| {
+            log::error!("native statevector simulation failed: {e}");
+            BackendError::NativeCircuit(format!("native statevector simulation failed: {e}"))
+        })?;
+        // Reserve a contiguous seed block, one seed per batch, from the same
+        // scheme `run_circuits` uses so a given base seed reproduces identical
+        // counts regardless of which path ran the batches.
+        let start = self
+            .counter
+            .fetch_add(shot_batches.len() as u64, Ordering::Relaxed);
+        shot_batches
+            .iter()
+            .enumerate()
+            .map(|(i, &shots)| {
+                let seed = self.base_seed.wrapping_add(start).wrapping_add(i as u64);
+                let raw = sample_projected(&concrete, &sv, shots as usize, seed);
+                Ok(format_counts(&concrete, raw))
             })
             .collect()
     }
@@ -377,6 +437,77 @@ mod tests {
     /// eight-outcome counts dict (not a single statistic) keeps this
     /// non-flaky. This is the exact inversion of the removed
     /// `seeding_is_reproducible_per_id`, which encoded the bug.
+    /// Fast path (defect #3): `run_shots_distributed` conserves the total shots
+    /// across batches (C-3) and is deterministic for a fixed base seed (C-7).
+    #[test]
+    fn run_shots_distributed_conserves_shots_and_is_deterministic() {
+        let cfg = config_with(OptLevel::default());
+        let batches = [3u32, 3, 2]; // 8 shots over 3 "QPUs", uneven split.
+        let out = NativeStatevectorBackend::new(2024)
+            .run_shots_distributed(&BoundCircuit::Native(bell()), &batches, &cfg)
+            .unwrap();
+        assert_eq!(out.len(), batches.len());
+        let total: u64 = out.iter().flat_map(|m| m.values()).sum();
+        assert_eq!(total, u64::from(batches.iter().sum::<u32>()));
+        // Same base seed reproduces byte-identical batches.
+        let again = NativeStatevectorBackend::new(2024)
+            .run_shots_distributed(&BoundCircuit::Native(bell()), &batches, &cfg)
+            .unwrap();
+        assert_eq!(out, again);
+        for m in &out {
+            for k in m.keys() {
+                assert!(k == "00" || k == "11", "unexpected outcome {k}");
+            }
+        }
+    }
+
+    /// Fast path equivalence (C-7): the single-evolution path yields
+    /// byte-identical counts to sampling each batch through `run_circuits` with
+    /// the same contiguous seed block (`seed = base_seed + i`). The optimisation
+    /// changes performance, never results.
+    #[test]
+    fn run_shots_distributed_matches_run_circuits_per_batch() {
+        let batches = [5u32, 5, 4];
+        let fast = NativeStatevectorBackend::new(99)
+            .run_shots_distributed(
+                &BoundCircuit::Native(bell()),
+                &batches,
+                &config_with(OptLevel::default()),
+            )
+            .unwrap();
+
+        // Reference: one fresh backend per batch, seeded `99 + i` so it replays
+        // the exact seed the fast path reserves for replica `i`.
+        let reference: Vec<_> = batches
+            .iter()
+            .enumerate()
+            .map(|(i, &shots)| {
+                let mut cfg = config_with(OptLevel::default());
+                cfg.shots = shots;
+                NativeStatevectorBackend::new(99u64.wrapping_add(i as u64))
+                    .run_circuits(&[BoundCircuit::Native(bell())], &cfg)
+                    .unwrap()
+                    .remove(0)
+            })
+            .collect();
+
+        assert_eq!(fast, reference);
+    }
+
+    /// A zero-shot batch samples nothing (empty map), so shots stay conserved
+    /// even when `shots < n_qpus` (some replicas get `base = 0`).
+    #[test]
+    fn run_shots_distributed_zero_batch_is_empty() {
+        let cfg = config_with(OptLevel::default());
+        let out = NativeStatevectorBackend::new(1)
+            .run_shots_distributed(&BoundCircuit::Native(bell()), &[1u32, 0, 0], &cfg)
+            .unwrap();
+        assert_eq!(out.len(), 3);
+        assert!(out[1].is_empty() && out[2].is_empty());
+        let total: u64 = out.iter().flat_map(|m| m.values()).sum();
+        assert_eq!(total, 1);
+    }
+
     #[test]
     fn omitted_seed_differs_across_calls_for_same_id() {
         use crate::infrastructure::Infrastructure;

--- a/crates/polypus/tests/running_quantum_circuits_local.rs
+++ b/crates/polypus/tests/running_quantum_circuits_local.rs
@@ -112,14 +112,21 @@ fn infrastructure_from_str_unknown_is_typed_error() {
 // the qmio backend's tests.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Build `AlgorithmArgs` for a native Bell circuit on the pure-Rust backend.
-fn native_bell_args(shots: u32, n_qpus: u32, id: &str) -> AlgorithmArgs {
+/// A native Bell `BoundCircuit`, for assembling `AlgorithmArgs` with any number
+/// of circuits.
+fn native_bell_circuit() -> BoundCircuit {
     let bell = ParameterizedCircuit::new(2)
         .h(0)
         .cx(0, 1)
         .measure_all()
         .assign_parameters(&[])
         .expect("bell circuit has no free parameters");
+    BoundCircuit::Native(bell)
+}
+
+/// Build `AlgorithmArgs` on the pure-Rust backend with an explicit circuit list
+/// (so the degenerate `qcs` lengths can be exercised).
+fn native_args(shots: u32, n_qpus: u32, id: &str, qcs: Vec<BoundCircuit>) -> AlgorithmArgs {
     AlgorithmArgs {
         config: ExecutionConfig {
             id: id.to_string(),
@@ -132,8 +139,13 @@ fn native_bell_args(shots: u32, n_qpus: u32, id: &str) -> AlgorithmArgs {
             // seed keeps the native backend's sampling deterministic across runs.
             seed: Some(7),
         },
-        qcs: vec![BoundCircuit::Native(bell)],
+        qcs,
     }
+}
+
+/// Build `AlgorithmArgs` for a single native Bell circuit on the pure-Rust backend.
+fn native_bell_args(shots: u32, n_qpus: u32, id: &str) -> AlgorithmArgs {
+    native_args(shots, n_qpus, id, vec![native_bell_circuit()])
 }
 
 /// Run the distribute-by-shots algorithm and return the merged counts.
@@ -147,6 +159,43 @@ fn distributed_counts(shots: u32, n_qpus: u32, id: &str) -> HashMap<String, u64>
             .extract::<HashMap<String, u64>>(py)
             .expect("distribute-by-shots must return a dict[str, int]")
     })
+}
+
+#[test]
+fn distribute_rejects_empty_qcs() {
+    // Defect #1: an empty `qcs` used to panic on `args.qcs[0]`. It must now be a
+    // typed error (ValueError across the FFI, contract C-1), never a panic.
+    pyo3::prepare_freethreaded_python();
+    let err = DistributeByShotsRun
+        .run(native_args(100, 2, "empty", vec![]))
+        .expect_err("empty qcs must be a typed error, not a panic");
+    Python::with_gil(|py| {
+        assert!(
+            err.is_instance_of::<pyo3::exceptions::PyValueError>(py),
+            "empty qcs must surface as a ValueError"
+        );
+    });
+}
+
+#[test]
+fn distribute_rejects_multiple_qcs() {
+    // Defect #2: extra circuits used to be silently ignored (only `qcs[0]` ran).
+    // More than one circuit must now be an explicit typed error.
+    pyo3::prepare_freethreaded_python();
+    let err = DistributeByShotsRun
+        .run(native_args(
+            100,
+            2,
+            "multi",
+            vec![native_bell_circuit(), native_bell_circuit()],
+        ))
+        .expect_err("more than one circuit must be a typed error, not silently truncated");
+    Python::with_gil(|py| {
+        assert!(
+            err.is_instance_of::<pyo3::exceptions::PyValueError>(py),
+            "extra circuits must surface as a ValueError"
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
Summary
Fixes [#84]. DistributeByShotsRun::run indexed args.qcs[0] directly, which caused three defects:

Panic on empty qcs — indexing qcs[0] panicked, and a panic on a path reachable from FFI violates our error-handling policy (should be a typed Result/PyErr).
Silent truncation of extra circuits — with more than one circuit, only qcs[0] ran and qcs[1..] were dropped without warning.
Redundant re-simulation on the native backend — the single circuit was duplicated n_qpus times and passed to run_circuits, which evolved the identical statevector n_qpus times before sampling.
The agreed scope is to reject invalid qcs lengths (this algorithm operates on exactly one circuit — no multi-circuit semantics) and to implement a single-evolution fast path for the native backend.

Changes
BackendError::InvalidCircuitCount { expected, got } — new typed variant, mapped to PyValueError (same convention as UnknownInfrastructure; input-parameter validation, consistent with contract C-1). DistributeByShotsRun::run now rejects qcs.len() != 1 at the top, before any backend is built.
QuantumBackend::run_shots_distributed(qc, shot_batches, config) — new trait method. The default impl reproduces the historical behaviour (replicate the circuit, group replicas with equal shot counts into uniform batches for run_circuits, zero-shot batches yield an empty map), so Aer / CUNQA / QMIO are unchanged.
NativeStatevectorBackend overrides it: evolves the statevector once and samples each shot batch from it, reusing the same contiguous seed-block scheme as run_circuits (counter.fetch_add + base_seed.wrapping_add). Counts stay byte-identical for a given seed.
polypus_sim::sample_projected — the qubit→classical-bit projection was factored out of StatevectorSimulator::run_and_sample into a reusable function so the fast path reuses it instead of duplicating it (run_and_sample now calls it, behaviour unchanged).
ExecutionConfig derives Clone (with a manual Clone on BackendConfig, since the Aer NoiseModel Py<PyAny> must be cloned under the GIL via clone_ref), so the default impl can derive a per-batch config that differs only in shots.
Contracts
C-3 (shot conservation) preserved: the total is split as base/base+1 per replica, zero-shot batches sample nothing.
C-7 (seeding) preserved: same seed ⇒ byte-identical counts; verified against the per-batch run_circuits path.
Tests
Reject empty qcs and reject more than one circuit (typed ValueError, no panic).
Native fast path: conserves shots, is deterministic for a fixed base seed, matches per-batch run_circuits byte-for-byte, and handles zero-shot batches.
The three existing shot-conservation tests pass unchanged.
Verified with cargo fmt --all --check, cargo clippy --workspace --all-targets -- -D warnings, the pure-crate --all-features suite, cargo test -p polypus, and cargo test --workspace.