### PR TITLE
fix(ci): stabilize CI — pin ruff, explicit lint select, robustify GIL…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v3
+        with:
+          # Pin ruff so a new release's changed default rules / formatter output
+          # cannot turn CI red without a deliberate bump. Keep in sync with the
+          # pin in requirements-dev.txt. Both `ruff check` (run by the action)
+          # and the `ruff format --check` step below use this version.
+          version: "0.16.1"
       - run: ruff format --check
 
   # Security advisories (RustSec), license allowlist and registry sources,

--- a/README.md
+++ b/README.md
@@ -130,14 +130,18 @@ Check the [`examples/`](examples/) directory for complete, runnable scripts.
 
 Pass the circuit, the number of shots, the infrastructure and the number of QPUs:
 ```python
-result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=1)
+result = polypus.run_quantum_circuit(
+    qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=1
+)
 ```
 
 ### Distributing Shots Across Multiple QPUs
 
 Set `n_qpus > 1` to split the shots across available QPUs and reduce execution time:
 ```python
-result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10)
+result = polypus.run_quantum_circuit(
+    qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10
+)
 ```
 
 When `infrastructure="cunqa"`, two optional kwargs size the SLURM allocation for the distributed QPUs:
@@ -183,7 +187,9 @@ If CUNQA is not available, set `infrastructure="local"`.
 ```python
 result = polypus.train(
     qc,
-    polypus.DE(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, tolerance=TOL),
+    polypus.DE(
+        generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, tolerance=TOL
+    ),
     shots=N_SHOTS,
     n_qpus=N_QPUS,
     dimensions=2 * layers,
@@ -191,18 +197,20 @@ result = polypus.train(
     infrastructure=infrastructure,
     nodes=NUM_NODES,
     cores_per_qpu=CORES_PER_QPU,
-    id=id
+    id=id,
 )
 ```
 
 `train()` (and `qml.train()`) return a `TrainResult` carrying the full optimization outcome, not just the tuned parameters:
 
 ```python
-print(result.best_params)     # list[float] — the optimized parameters
-print(result.best_fitness)    # float — cost/fitness at those parameters
+print(result.best_params)  # list[float] — the optimized parameters
+print(result.best_fitness)  # float — cost/fitness at those parameters
 print(result.iterations_run)  # int — iterations actually run (early-stopping aware)
-print(result.converged)       # bool — whether the convergence criterion was met
-print(result.seed)            # int — the effective RNG seed; pass it back as seed=... to reproduce the run
+print(result.converged)  # bool — whether the convergence criterion was met
+print(
+    result.seed
+)  # int — the effective RNG seed; pass it back as seed=... to reproduce the run
 ```
 
 Pin reproducibility with the `seed` keyword (`polypus.train(..., seed=42)`) or on the optimizer itself (`polypus.DE(..., seed=42)`); with no seed, one is drawn from OS entropy and reported back in `result.seed`.
@@ -212,8 +220,12 @@ Pin reproducibility with the `seed` keyword (`polypus.train(..., seed=42)`) or o
 ```python
 result = polypus.train(
     qc,
-    polypus.PSO(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE,
-                bounds=(0.0, np.pi), tolerance=TOL),
+    polypus.PSO(
+        generations=MAX_GENERATIONS,
+        population_size=POPULATION_SIZE,
+        bounds=(0.0, np.pi),
+        tolerance=TOL,
+    ),
     shots=N_SHOTS,
     n_qpus=N_QPUS,
     dimensions=2 * layers,
@@ -221,7 +233,7 @@ result = polypus.train(
     infrastructure=infrastructure,
     nodes=NUM_NODES,
     cores_per_qpu=CORES_PER_QPU,
-    id=id
+    id=id,
 )
 ```
 
@@ -232,8 +244,14 @@ result = polypus.train(
 ```python
 result = polypus.train(
     qc,
-    polypus.QNG(variance_fn, max_iters=MAX_GENERATIONS, bounds=(0.0, np.pi),
-                learning_rate=0.1, finite_difference_step=0.1, tikhonov_reg=0.05),
+    polypus.QNG(
+        variance_fn,
+        max_iters=MAX_GENERATIONS,
+        bounds=(0.0, np.pi),
+        learning_rate=0.1,
+        finite_difference_step=0.1,
+        tikhonov_reg=0.05,
+    ),
     shots=N_SHOTS,
     n_qpus=N_QPUS,
     dimensions=2 * layers,
@@ -241,7 +259,7 @@ result = polypus.train(
     infrastructure=infrastructure,
     nodes=NUM_NODES,
     cores_per_qpu=CORES_PER_QPU,
-    id=id
+    id=id,
 )
 ```
 
@@ -261,17 +279,34 @@ bell = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
 result = polypus.run_quantum_circuit(bell, shots=1000, infrastructure="local")
 
 # Parameterized ansatz → train (binding happens in Rust, GIL-free)
-qaoa = (polypus.Circuit(4)
-        .h(0).h(1).h(2).h(3)
-        .rzz(0, 1, polypus.Param(0)).rzz(1, 2, polypus.Param(0))
-        .rzz(2, 3, polypus.Param(0)).rzz(3, 0, polypus.Param(0))
-        .rx(0, polypus.Param(1)).rx(1, polypus.Param(1))
-        .rx(2, polypus.Param(1)).rx(3, polypus.Param(1))
-        .measure_all())
-result = polypus.train(qaoa, polypus.DE(generations=100, population_size=50),
-                       shots=1024, n_qpus=1, dimensions=2,
-                       expectation_function=my_cost, infrastructure="local",
-                       nodes=1, cores_per_qpu=1, id="qaoa")
+qaoa = (
+    polypus.Circuit(4)
+    .h(0)
+    .h(1)
+    .h(2)
+    .h(3)
+    .rzz(0, 1, polypus.Param(0))
+    .rzz(1, 2, polypus.Param(0))
+    .rzz(2, 3, polypus.Param(0))
+    .rzz(3, 0, polypus.Param(0))
+    .rx(0, polypus.Param(1))
+    .rx(1, polypus.Param(1))
+    .rx(2, polypus.Param(1))
+    .rx(3, polypus.Param(1))
+    .measure_all()
+)
+result = polypus.train(
+    qaoa,
+    polypus.DE(generations=100, population_size=50),
+    shots=1024,
+    n_qpus=1,
+    dimensions=2,
+    expectation_function=my_cost,
+    infrastructure="local",
+    nodes=1,
+    cores_per_qpu=1,
+    id="qaoa",
+)
 ```
 
 ### From Rust
@@ -298,8 +333,8 @@ From Python, both outputs are also available:
 
 ```python
 qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
-qir_text = qc.to_qir()            # str (.ll)
-qir_bitcode = qc.to_qir_bitcode() # bytes (.bc)
+qir_text = qc.to_qir()  # str (.ll)
+qir_bitcode = qc.to_qir_bitcode()  # bytes (.bc)
 ```
 
 ### QASM 2.0 Import
@@ -311,8 +346,8 @@ import polypus
 from qiskit import qasm2
 
 qc = polypus.Circuit.from_qasm2(qasm2.dumps(qiskit_circuit))  # interop
-qc = polypus.Circuit.from_qasm2(open("ansatz.qasm").read())   # persistence
-qc.rz(1, 0.5).measure_all()        # imported circuits are regular builders
+qc = polypus.Circuit.from_qasm2(open("ansatz.qasm").read())  # persistence
+qc.rz(1, 0.5).measure_all()  # imported circuits are regular builders
 ```
 
 Round-trip guarantee (verified by tests): for any circuit produced by this library, export → import → export is byte-identical. The same API exists in Rust as `ParameterizedCircuit::from_qasm2`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,12 @@ manifest-path = "crates/polypus/Cargo.toml"
 target-version = "py39"
 
 [tool.ruff.lint]
-# Default rules (pycodestyle errors + pyflakes) plus import sorting.
-extend-select = ["I"]
+# Pin the rule set explicitly (pycodestyle errors E4/E7/E9 + pyflakes F, plus
+# import sorting I). Using an explicit `select` instead of `extend-select` stops
+# a newer ruff's expanded default `select` from silently enforcing rules the
+# project has not adopted (which turned CI red on an unpinned ruff-action). The
+# ruff version is pinned in CI (.github/workflows/ci.yml) and requirements-dev.txt.
+select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.ruff.lint.per-file-ignores]
 # Package roots re-export their public API.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,5 +14,5 @@ pytest>=8.0
 
 # Lint/format (config in [tool.ruff] in pyproject.toml; CI enforces both
 # `ruff check` and `ruff format --check`)
-ruff>=0.8
+ruff==0.16.1  # pinned; keep in sync with .github/workflows/ci.yml (see pyproject [tool.ruff.lint])
 

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -308,9 +308,9 @@ def make(n, reps):
 # per-shot checks), the circuit is sized to complete in ~1.3s single-threaded:
 # still running when SIGINT arrives `_DELAY_BEFORE_SIGINT_S` after READY, done
 # well inside `_INTERRUPT_DEADLINE_S`. `__N_QPUS__` selects the variant:
-# 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun (which duplicates the
-# circuit across QPUs, so its per-QPU `reps` is scaled down to keep the total
-# run time comparable).
+# 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun. The latter's
+# single-evolution fast path evolves the shared circuit once (not once per QPU),
+# so both variants use the same `reps` to keep the total run time comparable.
 _RUN_CHILD_TEMPLATE = (
     r"""
 import sys, time
@@ -368,9 +368,12 @@ def test_run_quantum_circuit_single_responds_to_sigint_promptly():
 
 
 def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
-    # n_qpus > 1 -> DistributeByShotsRun. 4 QPUs x n=18/reps=25 is ~1.3s total.
+    # n_qpus > 1 -> DistributeByShotsRun. Its single-evolution fast path evolves
+    # the shared circuit once (not once per QPU), so this uses the same
+    # n=18/reps=100 as the single-run variant (~1.3s single-threaded) rather than
+    # a per-QPU-scaled reps — otherwise the run finishes inside the SIGINT window.
     _assert_responds_to_sigint_promptly(
-        _run_child(n_qpus=4, n=18, reps=25),
+        _run_child(n_qpus=4, n=18, reps=100),
         failure_hint=(
             "run_quantum_circuit (DistributeByShotsRun) — the GIL is likely "
             "held for the whole run or check_signals is missing before the "
@@ -383,11 +386,15 @@ def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
 # GIL-release proof: while a native `run_quantum_circuit` call is in flight, a
 # background Python thread spins a tight counter loop. If the GIL were held for
 # the whole run the thread is starved and advances only by the incidental amount
-# the call's Python entry/exit stages allow (measured ~1.4e5, stable across core
-# counts); with the GIL released it advances by tens of millions (measured
-# ~3.6e7 on 32 cores, ~4e7 on 2) over the run. The threshold sits ~35x above the
-# held-GIL value and ~7x below the released-GIL value, so it separates them
-# cleanly with wide margin on either side, independent of the runner's cores.
+# the call's Python entry/exit stages allow (measured ~1.4e5); with the GIL
+# released it keeps advancing at close to its free-running rate. Rather than a
+# brittle absolute count, the child calibrates that free-running rate (via a
+# time.sleep window, which releases the GIL) and reports the *ratio* of counts
+# achieved during the native run to counts expected at the free rate over the
+# same wall-clock. GIL released -> ratio near 1.0 (>=0.5 even under single-core
+# contention with the native thread); GIL held -> ratio ~0. The threshold sits
+# far below the released value and far above the held value, independent of the
+# runner's CPU speed or the native run's duration.
 #
 # Two design points make this robust (see module docstring):
 #   * A subprocess, not an in-process thread, so the measurement starts from a
@@ -399,7 +406,7 @@ def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
 #     the observation depend on spare cores the CI runner may not have. Depth
 #     comes from `n_qpus` (sequential per-QPU circuits), not qubit count, so the
 #     circuit stays cheap to build.
-_MIN_COUNTER_PROGRESS = 5_000_000
+_MIN_GIL_RELEASE_RATIO = 0.2
 
 _GIL_RELEASE_CHILD = (
     r"""
@@ -413,7 +420,7 @@ polypus.run_quantum_circuit(
     make(2, 1), shots=64, infrastructure="local", n_qpus=1, backend="polypus"
 )
 
-qc = make(11, 1500)  # sub-parallel-threshold; ~1.3-2.6s across 32..2 cores
+qc = make(11, 1500)  # sub-parallel-threshold native run (~1.3-2.6s across 32..2 cores)
 counter = 0
 stop = threading.Event()
 
@@ -425,17 +432,37 @@ def spin():
 worker = threading.Thread(target=spin)
 worker.start()
 try:
-    before = counter
+    import time
+
+    # Calibrate the worker's free-running spin rate: time.sleep releases the
+    # GIL, so the worker runs unobstructed during this window. Comparing the
+    # native run against this per-machine rate makes the test robust to CPU
+    # speed and native-run duration -- an absolute count threshold was not,
+    # and caused spurious CI failures on fast/loaded runners.
+    c0 = counter
+    time.sleep(0.2)
+    free_rate = (counter - c0) / 0.2  # counts/sec with the GIL free
+
     # n_qpus=20 -> 20 sequential single-thread circuits (DistributeByShotsRun),
     # enough wall-clock for the counter to accumulate a decisive lead.
+    before = counter
+    t0 = time.perf_counter()
     polypus.run_quantum_circuit(
         qc, shots=4096, infrastructure="local", n_qpus=20, backend="polypus"
     )
+    dt = time.perf_counter() - t0
     advanced = counter - before
 finally:
     stop.set()
     worker.join()
-print(f"ADVANCED {advanced}", flush=True)
+
+# Fraction of its free-running rate the worker sustained *during* the native
+# run. GIL released -> worker keeps running (ratio near 1.0, or ~0.5 under
+# single-core contention with the native thread); GIL held -> worker starved
+# (ratio ~0).
+expected = free_rate * dt
+ratio = (advanced / expected) if expected > 0 else 0.0
+print(f"ADVANCED {advanced} RATE {free_rate:.0f} DT {dt:.4f} RATIO {ratio:.4f}", flush=True)
 """
 )
 
@@ -451,8 +478,11 @@ def test_run_quantum_circuit_releases_gil_for_other_threads():
         f"GIL-release child did not complete cleanly.\n"
         f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     )
-    advanced = int(proc.stdout.split("ADVANCED", 1)[1].split()[0])
-    assert advanced > _MIN_COUNTER_PROGRESS, (
-        f"background thread advanced only {advanced} counts during the native "
-        f"run — the GIL was likely not released around run_quantum_circuit"
+    fields = proc.stdout.split("ADVANCED", 1)[1].split()
+    advanced = int(fields[0])
+    ratio = float(fields[fields.index("RATIO") + 1])
+    assert ratio > _MIN_GIL_RELEASE_RATIO, (
+        f"background thread sustained only {ratio:.3f} of its free-running rate "
+        f"during the native run (advanced {advanced} counts) — the GIL was "
+        f"likely not released around run_quantum_circuit\nstdout:\n{proc.stdout}"
     )


### PR DESCRIPTION
…-release test

- pyproject: use explicit `select` (E4/E7/E9/F/I) instead of `extend-select`, so a newer ruff's expanded default rule set can't turn CI red.
- ci.yml + requirements-dev.txt: pin ruff 0.16.1 (ruff-action was unpinned and drifted to a stricter formatter/ruleset).
- README.md: reformat with the pinned ruff.
- test_interrupt.py: replace the brittle absolute 5M-count GIL-release threshold with a per-machine free-rate ratio (robust to CPU speed / run duration).