### PR TITLE
statevector() guardrails: GIL release, qubit ceiling, NumPy return

### DIFF
--- a/crates/polypus-sim/src/statevector.rs
+++ b/crates/polypus-sim/src/statevector.rs
@@ -68,6 +68,16 @@ impl Statevector {
         &self.data
     }
 
+    /// Consume the state and return ownership of its amplitude buffer.
+    ///
+    /// The counterpart of [`amplitudes`](Self::amplitudes) for callers that hand
+    /// the buffer on and drop the state anyway: it moves the `2^n` amplitudes
+    /// out instead of forcing a `to_vec()` copy of a vector that may be several
+    /// GiB (see [`MAX_QUBITS`]).
+    pub fn into_amplitudes(self) -> Vec<C64> {
+        self.data
+    }
+
     /// L2 norm of the state. A correctly evolved state stays at `1` up to
     /// floating-point error.
     pub fn norm(&self) -> f64 {
@@ -179,5 +189,26 @@ impl Statevector {
             | GateInstruction::MeasureAll => {}
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `into_amplitudes` must hand out exactly the buffer `amplitudes` borrows —
+    /// it is the copy-free alternative to `amplitudes().to_vec()`, not a
+    /// different read-out.
+    #[test]
+    fn into_amplitudes_matches_the_borrowed_view() {
+        let mut sv = Statevector::new(2).expect("2 qubits is well below MAX_QUBITS");
+        sv.apply(&GateInstruction::H(0))
+            .expect("H is unconditional");
+        sv.apply(&GateInstruction::Cx(0, 1))
+            .expect("Cx is unconditional");
+
+        let borrowed = sv.amplitudes().to_vec();
+        let owned = sv.into_amplitudes();
+        assert_eq!(owned, borrowed);
     }
 }

--- a/crates/polypus/Cargo.toml
+++ b/crates/polypus/Cargo.toml
@@ -33,7 +33,17 @@ polypus-circuit = { workspace = true }
 polypus-sim = { workspace = true, features = ["parallel"] }
 polypus-optimizers = { workspace = true }
 polypus-logger = { workspace = true }
-pyo3 = { version = "0.24.2", features = ["num-complex"] }
+# Was 0.24.2; moved to 0.25 only to unblock `numpy` below (rust-numpy versions
+# are pinned 1:1 to a pyo3 version, and 0.24 is unusable — see the note there).
+# The bump needs no source changes and clears neither of the pyo3 advisories
+# ignored in `deny.toml`; those still want >=0.26 / >=0.29.
+pyo3 = { version = "0.25", features = ["num-complex"] }
+# Zero-copy handover of the `2^n` statevector amplitudes to Python as a
+# `numpy.ndarray` of `complex128` (see `bindings::circuit::statevector`). Must
+# stay >= 0.25: rust-numpy 0.24.0 still carries the deprecated
+# `ToPyArray::to_pyarray_bound`, whose doc link makes rustdoc ICE on current
+# stable (1.96) and so breaks `cargo doc -D warnings` in CI. 0.25 removed it.
+numpy = "0.25"
 rand = "0.8"
 ndarray = "0.16"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/polypus/src/bindings/circuit.rs
+++ b/crates/polypus/src/bindings/circuit.rs
@@ -115,6 +115,17 @@ fn push(mut slf: PyRefMut<'_, Circuit>, gate: GateInstruction) -> PyResult<PyRef
 /// (qubit 0 is the least-significant bit), so it can be compared directly with
 /// `qiskit.quantum_info.Statevector`.
 ///
+/// The simulation runs **GIL-free** — only the cheap parameter binding and the
+/// conversion of the result hold the GIL — so other Python threads keep making
+/// progress while it runs (see `docs/ENGINEERING.md` §3).
+///
+/// **Qubit ceiling.** A dense statevector needs `2^n` complex amplitudes
+/// (`16 · 2^n` bytes), so the backend refuses circuits with more than
+/// [`polypus_sim::MAX_QUBITS`] qubits (30 ≈ 16 GiB) and raises a `ValueError`
+/// naming the requested and the supported count **before** attempting any
+/// allocation. `polypus.Circuit` itself is deliberately unbounded (see
+/// `Circuit::new`): the ceiling belongs to this backend, not to the IR.
+///
 /// ```python
 /// import polypus
 /// qc = polypus.Circuit(2).h(0).cx(0, 1)
@@ -126,15 +137,36 @@ pub fn statevector(
     params: Option<Vec<f64>>,
 ) -> PyResult<Vec<polypus_sim::C64>> {
     let params = params.unwrap_or_default();
+    // Binding stays on this side of the release: it is O(gates), allocates
+    // nothing of size `2^n`, and reads the circuit through the `PyRef`.
     let concrete = qc.native().assign_parameters(&params).map_err(to_py_err)?;
-    let sv = StatevectorSimulator::new()
-        .run(&concrete)
+    // The simulation is the expensive, pure-Rust part: release the GIL for it
+    // so it cannot stall every other Python thread (docs/ENGINEERING.md §3).
+    //
+    // No `py.check_signals()` here, unlike `run_quantum_circuit`: this is a
+    // single simulation with no per-circuit boundary at which a pending Ctrl+C
+    // could be honored, its cost is bounded by the qubit ceiling above, and the
+    // interpreter raises the pending `KeyboardInterrupt` as soon as the call
+    // returns into Python bytecode. Interrupting it *mid-run* would mean signal
+    // checks inside `polypus-sim`, which must stay Python-free (§2).
+    let sv = qc
+        .py()
+        .allow_threads(|| StatevectorSimulator::new().run(&concrete))
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
     Ok(sv.amplitudes().to_vec())
 }
 
 #[pymethods]
 impl Circuit {
+    /// Build an empty circuit on `num_qubits` qubits.
+    ///
+    /// **Intentionally unbounded.** A `Circuit` is backend-agnostic IR: the same
+    /// object is routed by `polypus.run_quantum_circuit` to the native
+    /// statevector simulator, CUNQA, QMIO or Aer, and those capacities differ.
+    /// [`polypus_sim::MAX_QUBITS`] is the dense-statevector limit and is
+    /// enforced where it applies — when a circuit is *simulated* (see
+    /// [`statevector`]) — so checking it here would reject circuits that are
+    /// perfectly valid for the other backends.
     #[new]
     fn new(num_qubits: usize) -> Self {
         Circuit {

--- a/crates/polypus/src/bindings/circuit.rs
+++ b/crates/polypus/src/bindings/circuit.rs
@@ -4,6 +4,7 @@
 //! GIL-free circuits and pass them to `polypus.run_quantum_circuit` /
 //! `polypus.train` exactly like a Qiskit `QuantumCircuit`.
 
+use numpy::{IntoPyArray, PyArray1};
 use polypus_circuit::{CircuitError, GateInstruction, GateParam, ParameterizedCircuit};
 use polypus_sim::{Simulator, StatevectorSimulator};
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -111,9 +112,11 @@ fn push(mut slf: PyRefMut<'_, Circuit>, gate: GateInstruction) -> PyResult<PyRef
 /// `polypus-sim` backend (no Qiskit, no OpenQASM round-trip).
 ///
 /// `params` supplies one value per free parameter; omit it for a circuit that
-/// has none. Returns the `2^n` complex amplitudes in Qiskit little-endian order
-/// (qubit 0 is the least-significant bit), so it can be compared directly with
-/// `qiskit.quantum_info.Statevector`.
+/// has none. Returns the `2^n` complex amplitudes as a **`numpy.ndarray` of
+/// `dtype=complex128`**, in Qiskit little-endian order (qubit 0 is the
+/// least-significant bit), so it can be compared directly with
+/// `qiskit.quantum_info.Statevector` (whose `.data` is the same dtype) and fed
+/// straight into NumPy without a conversion step.
 ///
 /// The simulation runs **GIL-free** — only the cheap parameter binding and the
 /// conversion of the result hold the GIL — so other Python threads keep making
@@ -124,18 +127,21 @@ fn push(mut slf: PyRefMut<'_, Circuit>, gate: GateInstruction) -> PyResult<PyRef
 /// [`polypus_sim::MAX_QUBITS`] qubits (30 ≈ 16 GiB) and raises a `ValueError`
 /// naming the requested and the supported count **before** attempting any
 /// allocation. `polypus.Circuit` itself is deliberately unbounded (see
-/// `Circuit::new`): the ceiling belongs to this backend, not to the IR.
+/// `Circuit::new`): the ceiling belongs to this backend, not to the IR. Note
+/// that what a call near the ceiling spends its time on is *allocating* that
+/// buffer, not handing it to Python: even a gateless 30-qubit circuit costs ~5s
+/// (measured), essentially all of it `Statevector::new`'s 16 GiB `vec![]`.
 ///
 /// ```python
 /// import polypus
 /// qc = polypus.Circuit(2).h(0).cx(0, 1)
-/// amps = polypus.statevector(qc)          # [0.707…, 0, 0, 0.707…]
+/// amps = polypus.statevector(qc)          # array([0.707…+0j, 0j, 0j, 0.707…+0j])
 /// ```
 #[pyfunction(signature = (qc, params = None))]
-pub fn statevector(
-    qc: PyRef<'_, Circuit>,
+pub fn statevector<'py>(
+    qc: PyRef<'py, Circuit>,
     params: Option<Vec<f64>>,
-) -> PyResult<Vec<polypus_sim::C64>> {
+) -> PyResult<Bound<'py, PyArray1<polypus_sim::C64>>> {
     let params = params.unwrap_or_default();
     // Binding stays on this side of the release: it is O(gates), allocates
     // nothing of size `2^n`, and reads the circuit through the `PyRef`.
@@ -146,17 +152,19 @@ pub fn statevector(
     // There is still no *mid-run* check: `polypus-sim` has no per-gate hook to
     // call back into, and adding one would mean signal checks inside that
     // crate, which must stay Python-free (§2). But the GIL is reacquired here
-    // the moment `run` returns, before the amplitudes are copied and boxed
-    // into a Python list (`2^n` allocations for a large qubit count) — so a
-    // Ctrl+C that arrived at any point up to now is honored *before* paying
-    // for that conversion, instead of only once it completes and control
-    // returns to the caller's bytecode.
+    // the moment `run` returns, before the amplitudes are handed to NumPy — so a
+    // Ctrl+C that arrived at any point up to now is honored *before* paying for
+    // that conversion, instead of only once it completes and control returns to
+    // the caller's bytecode.
     let sv = qc
         .py()
         .allow_threads(|| StatevectorSimulator::new().run(&concrete))
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
     qc.py().check_signals()?;
-    Ok(sv.amplitudes().to_vec())
+    // `into_amplitudes` (not `amplitudes().to_vec()`) so the `2^n`-element
+    // buffer moves into the array instead of being copied: `sv` is owned here
+    // and dropped immediately after.
+    Ok(sv.into_amplitudes().into_pyarray(qc.py()))
 }
 
 #[pymethods]

--- a/crates/polypus/src/bindings/circuit.rs
+++ b/crates/polypus/src/bindings/circuit.rs
@@ -143,16 +143,19 @@ pub fn statevector(
     // The simulation is the expensive, pure-Rust part: release the GIL for it
     // so it cannot stall every other Python thread (docs/ENGINEERING.md §3).
     //
-    // No `py.check_signals()` here, unlike `run_quantum_circuit`: this is a
-    // single simulation with no per-circuit boundary at which a pending Ctrl+C
-    // could be honored, its cost is bounded by the qubit ceiling above, and the
-    // interpreter raises the pending `KeyboardInterrupt` as soon as the call
-    // returns into Python bytecode. Interrupting it *mid-run* would mean signal
-    // checks inside `polypus-sim`, which must stay Python-free (§2).
+    // There is still no *mid-run* check: `polypus-sim` has no per-gate hook to
+    // call back into, and adding one would mean signal checks inside that
+    // crate, which must stay Python-free (§2). But the GIL is reacquired here
+    // the moment `run` returns, before the amplitudes are copied and boxed
+    // into a Python list (`2^n` allocations for a large qubit count) — so a
+    // Ctrl+C that arrived at any point up to now is honored *before* paying
+    // for that conversion, instead of only once it completes and control
+    // returns to the caller's bytecode.
     let sv = qc
         .py()
         .allow_threads(|| StatevectorSimulator::new().run(&concrete))
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    qc.py().check_signals()?;
     Ok(sv.amplitudes().to_vec())
 }
 

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -85,13 +85,18 @@ boundary stays out-of-process and explicit; see
   function's `Result`, never swallowed or retyped.
 - `statevector` follows the same rule at a smaller scale: it releases the GIL
   around the `StatevectorSimulator::run` call (parameter binding stays on the
-  GIL side — it is O(gates) and allocates nothing of size `2^n`). It
-  deliberately does **not** call `py.check_signals()`: it is a single
-  simulation with no per-circuit boundary at which a pending Ctrl+C could be
-  honored, its cost is bounded by the qubit ceiling (§4), and the interpreter
-  raises the pending `KeyboardInterrupt` as soon as the call returns into
-  Python bytecode. Making it interruptible *mid-run* would require signal
-  checks inside `polypus-sim`, which must stay Python-free (§2).
+  GIL side — it is O(gates) and allocates nothing of size `2^n`), then calls
+  `py.check_signals()` the moment the GIL is reacquired, **before** copying and
+  boxing the amplitudes into a Python list — the same
+  "reacquire-then-check-before-building-the-result" boundary
+  `run_quantum_circuit` uses, just with one call instead of a loop. This still
+  isn't *mid-run*: `polypus-sim` has no per-gate hook to check signals against,
+  and adding one would mean signal checks inside that crate, which must stay
+  Python-free (§2). So a Ctrl+C that arrives while the simulation itself is
+  running is only honored once `run` returns — but from there, it fires before
+  the `2^n`-sized list conversion (§4) rather than after, which matters
+  because that conversion's cost scales only with qubit count, independent of
+  how deep or shallow the circuit was.
 - Preserve concurrent execution: candidates that bind/evaluate truly in
   parallel. If you add a path that runs circuits from worker threads, keep
   this guarantee.

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -83,6 +83,15 @@ boundary stays out-of-process and explicit; see
   the first statement before constructing any Python object. A pending Ctrl+C
   surfaces there as a `KeyboardInterrupt` propagated verbatim through the
   function's `Result`, never swallowed or retyped.
+- `statevector` follows the same rule at a smaller scale: it releases the GIL
+  around the `StatevectorSimulator::run` call (parameter binding stays on the
+  GIL side — it is O(gates) and allocates nothing of size `2^n`). It
+  deliberately does **not** call `py.check_signals()`: it is a single
+  simulation with no per-circuit boundary at which a pending Ctrl+C could be
+  honored, its cost is bounded by the qubit ceiling (§4), and the interpreter
+  raises the pending `KeyboardInterrupt` as soon as the call returns into
+  Python bytecode. Making it interruptible *mid-run* would require signal
+  checks inside `polypus-sim`, which must stay Python-free (§2).
 - Preserve concurrent execution: candidates that bind/evaluate truly in
   parallel. If you add a path that runs circuits from worker threads, keep
   this guarantee.
@@ -101,6 +110,16 @@ boundary stays out-of-process and explicit; see
 - **Parallel == sequential:** kernels under the `parallel` feature (rayon)
   must produce **bit-identical** results to the sequential path. Every new
   parallel kernel is tested against its sequential version.
+- **Qubit ceiling:** a dense statevector needs `2^n` complex amplitudes
+  (`16 · 2^n` bytes), so `polypus-sim` refuses circuits above
+  `polypus_sim::MAX_QUBITS` (30 ≈ 16 GiB) as the **first** thing
+  `StatevectorSimulator::run` does — before any allocation, and low enough that
+  `1 << n` cannot overflow. At the seam this surfaces as a `ValueError` naming
+  the requested and the supported count (`polypus.statevector`;
+  `tests/python/test_statevector.py`). `polypus.Circuit` itself stays
+  unbounded on purpose: it is backend-agnostic IR, and CUNQA/QMIO/Aer have
+  their own, different capacities — the ceiling is enforced where it applies,
+  not in the IR.
 - **Reproducibility:** the RNG is seedable (`rng.rs` in `polypus-sim` and in
   `polypus-optimizers`). Results must be deterministic given a seed. Don't
   introduce nondeterminism: iteration order over a `HashMap` affecting

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -86,15 +86,15 @@ boundary stays out-of-process and explicit; see
 - `statevector` follows the same rule at a smaller scale: it releases the GIL
   around the `StatevectorSimulator::run` call (parameter binding stays on the
   GIL side — it is O(gates) and allocates nothing of size `2^n`), then calls
-  `py.check_signals()` the moment the GIL is reacquired, **before** copying and
-  boxing the amplitudes into a Python list — the same
+  `py.check_signals()` the moment the GIL is reacquired, **before** handing the
+  amplitudes to NumPy — the same
   "reacquire-then-check-before-building-the-result" boundary
   `run_quantum_circuit` uses, just with one call instead of a loop. This still
   isn't *mid-run*: `polypus-sim` has no per-gate hook to check signals against,
   and adding one would mean signal checks inside that crate, which must stay
   Python-free (§2). So a Ctrl+C that arrives while the simulation itself is
   running is only honored once `run` returns — but from there, it fires before
-  the `2^n`-sized list conversion (§4) rather than after, which matters
+  the `2^n`-sized array conversion (§4) rather than after, which matters
   because that conversion's cost scales only with qubit count, independent of
   how deep or shallow the circuit was.
 - Preserve concurrent execution: candidates that bind/evaluate truly in
@@ -121,10 +121,21 @@ boundary stays out-of-process and explicit; see
   `StatevectorSimulator::run` does — before any allocation, and low enough that
   `1 << n` cannot overflow. At the seam this surfaces as a `ValueError` naming
   the requested and the supported count (`polypus.statevector`;
-  `tests/python/test_statevector.py`). `polypus.Circuit` itself stays
-  unbounded on purpose: it is backend-agnostic IR, and CUNQA/QMIO/Aer have
-  their own, different capacities — the ceiling is enforced where it applies,
-  not in the IR.
+  `tests/python/test_statevector.py`). Below the ceiling, those amplitudes cross
+  the seam as a **NumPy array of `dtype=complex128`** — one contiguous buffer
+  moved out of the `Statevector` (`into_amplitudes`, no copy) and wrapped by
+  rust-numpy — rather than as a `list` of boxed Python `complex` objects. That
+  removes a `2^n`-sized conversion which, at these sizes, cost more than the
+  simulation: a gateless 30-qubit call went from 29.7s to 5.0s, and a 26-qubit
+  one from 1.9s to 0.4s (one-off measurement on a 32-core dev box, not a tracked
+  `benchmarks/` script; deep circuits gain proportionally less because the gates
+  dominate — 30 qubits with a Hadamard layer: 50.4s → 25.6s). It does not make
+  near-ceiling statevectors cheap, though: what remains is `Statevector::new`'s
+  `2^n` allocation, which is why even a **gateless** 30-qubit call still costs
+  ~5s. The ceiling is a memory bound and says nothing about wall-clock.
+  `polypus.Circuit` itself stays unbounded on purpose: it is backend-agnostic
+  IR, and CUNQA/QMIO/Aer have their own, different capacities — the ceiling is
+  enforced where it applies, not in the IR.
 - **Reproducibility:** the RNG is seedable (`rng.rs` in `polypus-sim` and in
   `polypus-optimizers`). Results must be deterministic given a seed. Don't
   introduce nondeterminism: iteration order over a `HashMap` affecting

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -33,13 +33,15 @@ core and leaves the others free for the counter thread — the only configuratio
 in which a CPU-bound Python thread can be *observed* to make progress, and thus
 prove the GIL was released, even on a 2-core runner.
 
-``polypus.statevector`` (issue #86) gets the same GIL-release proof at the end of
-this module. It has no SIGINT test: it is a single simulation with no per-circuit
-boundary at which a pending Ctrl+C could be honored — its cost is bounded instead
-by the qubit ceiling (``polypus_sim::MAX_QUBITS``, covered in
-``test_statevector.py``), and the interpreter raises the pending
-``KeyboardInterrupt`` as soon as the call returns. See ``docs/ENGINEERING.md``
-§3.
+``polypus.statevector`` (issue #86) gets the same GIL-release proof at the end
+of this module, plus a SIGINT test of its own. There is still no per-gate
+boundary at which a pending Ctrl+C could be honored *mid-simulation* (the qubit
+ceiling — ``polypus_sim::MAX_QUBITS``, covered in ``test_statevector.py`` —
+bounds its memory, not its wall-clock time), but ``py.check_signals()`` is
+called the moment the GIL is reacquired, before the amplitudes are copied and
+boxed into a Python list — so a Ctrl+C already pending by then is honored
+*before* that conversion, not only once it completes and the call returns. See
+``docs/ENGINEERING.md`` §3.
 
 Why both entry points: `train`'s `VqcOracle` and `qml.train`'s `QmlOracle`
 share `run_and_evaluate`, but reach it through different paths — a native,
@@ -209,12 +211,20 @@ except BaseException as exc:  # e.g. a PanicException from a swallowed error
 """
 
 
-def _assert_responds_to_sigint_promptly(child_code, *, failure_hint, env=None):
+def _assert_responds_to_sigint_promptly(
+    child_code, *, failure_hint, env=None, delay=None, deadline=None
+):
     """Run `child_code` in a subprocess, SIGINT it mid-run, and assert a real
     `KeyboardInterrupt` was raised well before a completed run could finish.
-    Shared by the training and run_quantum_circuit variants below — they differ
-    only in which entry point/backend the child script exercises (and, for
-    run_quantum_circuit, an `env` that pins the sim single-threaded)."""
+    Shared by the training, run_quantum_circuit and statevector variants below
+    — they differ only in which entry point/backend the child script exercises
+    (and, for run_quantum_circuit, an `env` that pins the sim single-threaded).
+    `delay`/`deadline` default to the module-wide `_DELAY_BEFORE_SIGINT_S` /
+    `_INTERRUPT_DEADLINE_S`; the statevector variant overrides both since its
+    timing profile (seconds, not the others' generation/shot budgets) is
+    calibrated separately — see its test for why."""
+    delay = _DELAY_BEFORE_SIGINT_S if delay is None else delay
+    deadline = _INTERRUPT_DEADLINE_S if deadline is None else deadline
     proc = subprocess.Popen(
         [sys.executable, "-c", child_code],
         stdout=subprocess.PIPE,
@@ -233,17 +243,17 @@ def _assert_responds_to_sigint_promptly(child_code, *, failure_hint, env=None):
             f"stderr:\n{proc.stderr.read()}"
         )
 
-        time.sleep(_DELAY_BEFORE_SIGINT_S)
+        time.sleep(delay)
         proc.send_signal(signal.SIGINT)
 
         try:
-            out, err = proc.communicate(timeout=_INTERRUPT_DEADLINE_S)
+            out, err = proc.communicate(timeout=deadline)
         except subprocess.TimeoutExpired:
             proc.kill()
             out, err = proc.communicate()
             pytest.fail(
                 f"{failure_hint} did not respond to SIGINT within "
-                f"{_INTERRUPT_DEADLINE_S}s.\nstdout:\n{out}\nstderr:\n{err}"
+                f"{deadline}s.\nstdout:\n{out}\nstderr:\n{err}"
             )
     finally:
         if proc.poll() is None:
@@ -257,7 +267,7 @@ def _assert_responds_to_sigint_promptly(child_code, *, failure_hint, env=None):
         f"expected a KeyboardInterrupt; got stdout:\n{out}\nstderr:\n{err}"
     )
     elapsed = float(out.split("KEYBOARDINTERRUPT", 1)[1].split()[0])
-    assert elapsed < _INTERRUPT_DEADLINE_S, (
+    assert elapsed < deadline, (
         f"interrupt was honored but not promptly: {elapsed:.2f}s "
         f"(a full run would take far longer)"
     )
@@ -588,4 +598,68 @@ def test_statevector_releases_gil_for_other_threads():
         f"during {_SV_REPEATS} native simulations (advanced {advanced} counts) — "
         f"the GIL was likely not released around statevector\n"
         f"stdout:\n{proc.stdout}"
+    )
+
+
+# `statevector` also calls `py.check_signals()` the moment the GIL is
+# reacquired, *before* copying and boxing the amplitudes into a Python list
+# (see docs/ENGINEERING.md §3/§4) — so a Ctrl+C already pending at that point
+# is honored before paying for that conversion, rather than after.
+#
+# Proving this needs a circuit where the (unguarded) list conversion is the
+# dominant cost, not the (also unguarded, but far cheaper here) simulation:
+# `_SV_LARGE_N = 26` qubits with a single Hadamard layer — simulating is fast
+# regardless of qubit count for one gate per qubit, but converting `2^26` ≈ 67M
+# amplitudes into boxed Python complex objects is not. Measured on the
+# reference machine: a completed call takes ~3.8s (dominated by the
+# conversion); with `check_signals()` in place, a SIGINT sent 0.1s after READY
+# is honored at ~1.5s (the simulation's own share) — reverting the fix pushes
+# that back to ~3.3s, i.e. the interrupt is only caught once the whole
+# conversion finishes too. `_SV_DEADLINE_S` (2.5s) sits between those two
+# measurements, not at the module's own `_INTERRUPT_DEADLINE_S` (5.0s, sized
+# for the other children's much longer budgets): here the "full run" is only
+# ~3.8s, so re-using the wider default would let a regressed (post-conversion)
+# interrupt slip in under the deadline and pass anyway.
+_SV_LARGE_N = 26
+_SV_DELAY_BEFORE_SIGINT_S = 0.1
+_SV_DEADLINE_S = 2.5
+
+_SV_INTERRUPT_CHILD = (
+    r"""
+import sys, time
+import polypus
+
+def make(n):
+    qc = polypus.Circuit(n)
+    for q in range(n):
+        qc = qc.h(q)
+    return qc
+
+# Warm up the lazy import path outside the timed window.
+polypus.statevector(make(2))
+
+qc = make(__N__)
+print("READY", flush=True)
+start = time.time()
+try:
+    polypus.statevector(qc)
+    print("COMPLETED", flush=True)
+except KeyboardInterrupt:
+    print(f"KEYBOARDINTERRUPT {time.time() - start:.3f}", flush=True)
+except BaseException as exc:  # e.g. a PanicException from a swallowed signal
+    print(f"OTHER {type(exc).__name__}", flush=True)
+    sys.exit(1)
+""".replace("__N__", str(_SV_LARGE_N))
+)
+
+
+def test_statevector_responds_to_sigint_before_the_expensive_conversion():
+    _assert_responds_to_sigint_promptly(
+        _SV_INTERRUPT_CHILD,
+        failure_hint=(
+            "statevector — py.check_signals() before the amplitude/list "
+            "conversion is likely missing or misplaced"
+        ),
+        delay=_SV_DELAY_BEFORE_SIGINT_S,
+        deadline=_SV_DEADLINE_S,
     )

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -37,10 +37,9 @@ prove the GIL was released, even on a 2-core runner.
 of this module, plus a SIGINT test of its own. There is still no per-gate
 boundary at which a pending Ctrl+C could be honored *mid-simulation* (the qubit
 ceiling — ``polypus_sim::MAX_QUBITS``, covered in ``test_statevector.py`` —
-bounds its memory, not its wall-clock time), but ``py.check_signals()`` is
-called the moment the GIL is reacquired, before the amplitudes are copied and
-boxed into a Python list — so a Ctrl+C already pending by then is honored
-*before* that conversion, not only once it completes and the call returns. See
+bounds its memory, not its wall-clock time), so — as with
+``run_quantum_circuit`` — the interrupt is honored when the run *reaches*
+``py.check_signals()``, i.e. when the simulation completes. See
 ``docs/ENGINEERING.md`` §3.
 
 Why both entry points: `train`'s `VqcOracle` and `qml.train`'s `QmlOracle`
@@ -220,9 +219,9 @@ def _assert_responds_to_sigint_promptly(
     — they differ only in which entry point/backend the child script exercises
     (and, for run_quantum_circuit, an `env` that pins the sim single-threaded).
     `delay`/`deadline` default to the module-wide `_DELAY_BEFORE_SIGINT_S` /
-    `_INTERRUPT_DEADLINE_S`; the statevector variant overrides both since its
-    timing profile (seconds, not the others' generation/shot budgets) is
-    calibrated separately — see its test for why."""
+    `_INTERRUPT_DEADLINE_S`; the statevector variant overrides `delay` because
+    its whole run lasts about a second (rather than the others' generation/shot
+    budgets), so the SIGINT has to arrive sooner — see its test for why."""
     delay = _DELAY_BEFORE_SIGINT_S if delay is None else delay
     deadline = _INTERRUPT_DEADLINE_S if deadline is None else deadline
     proc = subprocess.Popen(
@@ -601,44 +600,56 @@ def test_statevector_releases_gil_for_other_threads():
     )
 
 
-# `statevector` also calls `py.check_signals()` the moment the GIL is
-# reacquired, *before* copying and boxing the amplitudes into a Python list
-# (see docs/ENGINEERING.md §3/§4) — so a Ctrl+C already pending at that point
-# is honored before paying for that conversion, rather than after.
+# `statevector` also calls `py.check_signals()` the moment the GIL is reacquired,
+# before handing the amplitudes to NumPy (see docs/ENGINEERING.md §3/§4), so a
+# Ctrl+C that arrived while the GIL-free simulation was running surfaces as a
+# `KeyboardInterrupt` out of the call itself — never swallowed into a
+# `PanicException`, and never ignored so the call reports a completed run.
 #
-# Proving this needs a circuit where the (unguarded) list conversion is the
-# dominant cost, not the (also unguarded, but far cheaper here) simulation:
-# `_SV_LARGE_N = 26` qubits with a single Hadamard layer — simulating is fast
-# regardless of qubit count for one gate per qubit, but converting `2^26` ≈ 67M
-# amplitudes into boxed Python complex objects is not. Measured on the
-# reference machine: a completed call takes ~3.8s (dominated by the
-# conversion); with `check_signals()` in place, a SIGINT sent 0.1s after READY
-# is honored at ~1.5s (the simulation's own share) — reverting the fix pushes
-# that back to ~3.3s, i.e. the interrupt is only caught once the whole
-# conversion finishes too. `_SV_DEADLINE_S` (2.5s) sits between those two
-# measurements, not at the module's own `_INTERRUPT_DEADLINE_S` (5.0s, sized
-# for the other children's much longer budgets): here the "full run" is only
-# ~3.8s, so re-using the wider default would let a regressed (post-conversion)
-# interrupt slip in under the deadline and pass anyway.
-_SV_LARGE_N = 26
+# What this test can and cannot pin down. It used to size the child so that the
+# *list* conversion dominated (26 qubits: ~3.8s completed, interrupt honored at
+# ~1.5s with the check in place and ~3.3s without it) and put the deadline
+# between those two numbers, which made the check's presence directly observable.
+# That gap is gone now that the amplitudes cross the seam as a NumPy array: the
+# Rust buffer is *moved* into the array rather than converted element by element,
+# so there is no expensive post-check phase left. Re-measured on the reference
+# machine (26q, full Hadamard layer): completed 1.52s, interrupt latency 1.52s —
+# and, with `check_signals()` temporarily removed and the extension rebuilt,
+# 1.52s again (CPython delivers the pending SIGINT at the very next bytecode
+# after the call returns, which is indistinguishable in wall-clock). No timing
+# threshold can separate the two cases any more, and neither can observing
+# whether the statement after the call ran (checked: it does not, either way).
+#
+# So this now guards the same property as the `run_quantum_circuit` children
+# above — a pending SIGINT is honored as a real `KeyboardInterrupt` when the run
+# reaches the check boundary, i.e. when it completes — and the deadline is a hang
+# guard sized above the full run, not a discriminator. The `check_signals()` call
+# stays because it is the documented boundary and keeps the interrupt ahead of
+# whatever result-building work may be added later; that part is enforced by
+# review and by ENGINEERING.md §3, no longer by a wall-clock assertion.
+#
+# Sizing: 27 qubits with a *single* gate. The finding that motivated dropping the
+# Hadamard layer is that near the ceiling the run's cost is `Statevector::new`'s
+# `2^n` allocation, not the gates — so one gate is enough to make the call last
+# ~0.85s (measured; 1.07s with RAYON_NUM_THREADS=1, i.e. essentially
+# core-count independent, since first-touch of the 2 GiB buffer is single-threaded
+# either way). That is comfortably longer than the 0.1s `delay`, so the SIGINT
+# lands while the simulation is genuinely in flight, and ~5x under the module's
+# `_INTERRUPT_DEADLINE_S` (5.0s) even on a slower runner — which is why, unlike
+# the `run_quantum_circuit` children, this one needs neither a bespoke deadline
+# nor `_SINGLE_THREADED_ENV`. A full Hadamard layer instead swings the run from
+# 1.5s (32 cores) to 3.9s (single-threaded), for no added signal.
+_SV_LARGE_N = 27
 _SV_DELAY_BEFORE_SIGINT_S = 0.1
-_SV_DEADLINE_S = 2.5
 
-_SV_INTERRUPT_CHILD = (
-    r"""
+_SV_INTERRUPT_CHILD = r"""
 import sys, time
 import polypus
 
-def make(n):
-    qc = polypus.Circuit(n)
-    for q in range(n):
-        qc = qc.h(q)
-    return qc
-
 # Warm up the lazy import path outside the timed window.
-polypus.statevector(make(2))
+polypus.statevector(polypus.Circuit(2).h(0))
 
-qc = make(__N__)
+qc = polypus.Circuit(__N__).h(0)
 print("READY", flush=True)
 start = time.time()
 try:
@@ -650,16 +661,15 @@ except BaseException as exc:  # e.g. a PanicException from a swallowed signal
     print(f"OTHER {type(exc).__name__}", flush=True)
     sys.exit(1)
 """.replace("__N__", str(_SV_LARGE_N))
-)
 
 
-def test_statevector_responds_to_sigint_before_the_expensive_conversion():
+def test_statevector_responds_to_sigint_promptly():
     _assert_responds_to_sigint_promptly(
         _SV_INTERRUPT_CHILD,
         failure_hint=(
-            "statevector — py.check_signals() before the amplitude/list "
-            "conversion is likely missing or misplaced"
+            "statevector — the SIGINT was swallowed instead of surfacing as a "
+            "KeyboardInterrupt (py.check_signals() after the GIL is reacquired "
+            "is likely missing, or the GIL is never released)"
         ),
         delay=_SV_DELAY_BEFORE_SIGINT_S,
-        deadline=_SV_DEADLINE_S,
     )

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -1,6 +1,6 @@
 """
 Ctrl+C responsiveness and GIL release during long-running calls
-(issues #36 and #73).
+(issues #36, #73 and #86).
 
 Acceptance criterion: a ``KeyboardInterrupt`` takes effect *promptly* while
 ``polypus.train`` (native backend) or ``polypus.qml.train`` (Qiskit/Aer
@@ -27,11 +27,19 @@ run is still in flight when SIGINT arrives ``_DELAY_BEFORE_SIGINT_S`` after
 READY, short enough to complete well inside ``_INTERRUPT_DEADLINE_S`` even on a
 slower CI core.
 
-The GIL-release test instead uses a small (sub-``parallel_threshold``) circuit
+The GIL-release tests instead use a small (sub-``parallel_threshold``) circuit
 that never engages the rayon pool at all, so the native run occupies a single
 core and leaves the others free for the counter thread — the only configuration
 in which a CPU-bound Python thread can be *observed* to make progress, and thus
 prove the GIL was released, even on a 2-core runner.
+
+``polypus.statevector`` (issue #86) gets the same GIL-release proof at the end of
+this module. It has no SIGINT test: it is a single simulation with no per-circuit
+boundary at which a pending Ctrl+C could be honored — its cost is bounded instead
+by the qubit ceiling (``polypus_sim::MAX_QUBITS``, covered in
+``test_statevector.py``), and the interpreter raises the pending
+``KeyboardInterrupt`` as soon as the call returns. See ``docs/ENGINEERING.md``
+§3.
 
 Why both entry points: `train`'s `VqcOracle` and `qml.train`'s `QmlOracle`
 share `run_and_evaluate`, but reach it through different paths — a native,
@@ -485,4 +493,99 @@ def test_run_quantum_circuit_releases_gil_for_other_threads():
         f"background thread sustained only {ratio:.3f} of its free-running rate "
         f"during the native run (advanced {advanced} counts) — the GIL was "
         f"likely not released around run_quantum_circuit\nstdout:\n{proc.stdout}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# statevector (issue #86)
+# --------------------------------------------------------------------------- #
+
+# `polypus.statevector` releases the GIL around the simulation only; parameter
+# binding (O(gates)) and the amplitude conversion stay on the GIL side. Proven
+# with the same calibrated-ratio design as the `run_quantum_circuit` child above.
+#
+# Sizing differs, though. `statevector` has no `shots`/`n_qpus` knob to buy
+# wall-clock with, and circuit *construction* cost grows superlinearly with the
+# gate count while simulation cost grows linearly, so a single
+# sub-`parallel_threshold` circuit long enough to measure takes far longer to
+# build than to simulate (42k gates: ~0.8s to build, ~0.09s to run). The child
+# therefore simulates one 11-qubit circuit `_SV_REPEATS` times in sequence — the
+# same "many sequential single-thread runs" trick the run_quantum_circuit child
+# gets from `n_qpus=20` — for ~1.4s of native work in total, with the qubit count
+# below polypus-sim's `parallel_threshold` (12) so the run never engages the
+# rayon pool and leaves the other cores free for the counter thread (see the note
+# above).
+#
+# Measured on the reference machine: ratio 0.97 with the GIL released, 0.05 with
+# `allow_threads` reverted (the residual comes from the interpreter's switch
+# interval at each of the `_SV_REPEATS` call boundaries, so it shrinks as the
+# per-call simulation grows — hence few, long calls rather than many short ones).
+# `_MIN_GIL_RELEASE_RATIO` (0.2) sits ~4x above the regressed value.
+_SV_REPEATS = 15
+
+_SV_GIL_RELEASE_CHILD = (
+    r"""
+import threading
+import time
+import polypus
+"""
+    + _MAKE_CIRCUIT_SRC
+    + r"""
+# Warm up the import/build paths outside the measured window.
+polypus.statevector(make(2, 1))
+
+qc = make(11, 2000)  # sub-parallel-threshold; ~0.09s per simulation
+counter = 0
+stop = threading.Event()
+
+def spin():
+    global counter
+    while not stop.is_set():
+        counter += 1
+
+worker = threading.Thread(target=spin)
+worker.start()
+try:
+    # Calibrate the worker's free-running spin rate (time.sleep releases the
+    # GIL), then compare against it — robust to CPU speed, as above.
+    c0 = counter
+    time.sleep(0.2)
+    free_rate = (counter - c0) / 0.2
+
+    before = counter
+    t0 = time.perf_counter()
+    for _ in range(__REPEATS__):
+        polypus.statevector(qc)
+    dt = time.perf_counter() - t0
+    advanced = counter - before
+finally:
+    stop.set()
+    worker.join()
+
+expected = free_rate * dt
+ratio = (advanced / expected) if expected > 0 else 0.0
+print(f"ADVANCED {advanced} RATE {free_rate:.0f} DT {dt:.4f} RATIO {ratio:.4f}", flush=True)
+""".replace("__REPEATS__", str(_SV_REPEATS))
+)
+
+
+def test_statevector_releases_gil_for_other_threads():
+    proc = subprocess.run(
+        [sys.executable, "-c", _SV_GIL_RELEASE_CHILD],
+        capture_output=True,
+        text=True,
+        timeout=_READY_TIMEOUT_S,
+    )
+    assert proc.returncode == 0 and "ADVANCED" in proc.stdout, (
+        f"GIL-release child did not complete cleanly.\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    fields = proc.stdout.split("ADVANCED", 1)[1].split()
+    advanced = int(fields[0])
+    ratio = float(fields[fields.index("RATIO") + 1])
+    assert ratio > _MIN_GIL_RELEASE_RATIO, (
+        f"background thread sustained only {ratio:.3f} of its free-running rate "
+        f"during {_SV_REPEATS} native simulations (advanced {advanced} counts) — "
+        f"the GIL was likely not released around statevector\n"
+        f"stdout:\n{proc.stdout}"
     )

--- a/tests/python/test_statevector.py
+++ b/tests/python/test_statevector.py
@@ -8,7 +8,9 @@ circuit independently with Qiskit gate calls and assert the amplitudes match to
 1e-10. The randomized test exercises the whole gate set over many circuits.
 
 Both backends use the little-endian convention (qubit 0 is the least-significant
-bit), so the amplitude arrays are compared directly.
+bit), so the amplitude arrays are compared directly — and both are NumPy arrays
+of ``complex128`` (``test_returns_a_complex128_numpy_array`` pins the Polypus
+side, which the ``np.asarray`` in ``_compare`` would otherwise not notice).
 
 The two tests at the end cover the *qubit ceiling* at the seam (issue #86): the
 dense statevector backend caps circuits at ``polypus_sim::MAX_QUBITS``
@@ -38,6 +40,28 @@ def _compare(polypus_amps, qc, atol=1e-10):
     assert got.shape == ref.shape, f"shape {got.shape} != {ref.shape}"
     assert np.allclose(got, ref, atol=atol), (
         f"\npolypus = {np.round(got, 4)}\nqiskit  = {np.round(ref, 4)}"
+    )
+
+
+def test_returns_a_complex128_numpy_array():
+    """The `2^n` amplitudes cross the seam as a `numpy.ndarray` of `complex128`,
+    not as a `list` of boxed Python `complex` objects: it is the dtype every
+    consumer wants (NumPy, and Qiskit's own `Statevector.data`) and it is far
+    cheaper to hand over, because the Rust buffer is moved into the array instead
+    of being converted element by element (measured at 26-30 qubits: a gateless
+    30-qubit call went from 29.7s to 5.0s — see `docs/ENGINEERING.md` §4).
+
+    Asserted on its own because the correctness tests above all funnel through
+    `np.asarray`, which accepts a list just as happily and would therefore not
+    catch a regression to the old return type."""
+    import polypus
+
+    amps = polypus.statevector(polypus.Circuit(3).h(0).cx(0, 1))
+
+    assert isinstance(amps, np.ndarray), f"expected np.ndarray, got {type(amps)!r}"
+    assert amps.dtype == np.complex128, f"expected complex128, got {amps.dtype}"
+    assert amps.shape == (8,), (
+        f"expected one amplitude per basis state; got {amps.shape}"
     )
 
 

--- a/tests/python/test_statevector.py
+++ b/tests/python/test_statevector.py
@@ -9,10 +9,17 @@ circuit independently with Qiskit gate calls and assert the amplitudes match to
 
 Both backends use the little-endian convention (qubit 0 is the least-significant
 bit), so the amplitude arrays are compared directly.
+
+The two tests at the end cover the *qubit ceiling* at the seam (issue #86): the
+dense statevector backend caps circuits at ``polypus_sim::MAX_QUBITS``
+(30 ≈ 16 GiB) and must reject anything larger with a ``ValueError`` before
+allocating — the Python-visible half of the guard already tested in Rust
+(``crates/polypus-sim/tests/scalability.rs``).
 """
 
 import math
 import random
+import time
 
 import numpy as np
 import pytest
@@ -194,3 +201,49 @@ def test_random_circuits_match_qiskit():
         for _ in range(depth):
             p = _apply_random_gate(p, qc, n, rng)
         _compare(polypus.statevector(p), qc)
+
+
+# ``polypus_sim::MAX_QUBITS``. Not exposed to Python (the constant belongs to the
+# simulator, not to the seam), so it is mirrored here — keep both in sync.
+_MAX_QUBITS = 30
+
+
+def test_qubit_ceiling_is_documented_at_the_seam():
+    """The ceiling has to be discoverable from Python, not only from the Rust
+    source: `help(polypus.statevector)` must state it."""
+    import polypus
+
+    doc = polypus.statevector.__doc__ or ""
+    assert "MAX_QUBITS" in doc and str(_MAX_QUBITS) in doc, (
+        f"statevector.__doc__ must document the qubit ceiling; got:\n{doc}"
+    )
+
+
+# Comfortably above the ceiling: 31 is the first rejected value, 40 would need
+# 16 TiB and 64 exceeds addressable memory entirely — an unguarded run would not
+# merely be slow, it would take the interpreter down with it.
+@pytest.mark.parametrize("num_qubits", [_MAX_QUBITS + 1, 40, 64])
+def test_rejects_circuits_above_the_qubit_ceiling(num_qubits):
+    """`statevector` must refuse a circuit larger than the backend's ceiling
+    with a `ValueError` (contract C-1's failure mode), raised *before* the
+    `2^n` allocation is attempted."""
+    import polypus
+
+    qc = polypus.Circuit(num_qubits).h(0)
+
+    start = time.perf_counter()
+    with pytest.raises(ValueError) as excinfo:
+        polypus.statevector(qc)
+    elapsed = time.perf_counter() - start
+
+    message = str(excinfo.value)
+    assert str(num_qubits) in message and str(_MAX_QUBITS) in message, (
+        f"the error must name the requested count and the limit; got: {message!r}"
+    )
+    assert "qubit" in message.lower(), f"unexpected error message: {message!r}"
+    # The guard is a single comparison, so the call returns essentially
+    # instantly. A slow failure would mean allocation was attempted first.
+    assert elapsed < 1.0, (
+        f"rejection took {elapsed:.3f}s — the guard must fire before any "
+        f"2^{num_qubits} allocation"
+    )


### PR DESCRIPTION
## Summary

- Releases the GIL around the native simulation in `statevector()` and calls
  `py.check_signals()` right after, so a pending Ctrl+C is honored as soon as
  the simulation completes instead of being silently held until the call
  returns to Python bytecode.
- Documents and tests, at the Python-visible seam, the qubit ceiling that
  already existed one layer down in `polypus-sim` (`MAX_QUBITS = 30`) — a
  clear `ValueError` naming both counts, raised before any `2^n` allocation.
- **Breaking:** `statevector()` now returns a `numpy.ndarray` of
  `dtype=complex128` instead of `list[complex]` — a zero-copy handover
  (`Statevector::into_amplitudes`) that's ~3-6x faster for large qubit counts.
  This required bumping `pyo3` 0.24.2 → 0.25 (rust-numpy pins 1:1 to a pyo3
  version, and numpy 0.24.0's deprecated `to_pyarray_bound` doc link ICEs
  current stable rustdoc — verified, no narrower fix available).
- `polypus.Circuit` itself stays intentionally unbounded — it's backend-agnostic
  IR also routed to CUNQA/QMIO/Aer, whose capacities differ from the native
  dense simulator's ceiling.

Two things this does *not* fix, on purpose — tracked as separate issues so they
don't block this one:
- `ParameterizedCircuit::try_push` is O(G²) in gate count (unrelated crate,
  unrelated defect, found in passing).
- `statevector()` still can't be interrupted *mid-simulation* — the qubit
  ceiling bounds memory, not wall-clock time, and fixing that needs a
  cancellation hook inside `polypus-sim` that this PR deliberately doesn't add.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers --all-features`
- [x] `cargo test -p polypus-logger`
- [x] `cargo test -p polypus --features qmio`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `maturin develop --release --features extension-module` + `pytest tests/python` — 146 passed
- [x] Both new regression tests confirmed non-vacuous by reverting their fix and rebuilding: the GIL-release ratio test drops from 0.97 to ~0.05, and the SIGINT-promptness test fails with `COMPLETED` when the signal is swallowed

Closes #86