### PR TITLE
perf(circuit): make try_push's C-4 check O(1) amortized (#109)

### DIFF
--- a/crates/polypus-circuit/src/circuit.rs
+++ b/crates/polypus-circuit/src/circuit.rs
@@ -2,7 +2,7 @@
 //! [`ConcreteCircuit`] (all angles bound).
 
 use crate::error::CircuitError;
-use crate::gate::{is_qubit_measured, ActsOn, GateInstruction, GateParam};
+use crate::gate::{ActsOn, GateInstruction, GateParam, MeasuredQubits};
 use crate::qasm;
 use crate::qasm_import;
 use crate::qir;
@@ -32,7 +32,7 @@ use crate::qir;
 /// programming errors, mirroring how Qiskit raises `CircuitError` at
 /// construction time. Parameter *values* are validated fallibly at binding
 /// time instead, returning [`CircuitError`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ParameterizedCircuit {
     /// Number of qubits in the (single) quantum register.
     pub num_qubits: usize,
@@ -41,6 +41,22 @@ pub struct ParameterizedCircuit {
     pub num_params: usize,
     /// The instruction sequence, in execution order.
     pub gates: Vec<GateInstruction>,
+    /// Push-time cache backing the C-4 check in [`try_push`](Self::try_push).
+    /// Derived from `gates`, never part of the circuit's identity; assigning
+    /// `gates` directly leaves it in its "not derived yet" state, from which the
+    /// next push rebuilds it.
+    pub(crate) measured: MeasuredQubits,
+}
+
+/// Structural equality over the circuit itself: the `measured` cache is derived
+/// from `gates`, so two circuits that differ only in whether that cache has been
+/// materialised yet are the same circuit.
+impl PartialEq for ParameterizedCircuit {
+    fn eq(&self, other: &Self) -> bool {
+        self.num_qubits == other.num_qubits
+            && self.num_params == other.num_params
+            && self.gates == other.gates
+    }
 }
 
 impl ParameterizedCircuit {
@@ -50,6 +66,7 @@ impl ParameterizedCircuit {
             num_qubits,
             num_params: 0,
             gates: Vec::new(),
+            measured: MeasuredQubits::default(),
         }
     }
 
@@ -130,17 +147,20 @@ impl ParameterizedCircuit {
     pub fn try_push(&mut self, gate: GateInstruction) -> Result<(), CircuitError> {
         // Terminal-measurement model (contract C-4): a unitary gate may not act
         // on a qubit that an earlier instruction already measured. The existing
-        // prefix is already valid, so only the new gate can offend. Checked
-        // before any mutation below.
+        // prefix is already valid, so only the new gate can offend. Answered from
+        // the incremental `measured` cache — rescanning `gates` here made building
+        // a circuit quadratic in its gate count. Checked before any mutation
+        // below; the cache itself is only advanced on the success path.
+        self.measured.sync(&self.gates);
         match gate.acts_on() {
-            ActsOn::One(q) if is_qubit_measured(&self.gates, q) => {
+            ActsOn::One(q) if self.measured.contains(q) => {
                 return Err(CircuitError::QubitAlreadyMeasured { qubit: q });
             }
             ActsOn::Two(a, b) => {
-                if is_qubit_measured(&self.gates, a) {
+                if self.measured.contains(a) {
                     return Err(CircuitError::QubitAlreadyMeasured { qubit: a });
                 }
-                if is_qubit_measured(&self.gates, b) {
+                if self.measured.contains(b) {
                     return Err(CircuitError::QubitAlreadyMeasured { qubit: b });
                 }
             }
@@ -201,6 +221,7 @@ impl ParameterizedCircuit {
             GateInstruction::Measure { qubit, .. } => self.check_qubit(*qubit)?,
             GateInstruction::MeasureAll => {}
         }
+        self.measured.record(&gate);
         self.gates.push(gate);
         Ok(())
     }

--- a/crates/polypus-circuit/src/gate.rs
+++ b/crates/polypus-circuit/src/gate.rs
@@ -1,6 +1,7 @@
 //! Core gate data types: [`GateParam`] and [`GateInstruction`].
 
 use crate::error::CircuitError;
+use std::collections::BTreeSet;
 
 /// An angle argument of a rotation gate.
 ///
@@ -173,16 +174,73 @@ impl GateInstruction {
     }
 }
 
-/// Whether `gates` already measured `qubit` (via a matching `Measure` or any
-/// `MeasureAll`). Used for the incremental C-4 check in
-/// [`ParameterizedCircuit::try_push`](crate::ParameterizedCircuit::try_push),
-/// where the existing prefix is known to already respect the contract.
-pub(crate) fn is_qubit_measured(gates: &[GateInstruction], qubit: usize) -> bool {
-    gates.iter().any(|g| match g {
-        GateInstruction::MeasureAll => true,
-        GateInstruction::Measure { qubit: q, .. } => *q == qubit,
-        _ => false,
-    })
+/// Incremental record of which qubits a circuit has already measured, used for
+/// the push-time C-4 check in
+/// [`ParameterizedCircuit::try_push`](crate::ParameterizedCircuit::try_push).
+///
+/// Rescanning the whole instruction list on every push made building a circuit
+/// of `G` gates cost O(G²); this cache makes each push O(log G) in the number of
+/// *distinct measured qubits* (O(1) amortized in the gate count). It mirrors the
+/// `measured: BTreeSet<usize>` the QASM importer's parser already carries, plus
+/// an `all` flag, because unlike the importer the builder is handed
+/// [`GateInstruction::MeasureAll`] directly by user code.
+///
+/// The cache is derived state: it is *not* part of a circuit's identity (see the
+/// `PartialEq` impl for [`ParameterizedCircuit`](crate::ParameterizedCircuit)),
+/// and a default value means "not derived yet" rather than "nothing measured",
+/// so a circuit assembled field-by-field — bypassing `try_push` entirely, as the
+/// QASM importer and several tests do — still gets the exact same answers as the
+/// old full rescan on its first push.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MeasuredQubits {
+    /// `false` in a freshly built value: [`Self::sync`] has not yet reconstructed
+    /// the cache from the circuit's instruction list.
+    derived: bool,
+    /// Qubits covered by an explicit [`GateInstruction::Measure`].
+    qubits: BTreeSet<usize>,
+    /// Set by [`GateInstruction::MeasureAll`], which measures *every* qubit. Kept
+    /// as a flag rather than expanded into `qubits` so that, exactly as before,
+    /// an out-of-range qubit index after a `MeasureAll` is reported as
+    /// already-measured rather than out-of-range.
+    all: bool,
+}
+
+impl MeasuredQubits {
+    /// Reconstruct the cache from `gates` unless it is already up to date. O(G)
+    /// once per circuit that was assembled without going through `try_push`,
+    /// O(1) on every subsequent push.
+    ///
+    /// This deliberately does not validate `gates`: hand-assembled sequences may
+    /// violate C-4, and the builder's job is only to answer "was this qubit
+    /// measured in the prefix", which is what the old rescan did too.
+    pub(crate) fn sync(&mut self, gates: &[GateInstruction]) {
+        if self.derived {
+            return;
+        }
+        for gate in gates {
+            self.record(gate);
+        }
+        self.derived = true;
+    }
+
+    /// Whether `qubit` has already been measured. Only meaningful after
+    /// [`Self::sync`].
+    pub(crate) fn contains(&self, qubit: usize) -> bool {
+        self.all || self.qubits.contains(&qubit)
+    }
+
+    /// Fold one instruction into the cache. Called for every gate the builder
+    /// accepts, on the success path only; non-measurement instructions
+    /// (including `Barrier`, which C-4 always allows) are inert.
+    pub(crate) fn record(&mut self, gate: &GateInstruction) {
+        match gate {
+            GateInstruction::Measure { qubit, .. } => {
+                self.qubits.insert(*qubit);
+            }
+            GateInstruction::MeasureAll => self.all = true,
+            _ => {}
+        }
+    }
 }
 
 /// Scan a full instruction sequence for a violation of the terminal-measurement
@@ -358,5 +416,80 @@ mod tests {
         let result = instruction.max_cbit();
 
         assert_eq!(result, None);
+    }
+
+    // ── MeasuredQubits (push-time C-4 cache) ─────────────────────────────
+
+    #[test]
+    fn measured_qubits_records_only_measurements() {
+        let mut measured = MeasuredQubits::default();
+        measured.sync(&[]);
+
+        measured.record(&GateInstruction::H(0));
+        measured.record(&GateInstruction::Cx(0, 1));
+        measured.record(&GateInstruction::Barrier(vec![0, 1]));
+        assert!(!measured.contains(0));
+        assert!(!measured.contains(1));
+
+        measured.record(&GateInstruction::Measure { qubit: 1, cbit: 0 });
+        assert!(!measured.contains(0));
+        assert!(measured.contains(1));
+
+        // Re-measuring is idempotent, and a barrier on a measured qubit is inert.
+        measured.record(&GateInstruction::Measure { qubit: 1, cbit: 1 });
+        measured.record(&GateInstruction::Barrier(vec![1]));
+        assert!(measured.contains(1));
+        assert!(!measured.contains(0));
+    }
+
+    #[test]
+    fn measured_qubits_measure_all_covers_every_index() {
+        let mut measured = MeasuredQubits::default();
+        measured.sync(&[]);
+
+        measured.record(&GateInstruction::MeasureAll);
+
+        assert!(measured.contains(0));
+        assert!(measured.contains(7));
+        // Deliberately beyond any plausible register: `MeasureAll` answers for
+        // out-of-range indices too, so `try_push` reports them as
+        // already-measured rather than out-of-range, exactly as the old rescan did.
+        assert!(measured.contains(usize::MAX));
+    }
+
+    #[test]
+    fn measured_qubits_sync_derives_from_an_existing_gate_list_once() {
+        let gates = vec![
+            GateInstruction::H(0),
+            GateInstruction::Measure { qubit: 0, cbit: 0 },
+            GateInstruction::Measure { qubit: 2, cbit: 1 },
+        ];
+
+        let mut measured = MeasuredQubits::default();
+        measured.sync(&gates);
+
+        assert!(measured.contains(0));
+        assert!(!measured.contains(1));
+        assert!(measured.contains(2));
+
+        // A second sync is a no-op: once derived, the cache is maintained by
+        // `record` alone and must not re-fold the (now stale) prefix.
+        measured.sync(&[GateInstruction::Measure { qubit: 1, cbit: 2 }]);
+        assert!(!measured.contains(1));
+    }
+
+    #[test]
+    fn measured_qubits_sync_does_not_validate() {
+        // A hand-assembled sequence that violates C-4 still yields the plain
+        // "was this qubit measured in the prefix" answer.
+        let gates = vec![
+            GateInstruction::Measure { qubit: 0, cbit: 0 },
+            GateInstruction::X(0),
+        ];
+
+        let mut measured = MeasuredQubits::default();
+        measured.sync(&gates);
+
+        assert!(measured.contains(0));
     }
 }

--- a/crates/polypus-circuit/src/qasm_import.rs
+++ b/crates/polypus-circuit/src/qasm_import.rs
@@ -1035,6 +1035,11 @@ impl Parser {
             num_qubits: n,
             num_params: 0,
             gates,
+            // Left un-derived on purpose: the parser's own `measured` set covers
+            // the per-qubit `Measure`s it validated, but `finish` also synthesises
+            // `MeasureAll`, so the builder's cache is rebuilt from `gates` on the
+            // first push into the imported circuit.
+            measured: Default::default(),
         }
     }
 }

--- a/crates/polypus-circuit/tests/circuit.rs
+++ b/crates/polypus-circuit/tests/circuit.rs
@@ -106,14 +106,12 @@ fn test_parameterized_circuit_gate_assign_parameters_wrong_number_of_params() {
 
 #[test]
 fn test_parameterized_circuit_assign_parameters_param_index_out_of_bounds() {
-    let qc = ParameterizedCircuit {
-        num_qubits: 1,
-        num_params: 1,
-        gates: vec![GateInstruction::Rx {
-            qubit: 0,
-            theta: GateParam::Param(5),
-        }],
-    };
+    let mut qc = ParameterizedCircuit::new(1);
+    qc.num_params = 1;
+    qc.gates = vec![GateInstruction::Rx {
+        qubit: 0,
+        theta: GateParam::Param(5),
+    }];
 
     let result = qc.assign_parameters(&[0.1]);
 
@@ -399,6 +397,135 @@ fn test_parameterized_circuit_try_push_track_params() {
     assert_eq!(qc.num_params, 4);
 }
 
+// Push-time C-4 state (contract C-4 enforced incrementally by `try_push`).
+
+#[test]
+fn try_push_rejects_unitary_on_a_measured_qubit() {
+    let mut qc = ParameterizedCircuit::new(2);
+    qc.try_push(GateInstruction::Measure { qubit: 0, cbit: 0 })
+        .unwrap();
+
+    assert_eq!(
+        qc.try_push(GateInstruction::X(0)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 0 })
+    );
+    // The other qubit is untouched by the measurement, and re-measuring and
+    // barriers remain legal on the measured one.
+    assert_eq!(qc.try_push(GateInstruction::H(1)), Ok(()));
+    assert_eq!(
+        qc.try_push(GateInstruction::Measure { qubit: 0, cbit: 1 }),
+        Ok(())
+    );
+    assert_eq!(qc.try_push(GateInstruction::Barrier(vec![0])), Ok(()));
+    assert_eq!(
+        qc.try_push(GateInstruction::Cx(1, 0)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 0 })
+    );
+}
+
+#[test]
+fn try_push_rejects_any_unitary_after_measure_all() {
+    let mut qc = ParameterizedCircuit::new(3);
+    qc.try_push(GateInstruction::MeasureAll).unwrap();
+
+    for q in 0..3 {
+        assert_eq!(
+            qc.try_push(GateInstruction::H(q)),
+            Err(CircuitError::QubitAlreadyMeasured { qubit: q })
+        );
+    }
+    // Two-qubit gates report the first offending operand, as before.
+    assert_eq!(
+        qc.try_push(GateInstruction::Cx(2, 1)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 2 })
+    );
+    // `MeasureAll` covers indices past the register too: the C-4 check runs
+    // before the range check, so this is "already measured", not "out of range".
+    assert_eq!(
+        qc.try_push(GateInstruction::H(9)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 9 })
+    );
+    // Measurements and barriers still go through.
+    assert_eq!(qc.try_push(GateInstruction::MeasureAll), Ok(()));
+    assert_eq!(qc.try_push(GateInstruction::Barrier(vec![])), Ok(()));
+    assert_eq!(qc.gates.len(), 3);
+}
+
+/// A rejected push must leave the circuit — including the incremental C-4
+/// state — exactly as it was, so later legal pushes still behave.
+#[test]
+fn try_push_rejections_do_not_disturb_the_measured_state() {
+    let mut qc = ParameterizedCircuit::new(3);
+    qc.try_push(GateInstruction::H(0)).unwrap();
+    qc.try_push(GateInstruction::Measure { qubit: 1, cbit: 0 })
+        .unwrap();
+
+    // A mix of rejections: C-4, out of range, identical qubits, non-finite angle.
+    assert_eq!(
+        qc.try_push(GateInstruction::Cx(0, 1)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 1 })
+    );
+    assert_eq!(
+        qc.try_push(GateInstruction::H(7)),
+        Err(CircuitError::QubitOutOfRange {
+            qubit: 7,
+            num_qubits: 3
+        })
+    );
+    assert_eq!(
+        qc.try_push(GateInstruction::Cx(2, 2)),
+        Err(CircuitError::IdenticalQubits { qubit: 2 })
+    );
+    assert_eq!(
+        qc.try_push(GateInstruction::Rz {
+            qubit: 2,
+            theta: GateParam::Fixed(f64::NAN),
+        }),
+        Err(CircuitError::NonFiniteParam)
+    );
+    assert_eq!(qc.gates.len(), 2);
+
+    // Unmeasured qubits are still usable, and measuring one more is tracked.
+    assert_eq!(qc.try_push(GateInstruction::Cx(0, 2)), Ok(()));
+    assert_eq!(
+        qc.try_push(GateInstruction::Measure { qubit: 2, cbit: 1 }),
+        Ok(())
+    );
+    assert_eq!(
+        qc.try_push(GateInstruction::Cx(0, 2)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 2 })
+    );
+    assert_eq!(qc.try_push(GateInstruction::H(0)), Ok(()));
+}
+
+/// The C-4 state is derived from `gates`, not assumed empty: a circuit whose
+/// instruction list was assembled without the builder (hand-written, or produced
+/// by the QASM importer) is still checked against its own measurements.
+#[test]
+fn try_push_derives_the_measured_state_from_existing_gates() {
+    let mut hand_assembled = ParameterizedCircuit::new(2);
+    hand_assembled.gates = vec![
+        GateInstruction::H(0),
+        GateInstruction::Measure { qubit: 0, cbit: 0 },
+    ];
+    assert_eq!(
+        hand_assembled.try_push(GateInstruction::X(0)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 0 })
+    );
+    assert_eq!(hand_assembled.try_push(GateInstruction::X(1)), Ok(()));
+
+    // Same via the importer, whose `finish` synthesises `MeasureAll`.
+    let mut imported = ParameterizedCircuit::from_qasm2(
+        "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncreg c[2];\nh q[0];\nmeasure q -> c;\n",
+    )
+    .unwrap();
+    assert_eq!(imported.gates.last(), Some(&GateInstruction::MeasureAll));
+    assert_eq!(
+        imported.try_push(GateInstruction::H(1)),
+        Err(CircuitError::QubitAlreadyMeasured { qubit: 1 })
+    );
+}
+
 #[test]
 fn test_parameterized_circuit_push_basic() {
     let qc = ParameterizedCircuit::new(2).push(GateInstruction::H(1));
@@ -500,14 +627,11 @@ fn test_export_rejects_non_finite_angle() {
     // Route 2: a circuit assembled by hand with a fixed non-finite angle,
     // bypassing the builder's construction-time guard — the exporter itself
     // still refuses it, so no `NaN`/`inf` literal is ever serialised.
-    let hand_assembled = ParameterizedCircuit {
-        num_qubits: 1,
-        num_params: 0,
-        gates: vec![GateInstruction::Rx {
-            qubit: 0,
-            theta: GateParam::Fixed(f64::INFINITY),
-        }],
-    };
+    let mut hand_assembled = ParameterizedCircuit::new(1);
+    hand_assembled.gates = vec![GateInstruction::Rx {
+        qubit: 0,
+        theta: GateParam::Fixed(f64::INFINITY),
+    }];
     assert_eq!(
         hand_assembled.to_qasm2_with_params(&[]),
         Err(CircuitError::NonFiniteParam)

--- a/crates/polypus-circuit/tests/circuit_qasm.rs
+++ b/crates/polypus-circuit/tests/circuit_qasm.rs
@@ -195,14 +195,12 @@ fn wrong_number_of_params_is_rejected() {
 #[test]
 fn param_index_out_of_bounds_is_rejected() {
     // Assemble manually so num_params and gate indices disagree.
-    let qc = ParameterizedCircuit {
-        num_qubits: 1,
-        num_params: 1,
-        gates: vec![GateInstruction::Rx {
-            qubit: 0,
-            theta: GateParam::Param(5),
-        }],
-    };
+    let mut qc = ParameterizedCircuit::new(1);
+    qc.num_params = 1;
+    qc.gates = vec![GateInstruction::Rx {
+        qubit: 0,
+        theta: GateParam::Param(5),
+    }];
     assert_eq!(
         qc.assign_parameters(&[0.1]),
         Err(CircuitError::ParamIndexOutOfBounds {

--- a/crates/polypus-circuit/tests/circuit_scaling.rs
+++ b/crates/polypus-circuit/tests/circuit_scaling.rs
@@ -22,6 +22,16 @@ const NUM_QUBITS: usize = 11;
 /// polluted by scheduling noise.
 const REPEATS: usize = 5;
 
+/// Upper bound on the gate count the calibration loop below will grow to.
+/// Purely a safety net against an unbounded search (e.g. a broken clock
+/// always reading ~0); on any realistic hardware the 2ms floor is reached
+/// far below this (~30-60k gates on current dev/CI machines), so raising it
+/// costs nothing in practice but removes the (very unlikely) risk of the
+/// search being cut off before the floor is reached on unusually fast
+/// hardware, which would leave the ratio comparison on sub-millisecond,
+/// noise-sensitive timings.
+const MAX_CALIBRATION_GATES: usize = 1_000_000;
+
 /// Build a circuit of `num_gates` instructions, alternating single-qubit
 /// rotations with two-qubit entanglers across the whole register. No
 /// measurements: the point is to time the C-4 check on unitaries.
@@ -59,7 +69,7 @@ fn building_a_circuit_scales_linearly_with_its_gate_count() {
     // dominate the ratio. Under the old quadratic behaviour the floor is reached
     // immediately, which only makes the ratio below more pronounced.
     let mut n = 2_000;
-    while best_build_time(n) < Duration::from_millis(2) && n < 64_000 {
+    while best_build_time(n) < Duration::from_millis(2) && n < MAX_CALIBRATION_GATES {
         n *= 2;
     }
 

--- a/crates/polypus-circuit/tests/circuit_scaling.rs
+++ b/crates/polypus-circuit/tests/circuit_scaling.rs
@@ -1,0 +1,83 @@
+//! Integration tests for polypus-circuit: build-time scaling.
+//!
+//! Regression guard for issue #109: `ParameterizedCircuit::try_push` used to
+//! enforce contract C-4 by rescanning every instruction already in the circuit,
+//! so appending gate `k` cost O(k) and building a circuit of `G` gates cost
+//! O(G²). The check is now answered from an incremental per-circuit cache.
+//!
+//! The assertion is on *scaling*, not on wall-clock time: doubling the gate
+//! count must roughly double the build time (linear), where a reinstated rescan
+//! would quadruple it. CI runners are shared and noisy, so absolute budgets
+//! would be flaky while the ratio is not, and the threshold below leaves a wide
+//! margin between the two regimes.
+
+use polypus_circuit::ParameterizedCircuit;
+use std::time::{Duration, Instant};
+
+/// Qubit count of the timed circuits: enough width for a realistic mix of
+/// single- and two-qubit gates (the issue's repro used 11).
+const NUM_QUBITS: usize = 11;
+
+/// Repetitions per measurement; the minimum is kept, being the sample least
+/// polluted by scheduling noise.
+const REPEATS: usize = 5;
+
+/// Build a circuit of `num_gates` instructions, alternating single-qubit
+/// rotations with two-qubit entanglers across the whole register. No
+/// measurements: the point is to time the C-4 check on unitaries.
+fn build(num_gates: usize) -> ParameterizedCircuit {
+    let mut qc = ParameterizedCircuit::new(NUM_QUBITS);
+    for i in 0..num_gates {
+        let q = i % NUM_QUBITS;
+        qc = if i % 2 == 0 {
+            qc.rx(q, 0.1)
+        } else {
+            qc.cx(q, (q + 1) % NUM_QUBITS)
+        };
+    }
+    qc
+}
+
+/// Fastest of [`REPEATS`] builds of `num_gates` gates.
+fn best_build_time(num_gates: usize) -> Duration {
+    (0..REPEATS)
+        .map(|_| {
+            let start = Instant::now();
+            let qc = build(num_gates);
+            let elapsed = start.elapsed();
+            // Consume the result so the build cannot be optimised away.
+            assert_eq!(qc.gates.len(), num_gates);
+            elapsed
+        })
+        .min()
+        .expect("REPEATS > 0")
+}
+
+#[test]
+fn building_a_circuit_scales_linearly_with_its_gate_count() {
+    // Grow the small size until one build is long enough that timer noise cannot
+    // dominate the ratio. Under the old quadratic behaviour the floor is reached
+    // immediately, which only makes the ratio below more pronounced.
+    let mut n = 2_000;
+    while best_build_time(n) < Duration::from_millis(2) && n < 64_000 {
+        n *= 2;
+    }
+
+    let small = best_build_time(n);
+    let large = best_build_time(2 * n);
+    let ratio = large.as_secs_f64() / small.as_secs_f64();
+    // Visible with `--nocapture` when investigating a regression.
+    println!(
+        "{n} gates: {small:?}; {} gates: {large:?}; {ratio:.2}x",
+        2 * n
+    );
+
+    // Linear ⇒ ~2x. Quadratic ⇒ ~4x. Assert well inside the gap.
+    assert!(
+        ratio < 3.0,
+        "build time grew {ratio:.2}x when the gate count doubled \
+         ({n} gates in {small:?}, {} gates in {large:?}); \
+         expected ~2x for a linear build, ~4x means an O(G²) rescan is back",
+        2 * n
+    );
+}

--- a/crates/polypus-circuit/tests/contracts.rs
+++ b/crates/polypus-circuit/tests/contracts.rs
@@ -186,14 +186,11 @@ fn c4_importer_rejects_gate_after_measure_with_line() {
 #[test]
 fn c4_qir_exporter_rejects_gate_after_measure() {
     // Hand-assembled (bypasses the builder's own check) to reach the exporter.
-    let qc = ParameterizedCircuit {
-        num_qubits: 1,
-        num_params: 0,
-        gates: vec![
-            GateInstruction::Measure { qubit: 0, cbit: 0 },
-            GateInstruction::X(0),
-        ],
-    };
+    let mut qc = ParameterizedCircuit::new(1);
+    qc.gates = vec![
+        GateInstruction::Measure { qubit: 0, cbit: 0 },
+        GateInstruction::X(0),
+    ];
     let err = qc.to_qir_with_params(&[]).unwrap_err();
     assert_eq!(err, CircuitError::QubitAlreadyMeasured { qubit: 0 });
 }

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -190,8 +190,24 @@ only to define behaviour for hand-assembled circuits)*.
 
 Backends and exporters **must reject** circuits that violate this with an
 explicit error — never silently reorder, deduplicate or no-op the measurement.
-The single shared check is `polypus_circuit::terminal_measurement_violation`,
-enforced in the builder, the importer, the simulator and the QIR exporter.
+The rule is enforced at four points, which must all reject identically (same
+offending qubit, same error) even though they see the circuit differently:
+
+- **Builder** (`ParameterizedCircuit::try_push`/`push`): incremental,
+  push-time. Each push is checked against the per-circuit record of qubits
+  already measured, which the push itself then updates — the prefix is known to
+  be valid, so only the new instruction can offend. Rescanning here would make
+  building a circuit quadratic in its gate count (issue #109).
+- **QASM importer**: incremental, parse-time, against the parser's own
+  `measured` set (which also carries the offending line number).
+- **Simulator** (`polypus-sim`) and **QIR exporter**: a single full-sequence
+  scan via `polypus_circuit::terminal_measurement_violation`, since both are
+  handed a complete instruction list — possibly hand-assembled, i.e. never
+  validated by the builder or the importer.
+
+`terminal_measurement_violation` is the reference definition of the rule: a
+unitary on a measured qubit is a violation, `Barrier` is always allowed, and
+re-measuring an already-measured qubit is allowed.
 Rationale and alternatives considered: see `docs/adr/0001-terminal-measurements.md`.
 
 **Enforcing test:** rejection tests in


### PR DESCRIPTION
## Summary
- `ParameterizedCircuit::try_push` enforced contract C-4 (terminal-measurement
  placement) by rescanning the entire gate list once per touched qubit, so
  appending gate `k` cost O(k) and building a circuit of `G` gates cost O(G²)
  — an 11-qubit, ~42k-gate circuit took ~0.8s to build vs ~0.09s to simulate.
- Replaces the rescan with an incremental per-circuit cache (`MeasuredQubits`:
  a `BTreeSet<usize>` of measured qubits + a `MeasureAll` flag, mirroring the
  QASM importer's existing `measured` parser state), updated on the success
  path of every push only. The cache is lazily derived — "not derived yet" is
  its default — so circuits assembled outside `try_push` (the QASM importer's
  `finish()`, hand-assembled test circuits) still get correct answers from a
  one-time O(G) rebuild on their first push.
- `docs/CONTRACTS.md`'s C-4 entry previously claimed a single shared
  `terminal_measurement_violation` scan enforced the rule everywhere; it now
  describes each of the four enforcement points accurately (builder and
  importer: incremental; simulator and QIR exporter: full-sequence scan). No
  change to C-4's semantics or its enforcing tests.
- Follow-up commit widens a test's build-time calibration safety cap (64k →
  1M gates) so the anti-regression test can't be cut short on unusually fast
  hardware before it finds its timing-noise floor — a no-op on current
  hardware, pure headroom.

## Why
Any code that assembles large circuits in a loop (benchmarks, deep VQE/QAOA
ansätze, generated test circuits) paid a quadratic cost for no reason: the
check only needs to know *whether* a qubit was ever measured, not rescan the
whole history to find out.

## What changed
- `crates/polypus-circuit/src/gate.rs` — new `MeasuredQubits` cache type;
  deleted the now-unused `is_qubit_measured` full-rescan helper.
  `terminal_measurement_violation` (the separate, once-per-circuit full scan
  used by the simulator and the QIR exporter) is untouched — it was never
  the quadratic path.
- `crates/polypus-circuit/src/circuit.rs` — `ParameterizedCircuit` carries a
  `pub(crate) measured: MeasuredQubits` field; `try_push` answers C-4 from it
  and advances it only on the success path. `PartialEq` is now a manual impl
  over `num_qubits`/`num_params`/`gates` — the cache is derived state, not
  part of a circuit's identity.
- `crates/polypus-circuit/src/qasm_import.rs` — `finish()` initializes the
  new field to its default ("not yet derived").
- `tests/circuit.rs`, `tests/contracts.rs`, `tests/circuit_qasm.rs` —
  struct-literal circuit construction rewritten as `new(n)` + field
  assignment, since the new cache field is crate-private and Rust struct
  literals are exhaustive. These tests still bypass the builder's own C-4
  check on purpose, which is what they're for.
- `crates/polypus-circuit/tests/circuit_scaling.rs` (new) — scaling-ratio
  regression test: asserts build time roughly doubles (not quadruples) when
  the gate count doubles, self-calibrated against timing noise instead of an
  absolute wall-clock budget.

## Compatibility note
`ParameterizedCircuit` can no longer be constructed via struct literal from
outside the crate (the new cache field is `pub(crate)`); `num_qubits`,
`num_params` and `gates` remain `pub` and individually settable. This was
never a documented construction path, but it's technically a breaking change
for any external Rust consumer of this crate as a standalone library —
flagging for whoever cuts the next release (crate is pre-1.0, `0.6.0`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers --all-features`
- [x] `cargo test --workspace`
- [x] `cargo test -p polypus --features qmio`
- [x] `maturin develop --release --features extension-module` + `pytest tests/python` (139 passed)
- [x] New scaling test: ~2.0x build-time ratio on doubling the gate count (was ~4.0x before the fix)

Closes #109