### PR TITLE
feat(bindings,evaluation): log run lifecycle and oracle failures

### DIFF
--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -30,6 +30,7 @@ use polypus_optimizers::{
     OptimizerError,
 };
 use std::sync::Arc;
+use std::time::Instant;
 use uuid::Uuid;
 
 /// Result of [`run_quantum_circuit`]: the measurement counts plus the run
@@ -169,6 +170,27 @@ fn unique_id(base: &str) -> String {
     format!("{}_{}", base, Uuid::new_v4())
 }
 
+/// Announce the start of a training run at the default log level.
+///
+/// The fields are exactly the C-7 manifest data — id, infrastructure, backend,
+/// n_qpus, shots, effective seed — so an operator watching a multi-hour run can
+/// tell from the log alone what was executed where, and with which seed to
+/// replay it. Shared by `train` and `qml_train`, whose start records are
+/// identical; nothing high-volume (no circuit dumps) belongs at this level.
+fn log_training_start(
+    id: &str,
+    infrastructure: &str,
+    backend: &str,
+    n_qpus: u32,
+    shots: u32,
+    seed: u64,
+) {
+    log::info!(
+        "training run {id} starting: infrastructure={infrastructure}, backend={backend}, \
+         n_qpus={n_qpus}, shots={shots}, seed={seed}"
+    );
+}
+
 /// Read the `seed` field pinned on the optimizer object passed as `method`,
 /// whichever of `DE`/`PSO`/`QNG` it is (`None` if it is none of them — the type
 /// error is surfaced later by the dispatch that actually runs the optimizer).
@@ -193,17 +215,30 @@ fn method_seed(method: &Bound<'_, PyAny>) -> Option<u64> {
 /// [`OracleErrorSlot`] and yields finite sentinels, so `optimize` may return
 /// `Ok` with a meaningless outcome. Surfacing the recorded error here is what
 /// makes the FFI boundary report the real cause instead of that garbage.
+///
+/// Both entry points funnel every DE/PSO/QNG branch through here, so this is
+/// also where the run's completion is logged — once, on the success path only
+/// (an oracle failure was already logged at `error!` where it was recorded).
+/// `start` is the [`Instant`] captured on entry to the entry point, so the
+/// reported duration covers the whole call.
 fn finish_optimization(
     py: Python<'_>,
     result: Result<OptimizationOutcome, OptimizerError>,
     errors: &OracleErrorSlot,
     seed: u64,
     id: String,
+    start: Instant,
 ) -> PyResult<PyObject> {
     if let Some(eval_err) = errors.take() {
         return Err(eval_err.into());
     }
     let outcome = result.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    log::info!(
+        "training run {id} completed: iterations_run={}, converged={}, duration={:?}",
+        outcome.iterations_run,
+        outcome.converged,
+        start.elapsed()
+    );
     outcome_to_train_result(py, outcome, seed, id)
 }
 
@@ -422,6 +457,7 @@ pub fn run_quantum_circuit<'py>(
     backend: &str,
     seed: Option<u64>,
 ) -> PyResult<pyo3::PyObject> {
+    let start = Instant::now();
     // Entry-point trace carrying the full circuit `Debug` repr on every call:
     // large and high-volume, so it stays at `debug` rather than the default log.
     log::debug!(
@@ -495,6 +531,14 @@ pub fn run_quantum_circuit<'py>(
         config,
     };
 
+    // Lifecycle record at the default level, carrying the C-7 manifest data only
+    // (the circuit itself stays in the `debug!` above): enough to see what ran
+    // where, and with which seed to replay it.
+    log::info!(
+        "run {id} starting: infrastructure={infrastructure}, backend={backend}, \
+         n_qpus={n_qpus}, shots={shots}, seed={effective_seed:?}"
+    );
+
     let algorithm: Box<
         dyn AlgorithmTrait<Args = AlgorithmArgs, AlgorithmReturnType = PyResult<PyObject>> + Send,
     > = if n_qpus == 1 {
@@ -511,6 +555,10 @@ pub fn run_quantum_circuit<'py>(
     // taking effect until the run finishes. See docs/ENGINEERING.md §3.
     // Keep the original counts payload intact and wrap it with the run manifest.
     let counts = qc.py().allow_threads(move || algorithm.run(args))?;
+    // Completion counterpart of the start record above. There is no
+    // iterations/convergence notion on this path (those are `TrainResult`
+    // fields), so this reports only the run and how long it took.
+    log::info!("run {id} completed: duration={:?}", start.elapsed());
     Python::with_gil(|py| {
         Py::new(
             py,
@@ -579,6 +627,7 @@ pub fn train<'py>(
     backend: &str,
     seed: Option<u64>,
 ) -> PyResult<PyObject> {
+    let start = Instant::now();
     validate_shots_and_qpus(shots, n_qpus)?;
     validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
     // Resolve the seed that drives the optimizer's RNG (contract C-7): explicit
@@ -643,6 +692,16 @@ pub fn train<'py>(
         // unconditionally so a native-backend training run reproduces exactly.
         seed: Some(effective_seed),
     });
+    // Log before `backend` is shadowed below: the `&str` device selector is what
+    // belongs in the manifest record, not the constructed backend object.
+    log_training_start(
+        &effective_id,
+        &infrastructure,
+        backend,
+        n_qpus,
+        shots,
+        effective_seed,
+    );
     let backend = Infrastructure::create_backend(&config)?;
     // Shared error slot: the oracles record the first evaluation failure here
     // (the optimizer traits cannot return a `Result`) and it is surfaced by
@@ -678,6 +737,7 @@ pub fn train<'py>(
             &errors,
             effective_seed,
             effective_id.clone(),
+            start,
         );
     }
 
@@ -700,6 +760,7 @@ pub fn train<'py>(
             &errors,
             effective_seed,
             effective_id.clone(),
+            start,
         );
     }
 
@@ -714,6 +775,7 @@ pub fn train<'py>(
             variance_oracle: Box::new(PyVarianceOracle {
                 variance_function: qng.variance_function.clone_ref(method.py()),
                 errors: errors.clone(),
+                run_id: effective_id.clone(),
             }),
             tikhonov_reg: qng.tikhonov_reg,
             seed: Some(effective_seed),
@@ -724,6 +786,7 @@ pub fn train<'py>(
             &errors,
             effective_seed,
             effective_id.clone(),
+            start,
         );
     }
 
@@ -795,6 +858,7 @@ pub fn qml_train<'py>(
     backend: &str,
     seed: Option<u64>,
 ) -> PyResult<PyObject> {
+    let start = Instant::now();
     validate_shots_and_qpus(shots, n_qpus)?;
     validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
     // Same seed precedence as `train` (contract C-7): kwarg > optimizer field >
@@ -904,6 +968,16 @@ pub fn qml_train<'py>(
         // unconditionally so a native-backend training run reproduces exactly.
         seed: Some(effective_seed),
     });
+    // Log before `backend` is shadowed below (see `train`): the device selector
+    // string is the manifest value, not the constructed backend object.
+    log_training_start(
+        &effective_id,
+        &infrastructure,
+        backend,
+        n_qpus,
+        shots,
+        effective_seed,
+    );
     let backend = Infrastructure::create_backend(&config)?;
     // Shared error slot (see `train`): oracles record the first evaluation
     // failure here and `finish_optimization` surfaces it after `optimize`.
@@ -934,6 +1008,7 @@ pub fn qml_train<'py>(
             &errors,
             effective_seed,
             effective_id.clone(),
+            start,
         );
     }
 
@@ -956,6 +1031,7 @@ pub fn qml_train<'py>(
             &errors,
             effective_seed,
             effective_id.clone(),
+            start,
         );
     }
 
@@ -970,6 +1046,7 @@ pub fn qml_train<'py>(
             variance_oracle: Box::new(PyVarianceOracle {
                 variance_function: qng.variance_function.clone_ref(py),
                 errors: errors.clone(),
+                run_id: effective_id.clone(),
             }),
             tikhonov_reg: qng.tikhonov_reg,
             seed: Some(effective_seed),
@@ -980,6 +1057,7 @@ pub fn qml_train<'py>(
             &errors,
             effective_seed,
             effective_id.clone(),
+            start,
         );
     }
 

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -221,6 +221,11 @@ fn method_seed(method: &Bound<'_, PyAny>) -> Option<u64> {
 /// (an oracle failure was already logged at `error!` where it was recorded).
 /// `start` is the [`Instant`] captured on entry to the entry point, so the
 /// reported duration covers the whole call.
+///
+/// An `OptimizerError` with no oracle failure recorded is a rejected
+/// optimizer configuration (`population_size` too small for DE, empty PSO/QNG
+/// `bounds`, …), caught before any oracle call — unlike an oracle failure, it
+/// has nowhere else to be logged, so it is logged here too.
 fn finish_optimization(
     py: Python<'_>,
     result: Result<OptimizationOutcome, OptimizerError>,
@@ -232,7 +237,10 @@ fn finish_optimization(
     if let Some(eval_err) = errors.take() {
         return Err(eval_err.into());
     }
-    let outcome = result.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let outcome = result.map_err(|e| {
+        log::error!("run {id}: optimizer rejected the configuration: {e}");
+        pyo3::exceptions::PyValueError::new_err(e.to_string())
+    })?;
     log::info!(
         "training run {id} completed: iterations_run={}, converged={}, duration={:?}",
         outcome.iterations_run,

--- a/crates/polypus/src/bindings/qng.rs
+++ b/crates/polypus/src/bindings/qng.rs
@@ -67,6 +67,11 @@ pub struct PyVarianceOracle {
     /// after `optimize` returns, since [`VarianceOracle`] cannot return a
     /// `Result`.
     pub errors: OracleErrorSlot,
+    /// Effective run id (`ExecutionConfig::id`) of the training run this adapter
+    /// serves, so a recorded failure names its run in the log. Owned rather than
+    /// borrowed: the adapter is boxed into the optimizer args and outlives the
+    /// entry-point frame that built it.
+    pub run_id: String,
 }
 
 impl PyVarianceOracle {
@@ -80,7 +85,7 @@ impl PyVarianceOracle {
         match self.try_call(py, theta, param_index) {
             Ok(value) => value,
             Err(e) => {
-                self.errors.record(e);
+                self.errors.record(e, &self.run_id);
                 0.0
             }
         }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -31,9 +31,24 @@ impl OracleErrorSlot {
     }
 
     /// Record `err` as the failure, keeping the *first* one recorded.
-    pub fn record(&self, err: EvaluationError) {
+    ///
+    /// `run_id` is the effective [`ExecutionConfig::id`] of the run whose oracle
+    /// failed, threaded in from the call site because this slot holds no run
+    /// metadata of its own. The failure is logged at `error!` here, as it is
+    /// recorded: from this point on the oracle only yields sentinel values, so
+    /// without this record the log would simply go quiet until `optimize()`
+    /// returns and the entry point raises.
+    pub fn record(&self, err: EvaluationError, run_id: &str) {
         let mut guard = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        // Log only when this call actually stores the error, so the message never
+        // claims to have "recorded" a failure it silently dropped.
         if guard.is_none() {
+            // Formatting the `Python(PyErr)` variant reacquires the GIL through
+            // `PyErr`'s own `Display`, and this can run with the GIL released
+            // (the optimizers run inside `allow_threads`). Safe either way:
+            // `Python::with_gil` is re-entrant — the same guarantee `cunqa.rs`
+            // relies on to acquire the GIL from within a `Drop`.
+            log::error!("run {run_id}: oracle evaluation failed: {err}");
             *guard = Some(err);
         }
     }

--- a/crates/polypus/src/evaluation/qml_oracle.rs
+++ b/crates/polypus/src/evaluation/qml_oracle.rs
@@ -37,7 +37,7 @@ impl EvaluationOracle for QmlOracle {
         match self.try_evaluate(candidates) {
             Ok(values) => values,
             Err(e) => {
-                self.errors.record(e);
+                self.errors.record(e, &self.config.id);
                 vec![0.0; candidates.len()]
             }
         }

--- a/crates/polypus/src/evaluation/vqc_oracle.rs
+++ b/crates/polypus/src/evaluation/vqc_oracle.rs
@@ -41,7 +41,7 @@ impl EvaluationOracle for VqcOracle {
         match self.try_evaluate(candidates) {
             Ok(values) => values,
             Err(e) => {
-                self.errors.record(e);
+                self.errors.record(e, &self.config.id);
                 vec![0.0; candidates.len()]
             }
         }


### PR DESCRIPTION
## Summary

- `train`, `qml_train`, and `run_quantum_circuit` now emit `info!` lifecycle
  records on start (the C-7 manifest data: id, infrastructure, backend,
  n_qpus, shots, effective seed) and on completion (`iterations_run`,
  `converged`, duration for `train`/`qml_train`; id + duration for
  `run_quantum_circuit`, which has no iteration/convergence concept) —
  visible in default builds since `info` is the compile-time ceiling.
- `OracleErrorSlot::record` now logs the failure at `error!` with the run id
  the moment it's recorded, closing the silent window between an evaluation
  failure and `optimize()` eventually returning and raising. Covers all
  three failure paths feeding the slot, not just the two the issue named:
  `VqcOracle` and `QmlOracle` pass their `ExecutionConfig::id`, and QNG's
  `PyVarianceOracle` — which had no run id in scope at all — gained one.
- Also closes a related silent path found while implementing this: an
  `OptimizerError` rejecting an invalid DE/PSO/QNG configuration
  (`population_size` too small, empty/NaN `bounds`) with no oracle failure
  involved reached the caller with no log trace. Logged at `error!` in the
  same `finish_optimization` chokepoint that already centralizes the
  completion log.
- No high-volume payloads moved to `info!`: the existing circuit-dump
  `debug!` in `run_quantum_circuit` is untouched.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p polypus -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers`
- [x] `cargo test -p polypus-logger`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `pytest tests/python` — 139 passed, including `test_oracle_contract.py`
      (the existing C-5 regression coverage for the exact oracle-failure path
      this PR modifies)
- [x] Manual verification against a live interpreter: no log-emission
      assertion harness exists anywhere in this crate today
      (`log::set_boxed_logger` installs once per process, incompatible with
      the shared test binary), so each new record was confirmed firing by
      hand — start/completion for `run_quantum_circuit` and `train`/`qml.train`,
      and the `error!` path for `VqcOracle`, `QmlOracle`, `PyVarianceOracle`,
      and both `OptimizerError` variants (`PopulationTooSmall`,
      `InvalidBounds`)

No `docs/CONTRACTS.md` changes (no C-1..C-8 contract or public API shape
changed) and no `docs/ENGINEERING.md` changes (§9 already documents the
observability convention this follows).

Closes #88