### PR TITLE
fix(bindings): validate id charset for train and qml.train

### DIFF
--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -348,6 +348,54 @@ fn validate_cunqa_allocation(infrastructure: &str, nodes: u32, cores_per_qpu: u3
     Ok(())
 }
 
+/// Maximum length accepted for the caller-supplied `id` prefix
+/// (`train`/`qml.train`). Bounded so the effective id — prefix plus the 36-char
+/// UUID v4 suffix [`unique_id`] appends — stays comfortably inside the limits
+/// SLURM job names and filesystem path components impose downstream.
+const MAX_ID_LEN: usize = 64;
+
+/// Validate the caller-supplied `id` at the Python-facing boundary
+/// (defense-in-depth, `docs/ENGINEERING.md` §8; contract C-9).
+///
+/// `id` becomes the CUNQA SLURM `family_name`/`family_id` (contract C-1,
+/// `crate::infrastructure::cunqa`) and is documented as naming temp files and
+/// log streams ([`ExecutionConfig::id`]), so an unrestricted string could carry
+/// whitespace, path separators (`../`) or shell metacharacters into whatever
+/// `qraise`/SLURM does with it downstream — which this crate cannot see. The
+/// accepted charset is `[A-Za-z0-9._-]`, non-empty and at most
+/// [`MAX_ID_LEN`] characters.
+///
+/// Checked before [`unique_id`] appends the UUID suffix, so a rejected id never
+/// produces a partially-valid effective id. The charset is checked before the
+/// length so a non-ASCII id gets the specific "invalid character" message
+/// (and, past that check, every character is one byte, making the reported
+/// length exact). Shared by every entry point rather than duplicated per
+/// function, mirroring [`validate_shots_and_qpus`] and
+/// [`validate_cunqa_allocation`].
+fn validate_id(id: &str) -> PyResult<()> {
+    if id.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "id must not be empty",
+        ));
+    }
+    if let Some(c) = id
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "id contains invalid character {c:?}; only ASCII letters, digits, \
+			 '.', '_' and '-' are allowed (got {id:?})"
+        )));
+    }
+    if id.len() > MAX_ID_LEN {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "id must be at most {MAX_ID_LEN} characters, got {} ({id:?})",
+            id.len()
+        )));
+    }
+    Ok(())
+}
+
 /// Interpret the `qc` argument of an entry point as a parameterised circuit
 /// template. A `polypus.Circuit` becomes [`CircuitSource::Native`] (binding
 /// will run GIL-free); any other object is assumed to be a Qiskit
@@ -540,7 +588,11 @@ pub fn run_quantum_circuit<'py>(
 /// The `id` kwarg is a human-readable *prefix*, not the literal effective id:
 /// a UUID v4 is appended for uniqueness (mirroring [`run_quantum_circuit`]),
 /// so `TrainResult.id` differs from what was passed in and names the run's
-/// SLURM allocation / temp files / log stream (see #75).
+/// SLURM allocation / temp files / log stream (see #75). Because it travels
+/// into those downstream names, the prefix is restricted to `[A-Za-z0-9._-]`,
+/// non-empty and at most 64 characters (contract C-9); anything else — a space,
+/// a path separator, a shell metacharacter — raises `ValueError` naming the
+/// offending character, before the UUID suffix is generated.
 ///
 /// Interruption: pressing Ctrl+C (or otherwise sending `SIGINT`) stops the
 /// optimization promptly and raises `KeyboardInterrupt` in Python, instead of
@@ -581,6 +633,7 @@ pub fn train<'py>(
 ) -> PyResult<PyObject> {
     validate_shots_and_qpus(shots, n_qpus)?;
     validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
+    validate_id(&id)?;
     // Resolve the seed that drives the optimizer's RNG (contract C-7): explicit
     // kwarg > optimizer object's `seed` field > fresh OS entropy. Unlike
     // `run_quantum_circuit`, a seed is always meaningful here — it seeds the
@@ -753,7 +806,10 @@ pub fn train<'py>(
 /// As in [`train`], the `id` kwarg is a human-readable *prefix*: a UUID v4 is
 /// appended for uniqueness (mirroring [`run_quantum_circuit`]), so the returned
 /// `TrainResult.id` differs from what was passed in and names the run's SLURM
-/// allocation / temp files / log stream (see #75).
+/// allocation / temp files / log stream (see #75). It carries the same charset
+/// restriction as [`train`] — `[A-Za-z0-9._-]`, non-empty, at most 64
+/// characters (contract C-9) — and an invalid prefix raises `ValueError`
+/// naming the offending character.
 ///
 /// Interruption: same behaviour as [`train`] — Ctrl+C stops the optimization
 /// promptly and raises `KeyboardInterrupt` rather than waiting for the run to
@@ -797,6 +853,7 @@ pub fn qml_train<'py>(
 ) -> PyResult<PyObject> {
     validate_shots_and_qpus(shots, n_qpus)?;
     validate_cunqa_allocation(&infrastructure, nodes, cores_per_qpu)?;
+    validate_id(&id)?;
     // Same seed precedence as `train` (contract C-7): kwarg > optimizer field >
     // OS entropy. qml.train always runs on a Qiskit/Aer path (native rejected
     // below); this seed governs the optimizer's RNG and, since it's threaded

--- a/crates/polypus/src/infrastructure/execution_config.rs
+++ b/crates/polypus/src/infrastructure/execution_config.rs
@@ -14,6 +14,15 @@ use crate::infrastructure::transpiler::OptLevel;
 #[derive(Debug, Clone)]
 pub struct ExecutionConfig {
     /// Unique identifier for this run (logging, temp files, SLURM job names).
+    ///
+    /// Already validated when it comes from a Python entry point: `train` /
+    /// `qml.train` restrict the caller-supplied *prefix* to `[A-Za-z0-9._-]`,
+    /// non-empty and at most 64 characters (contract C-9, `validate_id` in
+    /// `crate::bindings`) before appending the UUID v4 suffix, precisely because
+    /// this string reaches CUNQA's SLURM `family_name`/`family_id` and the temp
+    /// file / log stream names above. Constructing an `ExecutionConfig` directly
+    /// from Rust bypasses that check — keep the same charset if the value can
+    /// reach an external tool.
     pub id: String,
     /// Number of shots per circuit.
     pub shots: u32,

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -28,6 +28,7 @@ Rules of the road:
 | C-6 | Version coherence | `hygiene.yml` version step | ✅ present | tag/Cargo diverged at 0.6.0 |
 | C-7 | Seeding & run manifest | `tests/python/test_seed_reproducibility.py` + bindings/native Rust tests | ✅ present | repeated runs byte-identical / `train` seed hardcoded `None` (#34) |
 | C-8 | qml.train row/dimension symmetry | `tests/python/test_qml_train_validation.py` | ✅ present | silent row truncation / late Qiskit error (#79) |
+| C-9 | `id` charset (train/qml.train) | `tests/python/test_id_validation.py` | ✅ present | unvalidated `id` reached SLURM `family_name` / temp files / log streams (#89) |
 
 ⏳ contracts are specified but not yet mechanically enforced; treat them as
 review-enforced until the test lands. Each known break has a public issue
@@ -55,6 +56,8 @@ Every kwarg the Rust side sends **must be consumed** by the Python side;
 silently ignoring one (as happened with `cores_per_qpu`) is a contract
 violation.
 
+`family_name` is `ExecutionConfig::id`, whose charset is constrained by C-9.
+
 ### `run_qcs(infrastructure: str, **kwargs)`
 
 | backend | kwargs (exact names) |
@@ -62,7 +65,8 @@ violation.
 | local | `id: str`, `backend: str`, `qcs: list`, `shots: int`, `sim_method: str`, `noise_model` (optional), `seed: int` (optional, C-7) |
 | cunqa | `family_id: str`, `backend: str`, `qcs: list`, `shots: int`, `sim_method: str`, `seed: int` (optional, C-7) |
 
-`qcs` elements are either Qiskit `QuantumCircuit` objects or OpenQASM 2.0
+`id` / `family_id` are `ExecutionConfig::id`, whose charset is constrained by
+C-9. `qcs` elements are either Qiskit `QuantumCircuit` objects or OpenQASM 2.0
 strings; the Python side parses strings (`QuantumCircuit.from_qasm_str`).
 Returns `list[dict[str, int]]` — **one dict per circuit, in submission
 order** (see C-3 for the dict format).
@@ -355,3 +359,44 @@ legitimate type error and propagates as-is; it is not masked into the messages
 above.
 
 **Enforcing test:** `tests/python/test_qml_train_validation.py`.
+
+---
+
+## C-9 · `id` charset validation (`train` / `qml.train` Python entry points)
+
+The `id` kwarg of `polypus.train` and `polypus.qml.train` is a caller-supplied
+*prefix*: the entry point appends a UUID v4 to it and the result becomes
+`ExecutionConfig::id`, which names the run's temp files and log streams and —
+on `infrastructure="cunqa"` — travels to SLURM as the C-1 kwargs `family_name`
+(`connect_to_infrastructure`) and `family_id` (`run_qcs`), and from there
+verbatim into `qraise`. The crate cannot see how `qraise`/SLURM interpolate that
+name, so the string is constrained at the boundary instead of trusted:
+
+- **Charset.** Every character must be an ASCII letter, an ASCII digit, `.`,
+  `_` or `-` (i.e. `^[A-Za-z0-9._-]+$`). Whitespace, path separators (`/`,
+  `../`) and shell metacharacters (`;`, `|`, `` ` ``, `$`, `&`, newline) are
+  rejected. The `ValueError` names the **offending character** so the caller
+  can see which one failed.
+- **Non-empty.** An empty `id` is rejected: it would degrade the effective id to
+  a bare `_<uuid>` and carries no debugging value.
+- **Length.** At most **64 characters**, measured on the caller-supplied prefix
+  **before** the UUID suffix, keeping the effective id inside the limits SLURM
+  job names and filesystem path components impose.
+
+This is defense-in-depth, not a fix for a known exploit — the July 2026
+technical audit (#89) found the value unvalidated anywhere in the crate, which
+`docs/ENGINEERING.md` §8 ("validate and sanitize all inputs; never trust
+external data") does not allow for a string that leaves the process.
+
+**When it is checked.** Upfront, alongside the other kwarg guards
+(`validate_shots_and_qpus`, `validate_cunqa_allocation`) as the entry point's
+first statements — before any seam call, any backend creation and, crucially,
+before `unique_id` appends the UUID, so a rejected `id` never yields a
+partially-valid effective id. Validation is unconditional: unlike
+`nodes`/`cores_per_qpu` it is not gated on `infrastructure == "cunqa"`, because
+the temp-file and log-stream naming applies to every infrastructure.
+
+`run_quantum_circuit` is not covered: it generates its own `id` internally and
+takes no such kwarg.
+
+**Enforcing test:** `tests/python/test_id_validation.py`.

--- a/tests/python/test_id_validation.py
+++ b/tests/python/test_id_validation.py
@@ -1,0 +1,119 @@
+"""
+`id` charset validation at the Python boundary (contract C-9).
+
+These cover issue #89: the `id` kwarg of ``train``/``qml.train`` travelled
+verbatim into ``ExecutionConfig::id`` and from there into CUNQA's SLURM
+``family_name``/``family_id`` (forwarded to ``qraise``) plus the run's temp file
+and log stream names, with no character validation anywhere in the crate. A
+whitespace character, a path separator (``../``) or a shell metacharacter could
+therefore reach whatever CUNQA/SLURM does with the name downstream.
+
+The prefix is now restricted to ``[A-Za-z0-9._-]``, non-empty and at most 64
+characters, rejected with a ``ValueError`` naming the offending character. The
+check runs upfront — before any seam call, any backend creation and before the
+UUID v4 suffix is appended — so the rejection tests never reach a real backend
+and need no optimizer/backend mocking. The acceptance tests do run, on
+``infrastructure="local"`` with a deliberately tiny optimizer budget.
+"""
+
+import pytest
+
+# Accepted: plain alphanumeric, the three allowed punctuation characters mixed
+# in, a single character, and exactly the 64-character maximum.
+VALID_IDS = [
+    "run1",
+    "my.run_2-final",
+    "a",
+    "i" * 64,
+]
+
+# Rejected, paired with the fragment of the ValueError message that proves the
+# rejection was specific rather than incidental.
+INVALID_IDS = [
+    ("", "id must not be empty"),
+    ("my run", r"invalid character ' '"),
+    ("../etc/passwd", r"invalid character '/'"),
+    ("runs/1", r"invalid character '/'"),
+    ("run;rm -rf /", "invalid character ';'"),
+    ("run|tee", r"invalid character '\|'"),
+    ("run`whoami`", "invalid character '`'"),
+    ("run$USER", r"invalid character '\$'"),
+    ("run&background", "invalid character '&'"),
+    ("run\nid", r"invalid character '\\n'"),
+    ("i" * 65, "id must be at most 64 characters, got 65"),
+]
+
+
+def _train(id_):
+    """`polypus.train` with every kwarg pinned except `id`."""
+    import polypus
+
+    qc = polypus.Circuit(1).ry(0, polypus.Param(0)).measure_all()
+    return polypus.train(
+        qc,
+        polypus.DE(generations=2, population_size=4),
+        shots=64,
+        n_qpus=1,
+        dimensions=1,
+        expectation_function=lambda b: float(all(c == "1" for c in b)),
+        infrastructure="local",
+        nodes=1,
+        cores_per_qpu=1,
+        id=id_,
+        seed=7,
+    )
+
+
+def _qml_train(id_):
+    """`polypus.qml.train` with every kwarg pinned except `id`."""
+    import polypus
+    from qiskit.circuit.library import real_amplitudes, zz_feature_map
+
+    feature_map = zz_feature_map(feature_dimension=2, reps=1)
+    ansatz = real_amplitudes(num_qubits=2, reps=1)
+    return polypus.qml.train(
+        feature_map,
+        ansatz,
+        [[0.1, 0.2]],
+        polypus.DE(generations=2, population_size=4),
+        shots=64,
+        n_qpus=1,
+        dimensions=len(ansatz.parameters),
+        expectation_function=lambda b: sum(int(c) for c in b) / len(b),
+        infrastructure="local",
+        nodes=1,
+        cores_per_qpu=1,
+        id=id_,
+        seed=7,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.vqc
+class TestTrainIdValidation:
+    @pytest.mark.parametrize("id_", VALID_IDS)
+    def test_valid_id_accepted(self, id_):
+        result = _train(id_)
+        # The effective id keeps the accepted prefix and appends the UUID v4.
+        assert result.id.startswith(f"{id_}_")
+        assert result.id != id_
+
+    @pytest.mark.parametrize("id_,message", INVALID_IDS)
+    def test_invalid_id_rejected(self, id_, message):
+        with pytest.raises(ValueError, match=message):
+            _train(id_)
+
+
+@pytest.mark.integration
+@pytest.mark.vqc
+class TestQmlTrainIdValidation:
+    @pytest.mark.parametrize("id_", VALID_IDS)
+    def test_valid_id_accepted(self, id_):
+        result = _qml_train(id_)
+        assert result.id.startswith(f"{id_}_")
+        assert result.id != id_
+
+    @pytest.mark.parametrize("id_,message", INVALID_IDS)
+    def test_invalid_id_rejected(self, id_, message):
+        with pytest.raises(ValueError, match=message):
+            _qml_train(id_)


### PR DESCRIPTION
## Summary
- `id` (kwarg of `train`/`qml.train`) travelled verbatim into `ExecutionConfig::id` and from there into CUNQA's SLURM `family_name`/`family_id` (forwarded to `qraise`) plus the run's temp file and log stream names, with no character validation anywhere in the crate.
- Adds `validate_id` (mirrors `validate_shots_and_qpus`/`validate_cunqa_allocation`): restricts the caller-supplied prefix to `[A-Za-z0-9._-]`, non-empty, at most 64 characters, raising `ValueError` naming the offending character. Runs as the entry point's first statements, before any seam call and before `unique_id` appends the UUID suffix.
- Charset is checked before length, so a non-ASCII id gets the specific "invalid character" message instead of a byte-count length error.
- Documented as contract **C-9** in `docs/CONTRACTS.md` (plus cross-references from the C-1 kwarg tables), and on the `id` kwarg of both entry points and on `ExecutionConfig::id`.
- Defense-in-depth per `docs/ENGINEERING.md` §8 — no known reachable exploit today; `qraise`'s own handling of `family_name` is outside this crate's visibility.

## Scope
- `crates/polypus/src/bindings/mod.rs`
- `crates/polypus/src/infrastructure/execution_config.rs`
- `docs/CONTRACTS.md`
- `tests/python/test_id_validation.py` (new)

## Contracts
Adds **C-9** (`id` charset validation, train/qml.train). Enforced by `tests/python/test_id_validation.py`. Existing contracts (C-1, C-7) get one-line pointers from their kwarg tables; not otherwise modified.

## Out of scope (flagged, not touched)
- `packages/polypus_python/polypus_python/connectivity.py`'s `"cunqa"` branch is currently commented out, so `qraise` isn't reachable end-to-end from this repo today — validation is enforced at the Rust/PyO3 boundary instead.
- `running_functions.py`'s `get_logger` interpolates `id` unsanitized into a file path, but that function isn't on the current `train`/`qml.train`/`CunqaBackend` call path — unrelated to this issue.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p polypus-circuit -p polypus-sim -p polypus-physics -p polypus-optimizers --all-features`
- [x] `maturin develop --release --features extension-module && pytest tests/python` (169 passed, 30 new)
- [x] `ruff check` / `ruff format --check` on the new test file

Closes #89