### PR TITLE
fix(evaluation): classify counts conversion failure as Conversion (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v3
+        with:
+          # Pin ruff so a new release's changed default rules / formatter output
+          # cannot turn CI red without a deliberate bump. Keep in sync with the
+          # pin in requirements-dev.txt. Both `ruff check` (run by the action)
+          # and the `ruff format --check` step below use this version.
+          version: "0.16.1"
       - run: ruff format --check
 
   # Security advisories (RustSec), license allowlist and registry sources,

--- a/README.md
+++ b/README.md
@@ -130,14 +130,18 @@ Check the [`examples/`](examples/) directory for complete, runnable scripts.
 
 Pass the circuit, the number of shots, the infrastructure and the number of QPUs:
 ```python
-result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=1)
+result = polypus.run_quantum_circuit(
+    qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=1
+)
 ```
 
 ### Distributing Shots Across Multiple QPUs
 
 Set `n_qpus > 1` to split the shots across available QPUs and reduce execution time:
 ```python
-result = polypus.run_quantum_circuit(qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10)
+result = polypus.run_quantum_circuit(
+    qc, shots=NUM_SHOTS, infrastructure=INFRASTRUCTURE, n_qpus=10
+)
 ```
 
 When `infrastructure="cunqa"`, two optional kwargs size the SLURM allocation for the distributed QPUs:
@@ -183,7 +187,9 @@ If CUNQA is not available, set `infrastructure="local"`.
 ```python
 result = polypus.train(
     qc,
-    polypus.DE(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, tolerance=TOL),
+    polypus.DE(
+        generations=MAX_GENERATIONS, population_size=POPULATION_SIZE, tolerance=TOL
+    ),
     shots=N_SHOTS,
     n_qpus=N_QPUS,
     dimensions=2 * layers,
@@ -191,18 +197,20 @@ result = polypus.train(
     infrastructure=infrastructure,
     nodes=NUM_NODES,
     cores_per_qpu=CORES_PER_QPU,
-    id=id
+    id=id,
 )
 ```
 
 `train()` (and `qml.train()`) return a `TrainResult` carrying the full optimization outcome, not just the tuned parameters:
 
 ```python
-print(result.best_params)     # list[float] — the optimized parameters
-print(result.best_fitness)    # float — cost/fitness at those parameters
+print(result.best_params)  # list[float] — the optimized parameters
+print(result.best_fitness)  # float — cost/fitness at those parameters
 print(result.iterations_run)  # int — iterations actually run (early-stopping aware)
-print(result.converged)       # bool — whether the convergence criterion was met
-print(result.seed)            # int — the effective RNG seed; pass it back as seed=... to reproduce the run
+print(result.converged)  # bool — whether the convergence criterion was met
+print(
+    result.seed
+)  # int — the effective RNG seed; pass it back as seed=... to reproduce the run
 ```
 
 Pin reproducibility with the `seed` keyword (`polypus.train(..., seed=42)`) or on the optimizer itself (`polypus.DE(..., seed=42)`); with no seed, one is drawn from OS entropy and reported back in `result.seed`.
@@ -212,8 +220,12 @@ Pin reproducibility with the `seed` keyword (`polypus.train(..., seed=42)`) or o
 ```python
 result = polypus.train(
     qc,
-    polypus.PSO(generations=MAX_GENERATIONS, population_size=POPULATION_SIZE,
-                bounds=(0.0, np.pi), tolerance=TOL),
+    polypus.PSO(
+        generations=MAX_GENERATIONS,
+        population_size=POPULATION_SIZE,
+        bounds=(0.0, np.pi),
+        tolerance=TOL,
+    ),
     shots=N_SHOTS,
     n_qpus=N_QPUS,
     dimensions=2 * layers,
@@ -221,7 +233,7 @@ result = polypus.train(
     infrastructure=infrastructure,
     nodes=NUM_NODES,
     cores_per_qpu=CORES_PER_QPU,
-    id=id
+    id=id,
 )
 ```
 
@@ -232,8 +244,14 @@ result = polypus.train(
 ```python
 result = polypus.train(
     qc,
-    polypus.QNG(variance_fn, max_iters=MAX_GENERATIONS, bounds=(0.0, np.pi),
-                learning_rate=0.1, finite_difference_step=0.1, tikhonov_reg=0.05),
+    polypus.QNG(
+        variance_fn,
+        max_iters=MAX_GENERATIONS,
+        bounds=(0.0, np.pi),
+        learning_rate=0.1,
+        finite_difference_step=0.1,
+        tikhonov_reg=0.05,
+    ),
     shots=N_SHOTS,
     n_qpus=N_QPUS,
     dimensions=2 * layers,
@@ -241,7 +259,7 @@ result = polypus.train(
     infrastructure=infrastructure,
     nodes=NUM_NODES,
     cores_per_qpu=CORES_PER_QPU,
-    id=id
+    id=id,
 )
 ```
 
@@ -261,17 +279,34 @@ bell = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
 result = polypus.run_quantum_circuit(bell, shots=1000, infrastructure="local")
 
 # Parameterized ansatz → train (binding happens in Rust, GIL-free)
-qaoa = (polypus.Circuit(4)
-        .h(0).h(1).h(2).h(3)
-        .rzz(0, 1, polypus.Param(0)).rzz(1, 2, polypus.Param(0))
-        .rzz(2, 3, polypus.Param(0)).rzz(3, 0, polypus.Param(0))
-        .rx(0, polypus.Param(1)).rx(1, polypus.Param(1))
-        .rx(2, polypus.Param(1)).rx(3, polypus.Param(1))
-        .measure_all())
-result = polypus.train(qaoa, polypus.DE(generations=100, population_size=50),
-                       shots=1024, n_qpus=1, dimensions=2,
-                       expectation_function=my_cost, infrastructure="local",
-                       nodes=1, cores_per_qpu=1, id="qaoa")
+qaoa = (
+    polypus.Circuit(4)
+    .h(0)
+    .h(1)
+    .h(2)
+    .h(3)
+    .rzz(0, 1, polypus.Param(0))
+    .rzz(1, 2, polypus.Param(0))
+    .rzz(2, 3, polypus.Param(0))
+    .rzz(3, 0, polypus.Param(0))
+    .rx(0, polypus.Param(1))
+    .rx(1, polypus.Param(1))
+    .rx(2, polypus.Param(1))
+    .rx(3, polypus.Param(1))
+    .measure_all()
+)
+result = polypus.train(
+    qaoa,
+    polypus.DE(generations=100, population_size=50),
+    shots=1024,
+    n_qpus=1,
+    dimensions=2,
+    expectation_function=my_cost,
+    infrastructure="local",
+    nodes=1,
+    cores_per_qpu=1,
+    id="qaoa",
+)
 ```
 
 ### From Rust
@@ -298,8 +333,8 @@ From Python, both outputs are also available:
 
 ```python
 qc = polypus.Circuit(2).h(0).cx(0, 1).measure_all()
-qir_text = qc.to_qir()            # str (.ll)
-qir_bitcode = qc.to_qir_bitcode() # bytes (.bc)
+qir_text = qc.to_qir()  # str (.ll)
+qir_bitcode = qc.to_qir_bitcode()  # bytes (.bc)
 ```
 
 ### QASM 2.0 Import
@@ -311,8 +346,8 @@ import polypus
 from qiskit import qasm2
 
 qc = polypus.Circuit.from_qasm2(qasm2.dumps(qiskit_circuit))  # interop
-qc = polypus.Circuit.from_qasm2(open("ansatz.qasm").read())   # persistence
-qc.rz(1, 0.5).measure_all()        # imported circuits are regular builders
+qc = polypus.Circuit.from_qasm2(open("ansatz.qasm").read())  # persistence
+qc.rz(1, 0.5).measure_all()  # imported circuits are regular builders
 ```
 
 Round-trip guarantee (verified by tests): for any circuit produced by this library, export → import → export is byte-identical. The same API exists in Rust as `ParameterizedCircuit::from_qasm2`.

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -39,6 +39,11 @@ pub enum EvaluationError {
     /// `JoinError`). Never a Python exception, so unlike `Python` it must not be
     /// re-raised verbatim.
     Runtime(String),
+    /// Converting data across the Rust↔Python boundary on the evaluation path
+    /// failed (e.g. `expectation_values`'s return value isn't `list[float]`).
+    /// Unlike `Python`, this never originated in a raised Python exception, so
+    /// it must not be re-raised verbatim.
+    Conversion(String),
 }
 
 impl fmt::Display for EvaluationError {
@@ -48,6 +53,9 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Binding(err) => write!(f, "circuit binding failed: {err}"),
             EvaluationError::Python(err) => write!(f, "Python evaluation error: {err}"),
             EvaluationError::Runtime(m) => write!(f, "QML evaluation runtime error: {m}"),
+            EvaluationError::Conversion(m) => {
+                write!(f, "data conversion across the Python boundary failed: {m}")
+            }
         }
     }
 }
@@ -72,6 +80,9 @@ impl From<EvaluationError> for PyErr {
             // A Rust-side infrastructure failure: surface as the typed
             // polypus.EvaluationError, not PyO3's generic RuntimeError.
             EvaluationError::Runtime(m) => PyEvaluationError::new_err(m),
+            // A Rust-side data-conversion failure: surface as the typed
+            // polypus.EvaluationError, not the TypeError PyO3's extract() emits.
+            EvaluationError::Conversion(m) => PyEvaluationError::new_err(m),
         }
     }
 }
@@ -79,7 +90,7 @@ impl From<EvaluationError> for PyErr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::exceptions::PyRuntimeError;
+    use pyo3::exceptions::{PyRuntimeError, PyTypeError};
     use pyo3::types::PyAnyMethods;
     use pyo3::Python;
 
@@ -108,6 +119,34 @@ mod tests {
             );
             assert!(
                 err.to_string().contains("worker panicked"),
+                "the descriptive message must be preserved"
+            );
+        });
+    }
+
+    /// A wrong-shaped `expectation_values` return value is modelled by
+    /// [`EvaluationError::Conversion`]: a Rust-side data-conversion failure, not
+    /// a raised Python exception. It must cross the FFI as the typed
+    /// `polypus.EvaluationError`, never as the generic `TypeError` that PyO3's
+    /// `extract()` would otherwise emit. (End-to-end coverage lives in the
+    /// Python suite; this pins the mapping in isolation.)
+    #[test]
+    fn conversion_variant_maps_to_typed_evaluation_error() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let err: PyErr = EvaluationError::Conversion("not list[float]".to_string()).into();
+            assert!(
+                err.value(py).is_instance_of::<PyEvaluationError>(),
+                "Conversion must surface as polypus.EvaluationError"
+            );
+            // ...and specifically not the plain TypeError that extract() emits,
+            // which is what the pre-fix code let through verbatim.
+            assert!(
+                !err.value(py).is_instance_of::<PyTypeError>(),
+                "Conversion must not surface as the generic TypeError"
+            );
+            assert!(
+                err.to_string().contains("not list[float]"),
                 "the descriptive message must be preserved"
             );
         });

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -34,6 +34,11 @@ pub enum EvaluationError {
     /// A Python callback or conversion on the evaluation path raised. Carried
     /// verbatim so the original exception type is preserved across the FFI.
     Python(PyErr),
+    /// A Rust-originated infrastructure failure on the QML evaluation path
+    /// (Tokio runtime construction, or a worker task panic surfaced as a
+    /// `JoinError`). Never a Python exception, so unlike `Python` it must not be
+    /// re-raised verbatim.
+    Runtime(String),
 }
 
 impl fmt::Display for EvaluationError {
@@ -42,6 +47,7 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Backend(err) => write!(f, "{err}"),
             EvaluationError::Binding(err) => write!(f, "circuit binding failed: {err}"),
             EvaluationError::Python(err) => write!(f, "Python evaluation error: {err}"),
+            EvaluationError::Runtime(m) => write!(f, "QML evaluation runtime error: {m}"),
         }
     }
 }
@@ -63,6 +69,47 @@ impl From<EvaluationError> for PyErr {
             }
             // Preserve the original Python exception type raised by the callback.
             EvaluationError::Python(py_err) => py_err,
+            // A Rust-side infrastructure failure: surface as the typed
+            // polypus.EvaluationError, not PyO3's generic RuntimeError.
+            EvaluationError::Runtime(m) => PyEvaluationError::new_err(m),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::exceptions::PyRuntimeError;
+    use pyo3::types::PyAnyMethods;
+    use pyo3::Python;
+
+    /// A QML infrastructure failure (Tokio runtime construction or a
+    /// `spawn_blocking` worker panic surfaced as a `JoinError`) is modelled by
+    /// [`EvaluationError::Runtime`]. Forcing either condition deterministically
+    /// from a test is neither viable nor portable — OS resource exhaustion for
+    /// the runtime, and `evaluate_qml_single` is deliberately written not to
+    /// panic — so instead we pin the *mapping*: `Runtime` must cross the FFI as
+    /// the typed `polypus.EvaluationError`, never PyO3's generic
+    /// `RuntimeError`. (Scope decision documented in the PR for issue #81.)
+    #[test]
+    fn runtime_variant_maps_to_typed_evaluation_error() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let err: PyErr = EvaluationError::Runtime("worker panicked".to_string()).into();
+            assert!(
+                err.value(py).is_instance_of::<PyEvaluationError>(),
+                "Runtime must surface as polypus.EvaluationError"
+            );
+            // ...and specifically not PyO3's generic RuntimeError, which is what
+            // the pre-fix code raised for this Rust-side infrastructure failure.
+            assert!(
+                !err.value(py).is_instance_of::<PyRuntimeError>(),
+                "Runtime must not surface as the generic RuntimeError"
+            );
+            assert!(
+                err.to_string().contains("worker panicked"),
+                "the descriptive message must be preserved"
+            );
+        });
     }
 }

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -110,7 +110,7 @@ impl From<EvaluationError> for PyErr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::exceptions::{PyRuntimeError, PyTypeError};
+    use pyo3::exceptions::{PyMemoryError, PyRuntimeError, PyTypeError};
     use pyo3::types::PyAnyMethods;
     use pyo3::Python;
 
@@ -167,6 +167,40 @@ mod tests {
             );
             assert!(
                 err.to_string().contains("not list[float]"),
+                "the descriptive message must be preserved"
+            );
+        });
+    }
+
+    /// The native backend results failing to convert into a Python `list[dict]`
+    /// is also modelled by [`EvaluationError::Conversion`]. This call site
+    /// differs from the `expectation_values` one above: `counts` is our own
+    /// Rust-native `Vec<HashMap<String, u64>>`, never something a Python
+    /// callback handed back, so there is no original raised exception to
+    /// preserve — realistically only allocation failure can trip it, which
+    /// isn't practical to provoke from a test. So we pin the *mapping* for this
+    /// site's message: it must surface as the typed `polypus.EvaluationError`,
+    /// never as the `MemoryError` the pre-fix `EvaluationError::Python` arm
+    /// would have re-raised verbatim. (Issue #98, follow-up to #81.)
+    #[test]
+    fn counts_conversion_failure_maps_to_typed_evaluation_error() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let msg = "failed to convert the backend results into a Python list[dict]: OOM";
+            let err: PyErr = EvaluationError::Conversion(msg.to_string()).into();
+            assert!(
+                err.value(py).is_instance_of::<PyEvaluationError>(),
+                "a counts conversion failure must surface as polypus.EvaluationError"
+            );
+            // ...and specifically not the MemoryError the pre-fix code would
+            // have carried across verbatim via `EvaluationError::Python`.
+            assert!(
+                !err.value(py).is_instance_of::<PyMemoryError>(),
+                "a counts conversion failure must not surface as a raised MemoryError"
+            );
+            assert!(
+                err.to_string()
+                    .contains("backend results into a Python list[dict]"),
                 "the descriptive message must be preserved"
             );
         });

--- a/crates/polypus/src/evaluation/error.rs
+++ b/crates/polypus/src/evaluation/error.rs
@@ -44,6 +44,12 @@ pub enum EvaluationError {
     /// Unlike `Python`, this never originated in a raised Python exception, so
     /// it must not be re-raised verbatim.
     Conversion(String),
+    /// The Python-backed oracle returned a different number of expectation
+    /// values than circuits were submitted in this call (contract C-5).
+    WrongLength { expected: usize, got: usize },
+    /// The Python-backed oracle returned a non-finite expectation value
+    /// (contract C-5 requires every output to be a finite f64).
+    NonFinite { index: usize, value: f64 },
 }
 
 impl fmt::Display for EvaluationError {
@@ -56,6 +62,14 @@ impl fmt::Display for EvaluationError {
             EvaluationError::Conversion(m) => {
                 write!(f, "data conversion across the Python boundary failed: {m}")
             }
+            EvaluationError::WrongLength { expected, got } => write!(
+                f,
+                "oracle returned the wrong number of expectation values: expected {expected} (one per submitted circuit) but got {got} (contract C-5)"
+            ),
+            EvaluationError::NonFinite { index, value } => write!(
+                f,
+                "oracle returned a non-finite expectation value {value} at index {index}; contract C-5 requires every output to be a finite f64"
+            ),
         }
     }
 }
@@ -83,10 +97,13 @@ impl From<EvaluationError> for PyErr {
             // A Rust-side data-conversion failure: surface as the typed
             // polypus.EvaluationError, not the TypeError PyO3's extract() emits.
             EvaluationError::Conversion(m) => PyEvaluationError::new_err(m),
+            wrong_length @ EvaluationError::WrongLength { .. } => {
+                PyEvaluationError::new_err(wrong_length.to_string())
+            }
+            non_finite @ EvaluationError::NonFinite { .. } => {
+                PyEvaluationError::new_err(non_finite.to_string())
+            }
         }
-        .to_string();
-        assert!(msg.contains('3'), "offending index missing from: {msg}");
-        assert!(msg.contains("NaN"), "offending value missing from: {msg}");
     }
 }
 
@@ -153,5 +170,27 @@ mod tests {
                 "the descriptive message must be preserved"
             );
         });
+    }
+
+    #[test]
+    fn wrong_length_display_names_both_lengths() {
+        let msg = EvaluationError::WrongLength {
+            expected: 4,
+            got: 2,
+        }
+        .to_string();
+        assert!(msg.contains('4'), "expected length missing from: {msg}");
+        assert!(msg.contains('2'), "got length missing from: {msg}");
+    }
+
+    #[test]
+    fn non_finite_display_names_index_and_value() {
+        let msg = EvaluationError::NonFinite {
+            index: 3,
+            value: f64::NAN,
+        }
+        .to_string();
+        assert!(msg.contains('3'), "offending index missing from: {msg}");
+        assert!(msg.contains("NaN"), "offending value missing from: {msg}");
     }
 }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -151,9 +151,12 @@ pub use polypus_optimizers::EvaluationOracle;
 /// `polypus_python.expectation_values`, eliminating the duplication that
 /// previously existed across DE, PSO, QNG, and the orchestration layer.
 ///
-/// Returns an [`EvaluationError`] on any failure: a backend error is wrapped,
-/// and a Python error (import, `expectation_values`, extraction) is carried
-/// verbatim — never a panic.
+/// Returns an [`EvaluationError`] on any failure: a backend error is wrapped;
+/// a raised Python exception (import, a pending `KeyboardInterrupt`, or one
+/// thrown by `expectation_values` / the user callback) is carried verbatim; and
+/// a wrong-shaped `expectation_values` return value — a Rust-side conversion
+/// failure, not a raised exception — becomes [`EvaluationError::Conversion`].
+/// Never a panic.
 pub(crate) fn run_and_evaluate(
     backend: &dyn QuantumBackend,
     qcs: &[BoundCircuit],
@@ -180,7 +183,13 @@ pub(crate) fn run_and_evaluate(
             .map_err(EvaluationError::Python)?
             .call_method("expectation_values", (py_counts, expectation_fn), None)
             .map_err(EvaluationError::Python)?
+            // `expectation_values` returned successfully; a wrong-shaped value
+            // is a Rust-side conversion failure, not a raised Python exception.
             .extract::<Vec<f64>>()
-            .map_err(EvaluationError::Python)
+            .map_err(|e| {
+                EvaluationError::Conversion(format!(
+                    "expected expectation_values() to return list[float]: {e}"
+                ))
+            })
     })
 }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -192,6 +192,24 @@ pub(crate) fn run_and_evaluate(
                 EvaluationError::Conversion(format!(
                     "expected expectation_values() to return list[float]: {e}"
                 ))
-            })
+            })?;
+
+        // Contract C-5: the Python-backed oracle must return exactly one finite
+        // f64 per submitted circuit. This is the single choke point that calls
+        // `polypus_python.expectation_values`, so validating here protects every
+        // oracle: a short list would otherwise index out of bounds inside the
+        // pure-Rust optimizer (an uncatchable `PanicException` across the FFI),
+        // and a NaN/inf would silently poison the optimizer and yield a bogus
+        // result with no error at all.
+        if values.len() != qcs.len() {
+            return Err(EvaluationError::WrongLength {
+                expected: qcs.len(),
+                got: values.len(),
+            });
+        }
+        if let Some((index, &value)) = values.iter().enumerate().find(|(_, v)| !v.is_finite()) {
+            return Err(EvaluationError::NonFinite { index, value });
+        }
+        Ok(values)
     })
 }

--- a/crates/polypus/src/evaluation/mod.rs
+++ b/crates/polypus/src/evaluation/mod.rs
@@ -156,9 +156,10 @@ pub use polypus_optimizers::EvaluationOracle;
 /// Returns an [`EvaluationError`] on any failure: a backend error is wrapped;
 /// a raised Python exception (import, a pending `KeyboardInterrupt`, or one
 /// thrown by `expectation_values` / the user callback) is carried verbatim; and
-/// a wrong-shaped `expectation_values` return value — a Rust-side conversion
-/// failure, not a raised exception — becomes [`EvaluationError::Conversion`].
-/// Never a panic.
+/// a data-conversion failure across the Rust↔Python boundary — the native
+/// backend results failing to convert into a Python `list[dict]`, or a
+/// wrong-shaped `expectation_values` return value, neither of which is a raised
+/// exception — becomes [`EvaluationError::Conversion`]. Never a panic.
 pub(crate) fn run_and_evaluate(
     backend: &dyn QuantumBackend,
     qcs: &[BoundCircuit],
@@ -179,8 +180,14 @@ pub(crate) fn run_and_evaluate(
         py.check_signals().map_err(EvaluationError::Python)?;
         // Convert the native counts back into a Python `list[dict]` for the
         // Python `expectation_values` function. Once expectation computation is
-        // also native this round-trip disappears entirely.
-        let py_counts = counts.into_pyobject(py).map_err(EvaluationError::Python)?;
+        // also native this round-trip disappears entirely. `counts` is our own
+        // Rust-native value, so a failure here is a Rust-side conversion problem
+        // (realistically allocation failure), not a raised Python exception.
+        let py_counts = counts.into_pyobject(py).map_err(|e| {
+            EvaluationError::Conversion(format!(
+                "failed to convert the native backend results into a Python list[dict]: {e}"
+            ))
+        })?;
         let values = PyModule::import(py, "polypus_python")
             .map_err(EvaluationError::Python)?
             .call_method("expectation_values", (py_counts, expectation_fn), None)

--- a/crates/polypus/src/evaluation/qml_oracle.rs
+++ b/crates/polypus/src/evaluation/qml_oracle.rs
@@ -50,9 +50,9 @@ impl QmlOracle {
     /// yield finite sentinels while the entry point re-raises it.
     fn try_evaluate(&self, candidates: &[Vec<f64>]) -> Result<Vec<f64>, EvaluationError> {
         let rt = crate::utils::tokio_runtime().map_err(|e| {
-            EvaluationError::Python(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            EvaluationError::Runtime(format!(
                 "failed to start the Tokio runtime for QML evaluation: {e}"
-            )))
+            ))
         })?;
 
         let handles: Vec<_> = candidates
@@ -89,9 +89,7 @@ impl QmlOracle {
                         // A `JoinError` means the worker task itself panicked;
                         // turn it into a typed error rather than re-panicking.
                         let single = h.await.map_err(|e| {
-                            EvaluationError::Python(pyo3::exceptions::PyRuntimeError::new_err(
-                                format!("QML evaluation task failed: {e}"),
-                            ))
+                            EvaluationError::Runtime(format!("QML evaluation task failed: {e}"))
                         })?;
                         out.push(single?);
                     }

--- a/crates/polypus/src/infrastructure/cunqa.rs
+++ b/crates/polypus/src/infrastructure/cunqa.rs
@@ -84,9 +84,13 @@ impl QuantumBackend for CunqaBackend {
                     log::error!("CUNQA circuit execution failed: {e}");
                     BackendError::Seam(e)
                 })?;
-            result
-                .extract::<Vec<HashMap<String, u64>>>()
-                .map_err(BackendError::Seam)
+            // `run_qcs` returned successfully; a wrong-shaped value is a
+            // Rust-side conversion failure, not a seam exception (contract C-1).
+            result.extract::<Vec<HashMap<String, u64>>>().map_err(|e| {
+                BackendError::Conversion(format!(
+                    "expected run_qcs() to return list[dict[str, int]] (contract C-1): {e}"
+                ))
+            })
         })
     }
 

--- a/crates/polypus/src/infrastructure/local.rs
+++ b/crates/polypus/src/infrastructure/local.rs
@@ -60,7 +60,13 @@ impl QuantumBackend for LocalBackend {
                     log::error!("local infrastructure connection failed: {e}");
                     BackendError::Seam(e)
                 })?;
-            let connection_str = connection.extract::<String>().map_err(BackendError::Seam)?;
+            // The call above succeeded; a wrong-shaped return value is our
+            // Rust-side conversion failure, not a seam exception (contract C-1).
+            let connection_str = connection.extract::<String>().map_err(|e| {
+                BackendError::Conversion(format!(
+                    "expected connect_to_infrastructure(\"local\") to return str: {e}"
+                ))
+            })?;
 
             let kwargs = PyDict::new(py);
             let conv = |e: PyErr| BackendError::Conversion(e.to_string());
@@ -89,9 +95,13 @@ impl QuantumBackend for LocalBackend {
                     log::error!("local circuit execution failed: {e}");
                     BackendError::Seam(e)
                 })?;
-            result
-                .extract::<Vec<HashMap<String, u64>>>()
-                .map_err(BackendError::Seam)
+            // As above: `run_qcs` returned successfully, so a wrong-shaped
+            // value is a Rust-side conversion failure, not a seam exception.
+            result.extract::<Vec<HashMap<String, u64>>>().map_err(|e| {
+                BackendError::Conversion(format!(
+                    "expected run_qcs() to return list[dict[str, int]] (contract C-1): {e}"
+                ))
+            })
         })
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,12 @@ manifest-path = "crates/polypus/Cargo.toml"
 target-version = "py39"
 
 [tool.ruff.lint]
-# Default rules (pycodestyle errors + pyflakes) plus import sorting.
-extend-select = ["I"]
+# Pin the rule set explicitly (pycodestyle errors E4/E7/E9 + pyflakes F, plus
+# import sorting I). Using an explicit `select` instead of `extend-select` stops
+# a newer ruff's expanded default `select` from silently enforcing rules the
+# project has not adopted (which turned CI red on an unpinned ruff-action). The
+# ruff version is pinned in CI (.github/workflows/ci.yml) and requirements-dev.txt.
+select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.ruff.lint.per-file-ignores]
 # Package roots re-export their public API.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,5 +14,5 @@ pytest>=8.0
 
 # Lint/format (config in [tool.ruff] in pyproject.toml; CI enforces both
 # `ruff check` and `ruff format --check`)
-ruff>=0.8
+ruff==0.16.1  # pinned; keep in sync with .github/workflows/ci.yml (see pyproject [tool.ruff.lint])
 

--- a/tests/python/test_evaluation_extraction.py
+++ b/tests/python/test_evaluation_extraction.py
@@ -1,0 +1,85 @@
+"""
+Result-extraction failures on the evaluation path (issue #81 follow-up).
+
+``run_and_evaluate`` is the single caller of ``polypus_python.expectation_values``
+(used by ``polypus.train`` via ``VqcOracle`` and ``polypus.qml.train`` via
+``QmlOracle``). When ``expectation_values`` *succeeds* but returns a value whose
+shape isn't ``list[float]``, converting it Rust-side fails — that is a
+``EvaluationError::Conversion``, surfaced as ``polypus.EvaluationError``, not the
+bare ``TypeError`` PyO3's ``extract()`` emits and not a verbatim Python
+exception (which is reserved for a genuinely *raised* callback/seam error).
+
+This mirrors the ``test_seam_extraction.py`` tests for the ``run_qcs`` /
+``connect_to_infrastructure`` seam. It exercises the shortest reachable path,
+``polypus.train`` with ``infrastructure="local"`` (no SLURM), and monkeypatches
+``expectation_values`` so the wrong shape is forced deterministically.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.vqc]
+
+
+def _train(parametrized_circuit, simple_expectation_fn, run_id):
+    import polypus
+
+    return polypus.train(
+        parametrized_circuit,
+        polypus.DE(generations=2, population_size=4, tolerance=0.5),
+        shots=64,
+        n_qpus=1,
+        dimensions=1,
+        expectation_function=simple_expectation_fn,
+        infrastructure="local",
+        nodes=1,
+        cores_per_qpu=1,
+        id=run_id,
+    )
+
+
+def test_expectation_values_returning_scalar_is_evaluation_error(
+    monkeypatch, parametrized_circuit, simple_expectation_fn
+):
+    # expectation_values succeeds but returns a bare float instead of
+    # list[float]. The Rust-side extraction failure must be EvaluationError,
+    # not the plain TypeError extract() would surface pre-fix.
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "expectation_values", lambda *a, **k: 0.5)
+    with pytest.raises(polypus.EvaluationError) as excinfo:
+        _train(parametrized_circuit, simple_expectation_fn, "eval_extract_scalar")
+    assert not isinstance(excinfo.value, TypeError), (
+        "a wrong-shaped return value must not be reported as the plain "
+        "TypeError that PyO3's extract() emits"
+    )
+
+
+def test_expectation_values_returning_none_is_evaluation_error(
+    monkeypatch, parametrized_circuit, simple_expectation_fn
+):
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "expectation_values", lambda *a, **k: None)
+    with pytest.raises(polypus.EvaluationError):
+        _train(parametrized_circuit, simple_expectation_fn, "eval_extract_none")
+
+
+def test_expectation_callback_exception_propagates_verbatim(
+    monkeypatch, parametrized_circuit
+):
+    # Negative case: when the user's expectation_function *raises* (rather than
+    # returning a wrong shape), that genuine Python exception must propagate
+    # verbatim as itself, not be reclassified as polypus.EvaluationError.
+    import polypus
+
+    def exploding_expectation(_bitstring):
+        raise ValueError("user callback blew up")
+
+    with pytest.raises(ValueError, match="user callback blew up") as excinfo:
+        _train(parametrized_circuit, exploding_expectation, "eval_callback_raises")
+    assert not isinstance(excinfo.value, polypus.EvaluationError), (
+        "a genuine raised callback exception must not be reclassified as "
+        "polypus.EvaluationError"
+    )

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -308,9 +308,9 @@ def make(n, reps):
 # per-shot checks), the circuit is sized to complete in ~1.3s single-threaded:
 # still running when SIGINT arrives `_DELAY_BEFORE_SIGINT_S` after READY, done
 # well inside `_INTERRUPT_DEADLINE_S`. `__N_QPUS__` selects the variant:
-# 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun (which duplicates the
-# circuit across QPUs, so its per-QPU `reps` is scaled down to keep the total
-# run time comparable).
+# 1 -> AlgorithmSingleRun, >1 -> DistributeByShotsRun. The latter's
+# single-evolution fast path evolves the shared circuit once (not once per QPU),
+# so both variants use the same `reps` to keep the total run time comparable.
 _RUN_CHILD_TEMPLATE = (
     r"""
 import sys, time
@@ -368,9 +368,12 @@ def test_run_quantum_circuit_single_responds_to_sigint_promptly():
 
 
 def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
-    # n_qpus > 1 -> DistributeByShotsRun. 4 QPUs x n=18/reps=25 is ~1.3s total.
+    # n_qpus > 1 -> DistributeByShotsRun. Its single-evolution fast path evolves
+    # the shared circuit once (not once per QPU), so this uses the same
+    # n=18/reps=100 as the single-run variant (~1.3s single-threaded) rather than
+    # a per-QPU-scaled reps — otherwise the run finishes inside the SIGINT window.
     _assert_responds_to_sigint_promptly(
-        _run_child(n_qpus=4, n=18, reps=25),
+        _run_child(n_qpus=4, n=18, reps=100),
         failure_hint=(
             "run_quantum_circuit (DistributeByShotsRun) — the GIL is likely "
             "held for the whole run or check_signals is missing before the "
@@ -383,11 +386,15 @@ def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
 # GIL-release proof: while a native `run_quantum_circuit` call is in flight, a
 # background Python thread spins a tight counter loop. If the GIL were held for
 # the whole run the thread is starved and advances only by the incidental amount
-# the call's Python entry/exit stages allow (measured ~1.4e5, stable across core
-# counts); with the GIL released it advances by tens of millions (measured
-# ~3.6e7 on 32 cores, ~4e7 on 2) over the run. The threshold sits ~35x above the
-# held-GIL value and ~7x below the released-GIL value, so it separates them
-# cleanly with wide margin on either side, independent of the runner's cores.
+# the call's Python entry/exit stages allow (measured ~1.4e5); with the GIL
+# released it keeps advancing at close to its free-running rate. Rather than a
+# brittle absolute count, the child calibrates that free-running rate (via a
+# time.sleep window, which releases the GIL) and reports the *ratio* of counts
+# achieved during the native run to counts expected at the free rate over the
+# same wall-clock. GIL released -> ratio near 1.0 (>=0.5 even under single-core
+# contention with the native thread); GIL held -> ratio ~0. The threshold sits
+# far below the released value and far above the held value, independent of the
+# runner's CPU speed or the native run's duration.
 #
 # Two design points make this robust (see module docstring):
 #   * A subprocess, not an in-process thread, so the measurement starts from a
@@ -399,7 +406,7 @@ def test_run_quantum_circuit_distributed_responds_to_sigint_promptly():
 #     the observation depend on spare cores the CI runner may not have. Depth
 #     comes from `n_qpus` (sequential per-QPU circuits), not qubit count, so the
 #     circuit stays cheap to build.
-_MIN_COUNTER_PROGRESS = 5_000_000
+_MIN_GIL_RELEASE_RATIO = 0.2
 
 _GIL_RELEASE_CHILD = (
     r"""
@@ -413,7 +420,7 @@ polypus.run_quantum_circuit(
     make(2, 1), shots=64, infrastructure="local", n_qpus=1, backend="polypus"
 )
 
-qc = make(11, 1500)  # sub-parallel-threshold; ~1.3-2.6s across 32..2 cores
+qc = make(11, 1500)  # sub-parallel-threshold native run (~1.3-2.6s across 32..2 cores)
 counter = 0
 stop = threading.Event()
 
@@ -425,17 +432,37 @@ def spin():
 worker = threading.Thread(target=spin)
 worker.start()
 try:
-    before = counter
+    import time
+
+    # Calibrate the worker's free-running spin rate: time.sleep releases the
+    # GIL, so the worker runs unobstructed during this window. Comparing the
+    # native run against this per-machine rate makes the test robust to CPU
+    # speed and native-run duration -- an absolute count threshold was not,
+    # and caused spurious CI failures on fast/loaded runners.
+    c0 = counter
+    time.sleep(0.2)
+    free_rate = (counter - c0) / 0.2  # counts/sec with the GIL free
+
     # n_qpus=20 -> 20 sequential single-thread circuits (DistributeByShotsRun),
     # enough wall-clock for the counter to accumulate a decisive lead.
+    before = counter
+    t0 = time.perf_counter()
     polypus.run_quantum_circuit(
         qc, shots=4096, infrastructure="local", n_qpus=20, backend="polypus"
     )
+    dt = time.perf_counter() - t0
     advanced = counter - before
 finally:
     stop.set()
     worker.join()
-print(f"ADVANCED {advanced}", flush=True)
+
+# Fraction of its free-running rate the worker sustained *during* the native
+# run. GIL released -> worker keeps running (ratio near 1.0, or ~0.5 under
+# single-core contention with the native thread); GIL held -> worker starved
+# (ratio ~0).
+expected = free_rate * dt
+ratio = (advanced / expected) if expected > 0 else 0.0
+print(f"ADVANCED {advanced} RATE {free_rate:.0f} DT {dt:.4f} RATIO {ratio:.4f}", flush=True)
 """
 )
 
@@ -451,8 +478,11 @@ def test_run_quantum_circuit_releases_gil_for_other_threads():
         f"GIL-release child did not complete cleanly.\n"
         f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     )
-    advanced = int(proc.stdout.split("ADVANCED", 1)[1].split()[0])
-    assert advanced > _MIN_COUNTER_PROGRESS, (
-        f"background thread advanced only {advanced} counts during the native "
-        f"run — the GIL was likely not released around run_quantum_circuit"
+    fields = proc.stdout.split("ADVANCED", 1)[1].split()
+    advanced = int(fields[0])
+    ratio = float(fields[fields.index("RATIO") + 1])
+    assert ratio > _MIN_GIL_RELEASE_RATIO, (
+        f"background thread sustained only {ratio:.3f} of its free-running rate "
+        f"during the native run (advanced {advanced} counts) — the GIL was "
+        f"likely not released around run_quantum_circuit\nstdout:\n{proc.stdout}"
     )

--- a/tests/python/test_qml_error_propagation.py
+++ b/tests/python/test_qml_error_propagation.py
@@ -1,0 +1,66 @@
+"""
+QML evaluation-path error classification (issue #81, Change 2).
+
+``EvaluationError::Runtime`` (Tokio runtime construction, or a ``spawn_blocking``
+worker panic surfaced as a ``JoinError``) is a Rust-side infrastructure failure
+and now surfaces as ``polypus.EvaluationError`` rather than a bare
+``RuntimeError`` — pinned by the Rust unit test in
+``crates/polypus/src/evaluation/error.rs`` (forcing those OS-level conditions
+deterministically from Python is neither viable nor portable; see the PR).
+
+This test guards the *other* side of that change: a genuine Python exception
+raised by the user's ``expectation_function`` callback must still propagate
+**verbatim** (as itself), never be reclassified as ``polypus.EvaluationError``.
+It runs on the ``local`` path with a mocked backend, so no SLURM/hardware.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.vqc]
+
+
+def _patch_deterministic_backend(monkeypatch):
+    import polypus_python
+
+    def fake_run_qcs(infrastructure, **kwargs):
+        return [{"1": kwargs["shots"]} for _ in kwargs["qcs"]]
+
+    monkeypatch.setattr(polypus_python, "run_qcs", fake_run_qcs)
+
+
+def test_qml_callback_exception_propagates_verbatim(monkeypatch):
+    import numpy as np
+    import polypus
+    from qiskit.circuit.library import real_amplitudes, zz_feature_map
+
+    _patch_deterministic_backend(monkeypatch)
+
+    def exploding_expectation(_bitstring):
+        raise ValueError("user callback blew up")
+
+    feature_map = zz_feature_map(feature_dimension=2, reps=1)
+    ansatz = real_amplitudes(num_qubits=2, reps=1)
+    x_train = np.zeros((2, 2))
+
+    # The user's callback raises ValueError; contract C-1 / ENGINEERING.md §9
+    # require it to reach the caller as that same ValueError, not wrapped in
+    # polypus.EvaluationError.
+    with pytest.raises(ValueError, match="user callback blew up") as excinfo:
+        polypus.qml.train(
+            feature_map,
+            ansatz,
+            x_train,
+            polypus.DE(generations=2, population_size=4, tolerance=0.5),
+            shots=64,
+            n_qpus=1,
+            dimensions=len(ansatz.parameters),
+            expectation_function=exploding_expectation,
+            infrastructure="local",
+            nodes=1,
+            cores_per_qpu=1,
+            id="qml_verbatim_error",
+        )
+    assert not isinstance(excinfo.value, polypus.EvaluationError), (
+        "a genuine Python callback exception must not be reclassified as "
+        "polypus.EvaluationError"
+    )

--- a/tests/python/test_seam_extraction.py
+++ b/tests/python/test_seam_extraction.py
@@ -1,0 +1,68 @@
+"""
+Result-extraction failures at the ``polypus_python`` seam (issue #81).
+
+Contract C-1 re-raises a failure *thrown by the Python seam* verbatim (e.g.
+``ValueError`` for an unknown infrastructure, ``TypeError`` for a bad kwarg).
+But a seam call that *succeeds* and returns a value of the wrong shape is a
+Rust-side data-conversion failure, not a seam exception, so it must surface as
+``polypus.BackendError`` (mapped from ``BackendError::Conversion``), not as a
+bare ``TypeError`` from PyO3's extraction.
+
+These tests monkeypatch the seam (no SLURM / hardware needed), mirroring the
+style of ``test_seam_contract.py``. They exercise the ``local`` path: a real
+``connect_to_infrastructure("local")`` with a mocked ``run_qcs`` for the
+run-result case, and a mocked ``connect_to_infrastructure`` for the handle case.
+"""
+
+import pytest
+
+
+def _native_qc():
+    import polypus
+
+    return polypus.Circuit(1).h(0).measure_all()
+
+
+def _run_local():
+    import polypus
+
+    return polypus.run_quantum_circuit(
+        _native_qc(), shots=10, infrastructure="local", backend="aer"
+    )
+
+
+def test_run_qcs_returning_non_list_of_dicts_is_backend_error(monkeypatch):
+    # run_qcs succeeds but returns list[str] instead of list[dict[str, int]].
+    # The extraction failure is Rust-side, so it must be BackendError, not the
+    # raw TypeError that C-1 reserves for a genuine bad-kwarg seam failure.
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "run_qcs", lambda *a, **k: ["not", "dicts"])
+    with pytest.raises(polypus.BackendError) as excinfo:
+        _run_local()
+    assert not isinstance(excinfo.value, TypeError), (
+        "a wrong-shaped return value must not be reported as the plain "
+        "TypeError that C-1 uses for a bad kwarg"
+    )
+
+
+def test_run_qcs_returning_none_is_backend_error(monkeypatch):
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "run_qcs", lambda *a, **k: None)
+    with pytest.raises(polypus.BackendError):
+        _run_local()
+
+
+def test_connect_returning_non_str_is_backend_error(monkeypatch):
+    # connect_to_infrastructure succeeds but returns an int instead of a str
+    # connection handle: again a Rust-side extraction failure => BackendError.
+    import polypus
+    import polypus_python
+
+    monkeypatch.setattr(polypus_python, "connect_to_infrastructure", lambda *a, **k: 42)
+    with pytest.raises(polypus.BackendError) as excinfo:
+        _run_local()
+    assert not isinstance(excinfo.value, TypeError)


### PR DESCRIPTION
Closes #98.

⚠️ **Depends on #81 (not yet merged).** This branch is rebased on top of
`81-result-extraction-failures-are-misclassified-as-seam-errors-qml-rust-side-failures-surface-as-bare-runtimeerror`,
so the diff/commit list below includes #81's changes as well as the CI
stabilization commit already on `main` via #106. **Do not merge before #81.**
Once #81 lands on `main`, this branch should be rebased onto `main` so the
diff collapses to just the one commit below.

## Summary

`run_and_evaluate` (`crates/polypus/src/evaluation/mod.rs`) built the
Python-side counts payload with:

```rust
let py_counts = counts.into_pyobject(py).map_err(EvaluationError::Python)?;
EvaluationError::Python is documented as carrying a raised exception
verbatim so its original type survives the FFI. But counts is our own
Rust-native Vec<HashMap<String, u64>> — the backend's own output, never
something a Python callback handed back — so a failure here would be a
Rust-side conversion problem (realistically only allocation failure), with
no original raised exception to preserve. This misclassified it the same
way #81's three sites were misclassified before that fix.

This PR maps it to EvaluationError::Conversion instead (the variant #81
introduced), mirroring the sibling .extract::<Vec<f64>>() fix in the same
function, and updates the inline comment and the function's doc block to
match.

Changes
crates/polypus/src/evaluation/mod.rs: the into_pyobject call now maps
to EvaluationError::Conversion with a message naming what failed to
convert, plus updated comments/docs.
crates/polypus/src/evaluation/error.rs: new unit test
counts_conversion_failure_maps_to_typed_evaluation_error, following the
existing Runtime/Conversion test pattern, pinning that this call
site's failure surfaces as polypus.EvaluationError and not a
verbatim-reraised MemoryError.
Explicitly out of scope
py.check_signals() (KeyboardInterrupt) — unchanged, stays verbatim
EvaluationError::Python.
The expectation_values import/call itself — unchanged, stays verbatim
EvaluationError::Python (a real raised exception).
The already-fixed .extract::<Vec<f64>>() site from #81 — untouched.
No new Python-visible exception class, per the issue's acceptance
criteria.
Testing
All green locally:

cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p polypus
cargo test -p polypus --features qmio
A genuine OOM trigger isn't practical to test from Python, so coverage is a
Rust unit test pinning the EvaluationError → PyErr mapping for this call
site, per the issue's acceptance criteria.