### PR TITLE
feat(sim): interrupt statevector mid-simulation (#110)

### DIFF
--- a/benchmarks/bench_statevector.py
+++ b/benchmarks/bench_statevector.py
@@ -1,0 +1,172 @@
+"""
+Benchmark: the `polypus.statevector` hot path (and the native run path next to
+it), sized from "tiny" to "the gate loop is everything".
+
+Why it exists: `statevector` interrupts the simulation mid-run (issue #110) by
+having `polypus-sim`'s gate loop poll a cancellation hook, which reacquires the
+GIL to check for a pending signal. The hook is throttled inside `polypus-sim`
+(one clock read per ~64k amplitude updates, one hook call per ~25ms of wall clock
+*and* per 20x its own measured duration), and the claim that goes with it is that
+this costs nothing measurable -- so it needs numbers, per docs/ENGINEERING.md §9.
+
+Two paths are measured, because only one of them installs a hook:
+
+1. `polypus.statevector` — the hooked path. Per gate it pays a counter
+   decrement, occasionally an `Instant::now()`, and at most once per ~25ms a
+   `Python::with_gil` + `PyErr_CheckSignals`.
+2. `polypus.run_quantum_circuit` on the native backend — the *unhooked* path
+   (`Simulator::run`, hook `None`), where the whole cost is one `Option` test
+   per gate. Included so a regression there cannot hide.
+
+Then a third measurement, for the one case where the hook is *not* cheap:
+reacquiring the GIL costs ~1us when nothing else wants it, but milliseconds when
+another Python thread is running, because the interpreter only yields on its
+switch interval. One long simulation is timed alone and again with a Python
+thread spinning; the reported C/U ratio is machine-speed independent, so it can
+be compared across builds. That ratio is what justifies
+`CANCELLATION_OVERHEAD_DIVISOR` in polypus-sim (reference machine, 14q x 400:
+1.21 with no hook at all, 1.53 on a fixed 25ms cadence, 1.25 once the interval
+adapts to the hook's measured cost).
+
+Usage:
+    # before the change (or on main):
+    python benchmarks/bench_statevector.py --label baseline > /tmp/base.txt
+    # after:
+    python benchmarks/bench_statevector.py --label patched > /tmp/patched.txt
+    diff -y /tmp/base.txt /tmp/patched.txt
+
+Set RAYON_NUM_THREADS=1 to make the numbers core-count independent (the two
+largest cases are above polypus-sim's parallel threshold).
+"""
+
+import argparse
+import math
+import threading
+import time
+
+import polypus
+
+# (qubits, layer repetitions). The first three are the "common case" the
+# acceptance criterion cares about: circuits that finish in well under the
+# checkpoint interval, so an ideal throttle never calls the hook at all. The last
+# two are long enough for the hook to actually fire, once per ~25ms.
+CASES = [
+    (4, 2),
+    (8, 10),
+    (11, 100),
+    (14, 150),
+    (20, 15),
+]
+
+
+def make(n, reps):
+    """A GHZ-ish layer followed by `reps` cx+rx layers (no measurements)."""
+    qc = polypus.Circuit(n)
+    for q in range(n):
+        qc = qc.h(q)
+    for _ in range(reps):
+        for q in range(n - 1):
+            qc = qc.cx(q, q + 1)
+        for q in range(n):
+            qc = qc.rx(q, 0.3)
+    return qc
+
+
+def bench(fn, seconds=0.5, repeat=5):
+    """Best-of-`repeat` mean microseconds per call, each round filling roughly
+    `seconds` of wall clock (a minimum of 3 calls, so the slow cases stay
+    affordable). Best-of, not mean-of, to shed scheduler noise."""
+    best, calls_used = math.inf, 0
+    for _ in range(repeat):
+        # Calibrate the call count from one warm call.
+        t0 = time.perf_counter()
+        fn()
+        single = time.perf_counter() - t0
+        calls = max(3, int(seconds / single)) if single > 0 else 100
+        t0 = time.perf_counter()
+        for _ in range(calls):
+            fn()
+        us = (time.perf_counter() - t0) / calls * 1e6
+        if us < best:
+            best, calls_used = us, calls
+    return best, calls_used
+
+
+def one_run(qc):
+    """Seconds for a single `statevector` call."""
+    t0 = time.perf_counter()
+    polypus.statevector(qc)
+    return time.perf_counter() - t0
+
+
+def with_spinner(fn):
+    """Run `fn` while a Python thread spins a counter loop, so the GIL is
+    genuinely contended for the whole call."""
+    stop = threading.Event()
+
+    def spin():
+        n = 0
+        while not stop.is_set():
+            n += 1
+
+    worker = threading.Thread(target=spin)
+    worker.start()
+    try:
+        return fn()
+    finally:
+        stop.set()
+        worker.join()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", default="", help="tag printed with the results")
+    args = ap.parse_args()
+
+    # Warm up the lazy `polypus_python` import outside every measured window.
+    polypus.statevector(polypus.Circuit(2).h(0))
+    polypus.run_quantum_circuit(
+        polypus.Circuit(2).h(0).measure_all(),
+        shots=16,
+        infrastructure="local",
+        n_qpus=1,
+        backend="polypus",
+    )
+
+    tag = f" [{args.label}]" if args.label else ""
+    print(f"polypus.statevector{tag}")
+    print(f"  {'circuit':>16}  {'gates':>7}  {'us/call':>12}  {'calls':>7}")
+    for n, reps in CASES:
+        qc = make(n, reps)
+        gates = (2 * n - 1) * reps + n
+        us, calls = bench(lambda qc=qc: polypus.statevector(qc))
+        print(f"  {f'{n}q x {reps} reps':>16}  {gates:>7}  {us:>12.3f}  {calls:>7}")
+
+    print(f"\npolypus.run_quantum_circuit, native backend (no hook){tag}")
+    print(f"  {'circuit':>16}  {'gates':>7}  {'us/call':>12}  {'calls':>7}")
+    for n, reps in CASES[:4]:
+        qc = make(n, reps).measure_all()
+        gates = (2 * n - 1) * reps + n + 1
+        us, calls = bench(
+            lambda qc=qc: polypus.run_quantum_circuit(
+                qc, shots=256, infrastructure="local", n_qpus=1, backend="polypus"
+            )
+        )
+        print(f"  {f'{n}q x {reps} reps':>16}  {gates:>7}  {us:>12.3f}  {calls:>7}")
+
+    # The contended case: one long simulation, alone and against a spinning
+    # Python thread. Sized so the run spans many checkpoint intervals -- which is
+    # what the adaptive interval is there for.
+    n, reps = 14, 400
+    qc = make(n, reps)
+    print(f"\npolypus.statevector against a spinning Python thread{tag}")
+    uncontended = min(one_run(qc) for _ in range(3))
+    contended = min(with_spinner(lambda: one_run(qc)) for _ in range(3))
+    print(
+        f"  {n}q x {reps} reps: alone {uncontended * 1e3:.1f}ms, contended "
+        f"{contended * 1e3:.1f}ms, C/U {contended / uncontended:.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/polypus-sim/src/error.rs
+++ b/crates/polypus-sim/src/error.rs
@@ -34,6 +34,12 @@ pub enum SimError {
         /// The qubit that was operated on after being measured.
         qubit: usize,
     },
+    /// The caller asked for the simulation to stop before it finished, through
+    /// the cancellation hook passed to
+    /// [`Simulator::run_cancellable`](crate::Simulator::run_cancellable). The
+    /// partially evolved statevector is discarded: a run that stopped part-way
+    /// through the gate sequence is not a state any circuit describes.
+    Cancelled,
 }
 
 impl fmt::Display for SimError {
@@ -54,6 +60,9 @@ impl fmt::Display for SimError {
                 f,
                 "gate acts on qubit {qubit} after it was measured; Polypus circuits use terminal measurement (contract C-4)"
             ),
+            SimError::Cancelled => {
+                write!(f, "the simulation was cancelled before it completed")
+            }
         }
     }
 }

--- a/crates/polypus-sim/src/lib.rs
+++ b/crates/polypus-sim/src/lib.rs
@@ -37,6 +37,21 @@
 //! above [`MAX_QUBITS`] return [`SimError::TooManyQubits`] instead of
 //! attempting a doomed allocation. Gate kernels are applied in place (no
 //! per-gate allocation), with a diagonal fast path and optional parallelism.
+//!
+//! ## Cancellation
+//!
+//! That ceiling bounds *memory*, not time: a run costs gates × `2^n` and
+//! nothing bounds the gate count, so a circuit far below the ceiling can still
+//! run for minutes. [`Simulator::run_cancellable`] therefore takes an optional
+//! `FnMut() -> bool` that the gate loop polls periodically; returning `true`
+//! abandons the run with [`SimError::Cancelled`]. The hook is deliberately
+//! opaque — this crate never learns *why* the caller wants to stop, which is
+//! what lets a signal-driven caller (`polypus`'s `statevector` checks for a
+//! pending Ctrl+C in it) stay on the far side of the Python boundary. Calls are
+//! throttled on a wall-clock cadence — never per gate, so the frequency does not
+//! depend on how expensive a single gate is, and a fast circuit pays nothing —
+//! and the cadence adapts to the hook's own measured cost, so even a hook that
+//! turns out to take milliseconds cannot eat the run.
 
 #![deny(clippy::all)]
 

--- a/crates/polypus-sim/src/simulator.rs
+++ b/crates/polypus-sim/src/simulator.rs
@@ -6,12 +6,195 @@ use crate::rng::SplitMix64;
 use crate::statevector::Statevector;
 use polypus_circuit::{ConcreteCircuit, GateInstruction};
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 /// Abstraction over simulation backends. A future density-matrix or GPU
 /// backend can implement this same contract.
 pub trait Simulator {
     /// Evolve `|0…0⟩` through `circuit` and return the final state.
     fn run(&self, circuit: &ConcreteCircuit) -> Result<Statevector, SimError>;
+
+    /// Evolve `|0…0⟩` through `circuit`, with the option to stop part-way.
+    ///
+    /// `should_cancel`, when given, is invoked periodically while the circuit is
+    /// being applied; returning `true` abandons the run and yields
+    /// [`SimError::Cancelled`]. The hook is a plain `FnMut() -> bool` precisely
+    /// so this crate needs to know nothing about *why* the caller wants to
+    /// stop — a signal check, a deadline, a user-facing cancel button — which
+    /// keeps `polypus-sim` free of its caller's concerns. Passing `None` is
+    /// exactly [`run`](Self::run).
+    ///
+    /// **"Periodically" is the whole contract.** A hook can cost orders of
+    /// magnitude more than a gate, so an implementation is free to throttle the
+    /// calls (this crate's does, on a wall-clock cadence that adapts to how
+    /// expensive the hook turns out to be); never rely on the hook being called
+    /// once per gate, or a fixed number of times.
+    ///
+    /// The default implementation ignores `should_cancel` and runs to
+    /// completion, so a backend with no cancellation point of its own stays
+    /// correct and simply never returns [`SimError::Cancelled`].
+    ///
+    /// ```
+    /// use polypus_circuit::ParameterizedCircuit;
+    /// use polypus_sim::{Simulator, StatevectorSimulator};
+    ///
+    /// let circuit = ParameterizedCircuit::new(2)
+    ///     .h(0)
+    ///     .cx(0, 1)
+    ///     .assign_parameters(&[])
+    ///     .unwrap();
+    ///
+    /// // A hook that always asks to stop -- and a circuit that finishes anyway.
+    /// // Cancellation is prompt, not immediate: two gates are over long before
+    /// // the first checkpoint comes due, so the hook is never called (and this
+    /// // run never even reads the clock).
+    /// let mut stop = || true;
+    /// let sv = StatevectorSimulator::new()
+    ///     .run_cancellable(&circuit, Some(&mut stop))
+    ///     .unwrap();
+    /// assert_eq!(sv.num_qubits(), 2);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`SimError::Cancelled`] if `should_cancel` returned `true`, otherwise
+    /// the same errors as [`run`](Self::run).
+    fn run_cancellable(
+        &self,
+        circuit: &ConcreteCircuit,
+        _should_cancel: Option<&mut dyn FnMut() -> bool>,
+    ) -> Result<Statevector, SimError> {
+        self.run(circuit)
+    }
+}
+
+/// Wall-clock time that must pass between two calls of a `run_cancellable`
+/// cancellation hook — a floor, see [`CANCELLATION_OVERHEAD_DIVISOR`].
+///
+/// Chosen so the checkpoint is imperceptible as latency: a Ctrl+C is honored
+/// within about a frame.
+const CANCELLATION_CHECK_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Bound on what the hook may cost the run: it is called at most once per
+/// `CANCELLATION_OVERHEAD_DIVISOR` × (its own measured duration), so it can
+/// never take more than ~`1/divisor` of the wall clock.
+///
+/// This is what makes the floor above safe against a hook whose cost the
+/// simulator cannot know. `polypus`'s reacquires the GIL, which takes ~1µs when
+/// nothing else wants it — but *milliseconds* when another Python thread is
+/// running, because the holder only yields on the interpreter's switch interval
+/// (5ms by default). On the fixed 25ms cadence alone that was measurable: a
+/// contended run cost 1.53x its uncontended self, against 1.21x with no hook at
+/// all; deriving the interval from the observed cost brings it back to 1.25x
+/// while leaving the cheap, uncontended case on the 25ms floor. Reproduce with
+/// `benchmarks/bench_statevector.py`'s contended section — the ratio itself
+/// drifts with machine load, so compare the three builds in one sitting rather
+/// than against the figures quoted here.
+const CANCELLATION_OVERHEAD_DIVISOR: u32 = 20;
+
+/// Amplitude updates to perform between two `Instant::now()` reads while a
+/// cancellation hook is installed.
+///
+/// A clock read is cheap (tens of nanoseconds) but not free, so it too is
+/// amortized over several gates. Doing that by *work* rather than by a fixed
+/// gate count is what makes a single constant fit the whole qubit range: a gate
+/// touches `2^n` amplitudes, so from 16 qubits up one gate already costs far
+/// more than a clock read and the stride collapses to 1 (checking every gate,
+/// where a larger stride would only delay the checkpoint), while on a 4-qubit
+/// circuit the read is amortized over 4096 gates.
+const CLOCK_READ_WORK_UNITS: usize = 1 << 16;
+
+/// Throttled front-end for a `run_cancellable` cancellation hook.
+///
+/// The state a throttle needs only exists when there *is* a hook, so it lives
+/// behind the `Option`: a run without one costs exactly one `Option` test per
+/// gate and nothing else — no clock read, not even at the start.
+struct CancellationCheck<'a>(Option<Throttle<'a>>);
+
+/// A hook plus the two nested throttles that decide when to call it: `stride`
+/// gates between clock reads, `interval` between calls.
+struct Throttle<'a> {
+    /// The caller's hook. `true` means "stop applying gates".
+    hook: &'a mut dyn FnMut() -> bool,
+    /// Gates to apply between two clock reads; at least 1.
+    stride: usize,
+    /// Gates left before the next clock read.
+    countdown: usize,
+    /// When the hook was last called, or when the clock was first read.
+    /// `None` until then — a circuit shorter than `stride` gates never reads the
+    /// clock at all, so a fast run pays nothing for being cancellable.
+    last_check: Option<Instant>,
+    /// Wall clock to leave between hook calls: [`CANCELLATION_CHECK_INTERVAL`]
+    /// until the hook has been called once, then whatever
+    /// [`CANCELLATION_OVERHEAD_DIVISOR`] allows given its measured cost.
+    interval: Duration,
+}
+
+impl<'a> CancellationCheck<'a> {
+    /// A check for a `num_qubits`-wide run driving `hook`.
+    fn new(hook: Option<&'a mut dyn FnMut() -> bool>, num_qubits: usize) -> Self {
+        CancellationCheck(hook.map(|hook| {
+            // `min(16)` keeps the shift in range for any qubit count; the result
+            // has already saturated at the `max(1)` floor by then.
+            let stride = (CLOCK_READ_WORK_UNITS >> num_qubits.min(16)).max(1);
+            Throttle {
+                hook,
+                stride,
+                countdown: stride,
+                last_check: None,
+                interval: CANCELLATION_CHECK_INTERVAL,
+            }
+        }))
+    }
+
+    /// Whether the caller has asked to stop. Called once per gate — all the
+    /// throttling lives in [`Throttle::poll`].
+    fn cancelled(&mut self) -> bool {
+        match &mut self.0 {
+            Some(throttle) => throttle.poll(),
+            None => false,
+        }
+    }
+}
+
+impl Throttle<'_> {
+    /// One gate's worth of throttling: returns the hook's answer when it is due
+    /// to be called, and `false` (without calling it) the rest of the time.
+    fn poll(&mut self) -> bool {
+        self.countdown -= 1;
+        if self.countdown > 0 {
+            return false;
+        }
+        self.countdown = self.stride;
+        let now = Instant::now();
+        match self.last_check {
+            // First clock read of the run. Start the interval here rather than
+            // at the run's start: until the gate count justifies looking at the
+            // clock, there is nothing to time.
+            None => {
+                self.last_check = Some(now);
+                return false;
+            }
+            Some(last) => {
+                if now.saturating_duration_since(last) < self.interval {
+                    return false;
+                }
+            }
+        }
+        let stop = (self.hook)();
+        // Time the call and re-derive the interval from it, so an expensive hook
+        // is simply called less often instead of eating the run. This second
+        // clock read costs nothing: it happens once per hook call, not per gate.
+        let done = Instant::now();
+        self.interval = CANCELLATION_CHECK_INTERVAL.max(
+            done.saturating_duration_since(now)
+                .saturating_mul(CANCELLATION_OVERHEAD_DIVISOR),
+        );
+        // Measure the next interval from *after* the call, so the hook's own
+        // duration is never counted as part of it.
+        self.last_check = Some(done);
+        stop
+    }
 }
 
 /// Dense statevector backend.
@@ -122,6 +305,17 @@ pub fn sample_projected(
 
 impl Simulator for StatevectorSimulator {
     fn run(&self, circuit: &ConcreteCircuit) -> Result<Statevector, SimError> {
+        // One gate loop serves both entry points: an uncancellable run *is* a
+        // cancellable one with no hook, and pays one `Option` test per gate for
+        // it (see `CancellationCheck::cancelled`).
+        self.run_cancellable(circuit, None)
+    }
+
+    fn run_cancellable(
+        &self,
+        circuit: &ConcreteCircuit,
+        should_cancel: Option<&mut dyn FnMut() -> bool>,
+    ) -> Result<Statevector, SimError> {
         if circuit.num_qubits > self.max_qubits {
             return Err(SimError::TooManyQubits {
                 requested: circuit.num_qubits,
@@ -152,7 +346,20 @@ impl Simulator for StatevectorSimulator {
         );
         let mut sv = Statevector::new(circuit.num_qubits)?;
         sv.set_parallel_threshold(self.parallel_threshold);
-        for gate in &circuit.gates {
+        // `Statevector::new`'s `2^n` allocation above is deliberately *not* a
+        // cancellation point: near the qubit ceiling it dominates the run, but
+        // it is one `vec![]` with nothing to interleave a check into. What the
+        // hook covers is the gate sequence — whose cost (gates x `2^n`) is
+        // unbounded, where the allocation's is capped by `max_qubits`.
+        let mut cancellation = CancellationCheck::new(should_cancel, circuit.num_qubits);
+        for (applied, gate) in circuit.gates.iter().enumerate() {
+            if cancellation.cancelled() {
+                log::debug!(
+                    "simulation cancelled by the caller after {applied} of {} gate(s)",
+                    circuit.gates.len()
+                );
+                return Err(SimError::Cancelled);
+            }
             sv.apply(gate)?;
         }
         Ok(sv)

--- a/crates/polypus-sim/tests/cancellation.rs
+++ b/crates/polypus-sim/tests/cancellation.rs
@@ -1,0 +1,148 @@
+//! Mid-run cancellation (issue #110): the hook passed to
+//! [`Simulator::run_cancellable`] stops the gate loop, is polled until it says
+//! stop, is throttled far below the gate count, and leaves a run it does not
+//! cancel byte-identical to [`Simulator::run`].
+//!
+//! **Timing-independent by construction.** Every long circuit here ends in a
+//! rotation whose angle is `NaN`, which `Statevector::apply` rejects with
+//! [`SimError::NonFiniteAmplitude`]. The returned *error variant alone* therefore
+//! says whether the loop reached the end of the circuit — `Cancelled` proves it
+//! stopped early, `NonFiniteAmplitude` proves it did not — so nothing here
+//! asserts on wall-clock time, which would be flaky on a loaded CI runner and
+//! would have to be re-tuned for the ~40x gap between the debug and release
+//! profiles. What the circuits *are* sized for is duration: long enough that the
+//! throttle's checkpoints come due while the loop is still running, with a wide
+//! enough margin to hold on a much faster machine (the sizes below are ~10x and
+//! ~30x the checkpoint interval in release, ~40x that in debug).
+
+use polypus_circuit::{ConcreteCircuit, GateInstruction as G, GateParam::Fixed};
+use polypus_sim::{SimError, Simulator, StatevectorSimulator, MAX_QUBITS};
+
+/// Qubits for the long circuits. High enough that a single gate is expensive
+/// (16k amplitudes), so a modest gate count buys a run of a few hundred
+/// milliseconds.
+const N: usize = 14;
+
+/// Gates for a circuit that must outlive several checkpoints (~0.8s in release,
+/// far longer in debug — it is never run to completion).
+const LONG: usize = 60_000;
+
+/// Gates for a circuit that must outlive *at least one* checkpoint and then be
+/// run to completion, so it is kept as short as that allows.
+const SHORT: usize = 3_000;
+
+/// A simulator pinned to the sequential kernels (`parallel_threshold` above any
+/// qubit count used here), so these tests take the same path — and last the same
+/// time — whether or not the `parallel` feature is enabled, and regardless of
+/// the runner's core count.
+fn sequential_sim() -> StatevectorSimulator {
+    StatevectorSimulator {
+        max_qubits: MAX_QUBITS,
+        parallel_threshold: MAX_QUBITS + 1,
+    }
+}
+
+/// `gates` cheap rotations, then one rotation by `NaN` — see the module docs for
+/// why the last gate is poisoned.
+fn nan_terminated_circuit(gates: usize) -> ConcreteCircuit {
+    let mut instructions = Vec::with_capacity(gates + 1);
+    for i in 0..gates {
+        instructions.push(G::Rx {
+            qubit: i % N,
+            theta: Fixed(0.1),
+        });
+    }
+    instructions.push(G::Rx {
+        qubit: 0,
+        theta: Fixed(f64::NAN),
+    });
+    ConcreteCircuit {
+        num_qubits: N,
+        gates: instructions,
+    }
+}
+
+#[test]
+fn a_hook_that_asks_to_stop_ends_the_run_early() {
+    let circuit = nan_terminated_circuit(LONG);
+    let mut calls = 0usize;
+    let err = {
+        let mut cancel = || {
+            calls += 1;
+            true
+        };
+        sequential_sim()
+            .run_cancellable(&circuit, Some(&mut cancel))
+            .unwrap_err()
+    };
+    // `Cancelled`, not `NonFiniteAmplitude`: the loop never reached the last
+    // gate, i.e. the run really was abandoned mid-circuit.
+    assert_eq!(err, SimError::Cancelled);
+    // And it stopped at the *first* "yes" rather than polling on.
+    assert_eq!(calls, 1);
+}
+
+#[test]
+fn the_hook_is_polled_until_it_asks_to_stop() {
+    let circuit = nan_terminated_circuit(LONG);
+    let mut calls = 0usize;
+    let err = {
+        let mut cancel = || {
+            calls += 1;
+            calls >= 3
+        };
+        sequential_sim()
+            .run_cancellable(&circuit, Some(&mut cancel))
+            .unwrap_err()
+    };
+    assert_eq!(err, SimError::Cancelled);
+    assert_eq!(calls, 3);
+}
+
+#[test]
+fn a_hook_that_never_cancels_lets_the_run_finish() {
+    let circuit = nan_terminated_circuit(SHORT);
+    let mut calls = 0usize;
+    let err = {
+        let mut never = || {
+            calls += 1;
+            false
+        };
+        sequential_sim()
+            .run_cancellable(&circuit, Some(&mut never))
+            .unwrap_err()
+    };
+    // Reached the poisoned final gate: a hook answering "no" must not cut the
+    // circuit short.
+    assert_eq!(err, SimError::NonFiniteAmplitude);
+    // The checkpoints did fire (otherwise the test above proves nothing) …
+    assert!(calls >= 1, "the hook was never polled");
+    // … but nowhere near once per gate: that is the throttle doing its job, and
+    // the whole reason an expensive hook (the `polypus` crate's reacquires the
+    // GIL) cannot slow a simulation down.
+    assert!(
+        calls < SHORT / 10,
+        "hook polled {calls} times for {SHORT} gates — the throttle is not working"
+    );
+}
+
+#[test]
+fn no_hook_is_exactly_run() {
+    let circuit = ConcreteCircuit {
+        num_qubits: 3,
+        gates: vec![
+            G::H(0),
+            G::Cx(0, 1),
+            G::Rx {
+                qubit: 2,
+                theta: Fixed(0.7),
+            },
+        ],
+    };
+    let sim = sequential_sim();
+    let with_none = sim.run_cancellable(&circuit, None).unwrap();
+    let plain = sim.run(&circuit).unwrap();
+    // Bit-identical, not merely close: `run` is defined as `run_cancellable`
+    // with no hook, so the two share one gate loop.
+    assert_eq!(with_none.amplitudes(), plain.amplitudes());
+}

--- a/crates/polypus/src/bindings/circuit.rs
+++ b/crates/polypus/src/bindings/circuit.rs
@@ -6,7 +6,7 @@
 
 use numpy::{IntoPyArray, PyArray1};
 use polypus_circuit::{CircuitError, GateInstruction, GateParam, ParameterizedCircuit};
-use polypus_sim::{Simulator, StatevectorSimulator};
+use polypus_sim::{SimError, Simulator, StatevectorSimulator};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -122,6 +122,18 @@ fn push(mut slf: PyRefMut<'_, Circuit>, gate: GateInstruction) -> PyResult<PyRef
 /// conversion of the result hold the GIL — so other Python threads keep making
 /// progress while it runs (see `docs/ENGINEERING.md` §3).
 ///
+/// **Interruptible.** A `KeyboardInterrupt` takes effect *mid-simulation*
+/// (issue #110): the gate loop calls back into this function at checkpoints at
+/// least ~25ms apart, each of which reacquires the GIL just long enough to
+/// check for a pending signal — and, if one is pending, abandons the run and
+/// raises that original exception verbatim. The throttling lives inside
+/// `polypus-sim` and is what keeps this cheap: a circuit that finishes inside
+/// one interval never calls back at all, the frequency does not depend on how
+/// expensive an individual gate is, and the interval stretches to keep the
+/// callback under ~5% of the run (which matters when another Python thread
+/// holds the GIL and reacquiring it costs milliseconds). What is *not*
+/// interruptible is the `2^n` allocation below, which is a single `vec![]`.
+///
 /// **Qubit ceiling.** A dense statevector needs `2^n` complex amplitudes
 /// (`16 · 2^n` bytes), so the backend refuses circuits with more than
 /// [`polypus_sim::MAX_QUBITS`] qubits (30 ≈ 16 GiB) and raises a `ValueError`
@@ -130,7 +142,10 @@ fn push(mut slf: PyRefMut<'_, Circuit>, gate: GateInstruction) -> PyResult<PyRef
 /// `Circuit::new`): the ceiling belongs to this backend, not to the IR. Note
 /// that what a call near the ceiling spends its time on is *allocating* that
 /// buffer, not handing it to Python: even a gateless 30-qubit circuit costs ~5s
-/// (measured), essentially all of it `Statevector::new`'s 16 GiB `vec![]`.
+/// (measured), essentially all of it `Statevector::new`'s 16 GiB `vec![]`. The
+/// ceiling bounds memory, not wall-clock time — cost scales with gates × `2^n`
+/// and nothing bounds the gate count, which is why the run has to stay
+/// interruptible (see above) rather than relying on being short.
 ///
 /// ```python
 /// import polypus
@@ -149,17 +164,60 @@ pub fn statevector<'py>(
     // The simulation is the expensive, pure-Rust part: release the GIL for it
     // so it cannot stall every other Python thread (docs/ENGINEERING.md §3).
     //
-    // There is still no *mid-run* check: `polypus-sim` has no per-gate hook to
-    // call back into, and adding one would mean signal checks inside that
-    // crate, which must stay Python-free (§2). But the GIL is reacquired here
-    // the moment `run` returns, before the amplitudes are handed to NumPy — so a
-    // Ctrl+C that arrived at any point up to now is honored *before* paying for
-    // that conversion, instead of only once it completes and control returns to
-    // the caller's bytecode.
-    let sv = qc
-        .py()
-        .allow_threads(|| StatevectorSimulator::new().run(&concrete))
-        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    // Cancellation hook: `polypus-sim`'s gate loop calls this closure
+    // periodically (throttled on its side to ≥25ms apart *and* to a small
+    // fraction of the run, so the frequency is decoupled from gate cost and a
+    // fast circuit never pays for it). Reacquiring the GIL from inside
+    // `allow_threads` is safe and re-entrant — the same `Python::with_gil`
+    // guarantee `cunqa.rs` relies on to acquire the GIL from a `Drop` (§9) —
+    // and `check_signals()` here is what turns a pending SIGINT into a
+    // `KeyboardInterrupt` *mid-run*, since releasing the GIL does not by itself
+    // process signals (§3).
+    //
+    // The `PyErr` cannot travel back through `SimError` (`polypus-sim` is
+    // Python-free by design, §2), so it is stashed here and recovered below —
+    // the same problem `OracleErrorSlot` solves for the optimizer oracles, and
+    // the same reason: a generic trait boundary must not downgrade the real
+    // exception. No `Arc<Mutex<...>>` is needed, though: `statevector` is
+    // single-shot, and the hook runs on this very thread (the simulation is
+    // inline in `allow_threads`, not on a worker), so a `&mut` local is enough.
+    // That is also why `check_signals()` is effective at all: it is a no-op off
+    // the main thread, and this closure runs on whichever thread called us.
+    let mut pending: Option<PyErr> = None;
+    let outcome = qc.py().allow_threads(|| {
+        let mut cancelled = || {
+            Python::with_gil(|py| match py.check_signals() {
+                Ok(()) => false,
+                Err(err) => {
+                    pending = Some(err);
+                    true
+                }
+            })
+        };
+        StatevectorSimulator::new().run_cancellable(&concrete, Some(&mut cancelled))
+    });
+    let sv = match outcome {
+        Ok(sv) => sv,
+        // Propagate the *real* pending exception verbatim. Mapping this through
+        // `PyValueError::new_err(e.to_string())` like the variants below would
+        // silently downgrade a `KeyboardInterrupt` into a bogus `ValueError`
+        // (and `check_signals()` cannot be re-run to recover it: raising it
+        // cleared the pending flag).
+        Err(SimError::Cancelled) => {
+            return match pending {
+                Some(err) => Err(err),
+                // Unreachable today — the only hook installed above records a
+                // `PyErr` before it returns `true`. Handled rather than
+                // `unwrap()`ed (§9) so a future cancellation source still
+                // surfaces a typed error instead of a `PanicException`.
+                None => Err(PyValueError::new_err(SimError::Cancelled.to_string())),
+            };
+        }
+        Err(e) => return Err(PyValueError::new_err(e.to_string())),
+    };
+    // A signal that arrived after the last checkpoint (or during the `2^n`
+    // allocation, which has no checkpoint) is still honored here, the moment
+    // the GIL is reacquired and before the amplitudes are handed to NumPy.
     qc.py().check_signals()?;
     // `into_amplitudes` (not `amplitudes().to_vec()`) so the `2^n`-element
     // buffer moves into the array instead of being copied: `sv` is owned here

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -84,19 +84,46 @@ boundary stays out-of-process and explicit; see
   surfaces there as a `KeyboardInterrupt` propagated verbatim through the
   function's `Result`, never swallowed or retyped.
 - `statevector` follows the same rule at a smaller scale: it releases the GIL
-  around the `StatevectorSimulator::run` call (parameter binding stays on the
-  GIL side — it is O(gates) and allocates nothing of size `2^n`), then calls
-  `py.check_signals()` the moment the GIL is reacquired, **before** handing the
-  amplitudes to NumPy — the same
-  "reacquire-then-check-before-building-the-result" boundary
-  `run_quantum_circuit` uses, just with one call instead of a loop. This still
-  isn't *mid-run*: `polypus-sim` has no per-gate hook to check signals against,
-  and adding one would mean signal checks inside that crate, which must stay
-  Python-free (§2). So a Ctrl+C that arrives while the simulation itself is
-  running is only honored once `run` returns — but from there, it fires before
-  the `2^n`-sized array conversion (§4) rather than after, which matters
-  because that conversion's cost scales only with qubit count, independent of
-  how deep or shallow the circuit was.
+  around the `StatevectorSimulator::run_cancellable` call (parameter binding
+  stays on the GIL side — it is O(gates) and allocates nothing of size `2^n`),
+  and calls `py.check_signals()` both *mid-run* and the moment the GIL is
+  reacquired, **before** handing the amplitudes to NumPy — the latter being the
+  same "reacquire-then-check-before-building-the-result" boundary
+  `run_quantum_circuit` uses.
+- The mid-run half is worth spelling out, because it is how a pure-Rust crate
+  stays interruptible without learning about Python (§2). `polypus-sim`'s gate
+  loop takes an `Option<&mut dyn FnMut() -> bool>` and polls it periodically;
+  `true` abandons the run with `SimError::Cancelled`. It knows nothing about
+  *why* — a signal, a deadline, a cancel button all look the same to it. Only
+  `statevector` fills that hook with `Python::with_gil(|py| py.check_signals())`
+  (re-entrant from inside `allow_threads`, the same guarantee `cunqa.rs`'s
+  `Drop` relies on — see §9). Two rules make it work:
+  - **Throttle inside the pure crate, not at the Python boundary.** The hook is
+    called at most once per ~25ms of wall clock (with the clock itself read once
+    per ~64k amplitude updates), so its frequency is decoupled from gate cost —
+    a cheap 1-qubit gate and a 25-qubit gate differ by orders of magnitude — and
+    a circuit that finishes quickly never calls it at all. Interrupt latency is
+    then bounded by a constant instead of by the run's own duration, which
+    matters because `polypus_sim::MAX_QUBITS` bounds a run's *memory*, not its
+    wall-clock time: cost scales with gates × `2^n` and nothing bounds the gate
+    count. The interval is also stretched to a multiple of the hook's *measured*
+    duration, because the simulator cannot know what a hook costs: this one is
+    ~1µs when nothing else wants the GIL and milliseconds when another Python
+    thread holds it (the interpreter only yields on its switch interval), and
+    without that adaptation the latter case measurably slowed a contended run
+    down. Backed by `benchmarks/bench_statevector.py`.
+  - **Recover the real exception at the Python-facing boundary.** `SimError`
+    cannot carry a `PyErr` (§2), so the hook stashes the `PyErr` and
+    `statevector` re-raises *that* verbatim when the run comes back
+    `Cancelled` — never `PyValueError::new_err(e.to_string())`, which would
+    downgrade a `KeyboardInterrupt` into a bogus `ValueError`. Same problem, and
+    the same answer, as `OracleErrorSlot` in
+    `crates/polypus/src/evaluation/mod.rs`; no shared slot is needed here
+    because `statevector` is single-shot and the hook runs on the calling
+    thread. What is *not* interruptible is `Statevector::new`'s `2^n`
+    allocation — one `vec![]` with nowhere to put a checkpoint — which is why
+    the post-run check above stays: near the qubit ceiling that allocation is
+    the whole run.
 - Preserve concurrent execution: candidates that bind/evaluate truly in
   parallel. If you add a path that runs circuits from worker threads, keep
   this guarantee.

--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -1,6 +1,6 @@
 """
 Ctrl+C responsiveness and GIL release during long-running calls
-(issues #36, #73 and #86).
+(issues #36, #73, #86 and #110).
 
 Acceptance criterion: a ``KeyboardInterrupt`` takes effect *promptly* while
 ``polypus.train`` (native backend) or ``polypus.qml.train`` (Qiskit/Aer
@@ -34,13 +34,20 @@ in which a CPU-bound Python thread can be *observed* to make progress, and thus
 prove the GIL was released, even on a 2-core runner.
 
 ``polypus.statevector`` (issue #86) gets the same GIL-release proof at the end
-of this module, plus a SIGINT test of its own. There is still no per-gate
-boundary at which a pending Ctrl+C could be honored *mid-simulation* (the qubit
-ceiling — ``polypus_sim::MAX_QUBITS``, covered in ``test_statevector.py`` —
-bounds its memory, not its wall-clock time), so — as with
-``run_quantum_circuit`` — the interrupt is honored when the run *reaches*
-``py.check_signals()``, i.e. when the simulation completes. See
-``docs/ENGINEERING.md`` §3.
+of this module, plus two SIGINT tests. Unlike ``run_quantum_circuit``, it *is*
+interruptible mid-run (issue #110): ``polypus-sim``'s gate loop polls an
+injected, Python-agnostic cancellation hook, and ``statevector`` supplies one
+that reacquires the GIL and calls ``py.check_signals()``, so a pending Ctrl+C
+stops the simulation part-way through the gate sequence instead of waiting for
+it to finish. This matters because the qubit ceiling
+(``polypus_sim::MAX_QUBITS``, covered in ``test_statevector.py``) bounds a run's
+*memory*, not its wall-clock time: cost scales with gates × ``2^n`` and nothing
+bounds the gate count. The two tests split along that line —
+``test_statevector_responds_to_sigint_mid_simulation`` proves the gate loop
+itself is cut short (by comparing against a completed run of the same circuit),
+while ``test_statevector_responds_to_sigint_promptly`` covers the remaining
+post-run boundary, which is all a run dominated by ``Statevector::new``'s
+``2^n`` allocation can offer. See ``docs/ENGINEERING.md`` §3.
 
 Why both entry points: `train`'s `VqcOracle` and `qml.train`'s `QmlOracle`
 share `run_and_evaluate`, but reach it through different paths — a native,
@@ -219,9 +226,14 @@ def _assert_responds_to_sigint_promptly(
     — they differ only in which entry point/backend the child script exercises
     (and, for run_quantum_circuit, an `env` that pins the sim single-threaded).
     `delay`/`deadline` default to the module-wide `_DELAY_BEFORE_SIGINT_S` /
-    `_INTERRUPT_DEADLINE_S`; the statevector variant overrides `delay` because
-    its whole run lasts about a second (rather than the others' generation/shot
-    budgets), so the SIGINT has to arrive sooner — see its test for why."""
+    `_INTERRUPT_DEADLINE_S`; the statevector variants override `delay` because
+    their whole run lasts a few seconds (rather than the others' generation/shot
+    budgets), so the SIGINT has to arrive sooner — see their tests for why.
+
+    Returns `(elapsed, ready_fields)`: the interrupt latency the child measured
+    itself, and whatever it printed after `READY` on its first line (the mid-run
+    statevector test uses that channel to carry a completed-run baseline it
+    measured in the same process, on the same machine)."""
     delay = _DELAY_BEFORE_SIGINT_S if delay is None else delay
     deadline = _INTERRUPT_DEADLINE_S if deadline is None else deadline
     proc = subprocess.Popen(
@@ -237,7 +249,8 @@ def _assert_responds_to_sigint_promptly(
         if not ready:
             raise AssertionError("child did not start training within the timeout")
         first_line = proc.stdout.readline().strip()
-        assert first_line == "READY", (
+        ready_fields = first_line.split()
+        assert ready_fields[:1] == ["READY"], (
             f"unexpected child startup output {first_line!r}; "
             f"stderr:\n{proc.stderr.read()}"
         )
@@ -270,6 +283,7 @@ def _assert_responds_to_sigint_promptly(
         f"interrupt was honored but not promptly: {elapsed:.2f}s "
         f"(a full run would take far longer)"
     )
+    return elapsed, ready_fields[1:]
 
 
 def test_native_training_responds_to_sigint_promptly():
@@ -606,6 +620,14 @@ def test_statevector_releases_gil_for_other_threads():
 # `KeyboardInterrupt` out of the call itself — never swallowed into a
 # `PanicException`, and never ignored so the call reports a completed run.
 #
+# This is the *post-run* boundary, and since #110 it is no longer the only one:
+# the gate loop is polled mid-run too, which
+# `test_statevector_responds_to_sigint_mid_simulation` below proves. The two
+# tests are complementary rather than redundant, and this one's sizing is exactly
+# why: at 27 qubits the run's cost is `Statevector::new`'s `2^n` allocation — a
+# single `vec![]` with nowhere to put a checkpoint — so this child has *only* the
+# post-run boundary to be caught by, and keeps guarding it.
+#
 # What this test can and cannot pin down. It used to size the child so that the
 # *list* conversion dominated (26 qubits: ~3.8s completed, interrupt honored at
 # ~1.5s with the check in place and ~3.3s without it) and put the deadline
@@ -626,7 +648,10 @@ def test_statevector_releases_gil_for_other_threads():
 # guard sized above the full run, not a discriminator. The `check_signals()` call
 # stays because it is the documented boundary and keeps the interrupt ahead of
 # whatever result-building work may be added later; that part is enforced by
-# review and by ENGINEERING.md §3, no longer by a wall-clock assertion.
+# review and by ENGINEERING.md §3, no longer by a wall-clock assertion. The
+# discriminating-timing role this test lost is now carried by the mid-run test
+# below, which recovers it by comparing against a completed run of its own
+# circuit instead of against a fixed deadline.
 #
 # Sizing: 27 qubits with a *single* gate. The finding that motivated dropping the
 # Hadamard layer is that near the ceiling the run's cost is `Statevector::new`'s
@@ -672,4 +697,88 @@ def test_statevector_responds_to_sigint_promptly():
             "is likely missing, or the GIL is never released)"
         ),
         delay=_SV_DELAY_BEFORE_SIGINT_S,
+    )
+
+
+# Mid-run interruption (issue #110): the SIGINT must cut the *gate loop* short,
+# not merely be honored once the simulation finishes anyway. Since #110,
+# `polypus-sim`'s loop polls a cancellation hook that `statevector` fills with a
+# GIL-reacquiring `py.check_signals()`, and a cancelled run raises the pending
+# `KeyboardInterrupt` verbatim (never the `ValueError` that mapping the new
+# `SimError::Cancelled` through `PyValueError` would have produced, and never a
+# `PanicException`).
+#
+# How this discriminates, where `test_statevector_responds_to_sigint_promptly`
+# above no longer can: the child times a *completed* run of the same circuit
+# before printing READY (which doubles as the warm-up), and the parent asserts
+# the interrupted run came in under `_SV_MID_RUN_MAX_FRACTION` of it. Both
+# numbers come from the same process on the same machine, so the comparison
+# survives any CI speed — a slow runner scales both — where an absolute deadline
+# would only prove the call returned before a hang guard. Without a mid-run
+# checkpoint the ratio is ~1.0 (the interrupt lands when the run ends); with one
+# it is the SIGINT delay plus one ~25ms checkpoint over the full run's duration
+# (measured on the reference machine: 0.31s against 2.75s completed, ratio 0.11,
+# i.e. ~4.5x inside the 0.5 threshold).
+#
+# Sizing, the inverse of the test above: 20 qubits (`2^20` amplitudes = 16 MiB,
+# so `Statevector::new`'s allocation is noise) with 1580 gates, which puts *all*
+# the ~2.8s single-threaded run time in the gate loop — the one place a hook can
+# live. `_SINGLE_THREADED_ENV` keeps that duration core-count independent, as for
+# the run_quantum_circuit children; 20 qubits is above polypus-sim's
+# `parallel_threshold`, so without it the run time would vary with the runner's
+# core count. Building the circuit is free by comparison (<1ms measured), which
+# is what makes the elapsed comparison a statement about simulation alone.
+_SV_MID_RUN_N = 20
+_SV_MID_RUN_REPS = 40
+_SV_MID_RUN_DELAY_BEFORE_SIGINT_S = 0.3
+_SV_MID_RUN_MAX_FRACTION = 0.5
+
+_SV_MID_RUN_CHILD = (
+    r"""
+import sys, time
+import polypus
+"""
+    + _MAKE_CIRCUIT_SRC
+    + r"""
+qc = make(__N__, __REPS__)
+
+# Time a full run of this very circuit: it is both the warm-up (paying the lazy
+# import cost outside the timed window) and the baseline the parent compares the
+# interrupted run against.
+t0 = time.time()
+polypus.statevector(qc)
+completed = time.time() - t0
+
+print(f"READY {completed:.3f}", flush=True)
+start = time.time()
+try:
+    polypus.statevector(qc)
+    print("COMPLETED", flush=True)
+except KeyboardInterrupt:
+    print(f"KEYBOARDINTERRUPT {time.time() - start:.3f}", flush=True)
+except BaseException as exc:  # e.g. a ValueError from a downgraded cancellation
+    print(f"OTHER {type(exc).__name__}", flush=True)
+    sys.exit(1)
+""".replace("__N__", str(_SV_MID_RUN_N)).replace("__REPS__", str(_SV_MID_RUN_REPS))
+)
+
+
+def test_statevector_responds_to_sigint_mid_simulation():
+    elapsed, ready_fields = _assert_responds_to_sigint_promptly(
+        _SV_MID_RUN_CHILD,
+        failure_hint=(
+            "statevector — the simulation was not interrupted mid-run (the "
+            "cancellation hook passed to polypus-sim's gate loop is likely "
+            "missing, never polled, or its check_signals() never reacquires "
+            "the GIL)"
+        ),
+        env=_SINGLE_THREADED_ENV,
+        delay=_SV_MID_RUN_DELAY_BEFORE_SIGINT_S,
+    )
+    completed = float(ready_fields[0])
+    assert elapsed < completed * _SV_MID_RUN_MAX_FRACTION, (
+        f"the KeyboardInterrupt was raised after {elapsed:.2f}s, but a full run "
+        f"of the same circuit takes {completed:.2f}s — the interrupt was honored "
+        f"when the simulation *finished*, not mid-run: the gate loop's "
+        f"cancellation hook is not stopping it"
     )


### PR DESCRIPTION
Closes #110.

## Scope

`polypus-sim` (the cancellation hook) and `polypus`'s `statevector` binding (the
Python-facing half). Nothing else in either crate changes behaviour.

## Collateral files

| File | Why |
|---|---|
| `docs/ENGINEERING.md` | §3 asserted "this still isn't *mid-run*", which this PR makes false. |
| `tests/python/test_interrupt.py` | Module docstring made the same claim; adds the new mid-run test; the helper gained a `READY` payload channel. |
| `benchmarks/bench_statevector.py` (new) | §9 requires performance claims — including a claim of *no* regression — to be backed by `benchmarks/`, and nothing there measured `statevector`. |

## Contracts

None. This touches no seam listed in `docs/CONTRACTS.md` (C-1…C-9): the gate
vocabulary, counts format, terminal-measurement rule, oracle contract and
seeding scheme are all untouched. `SimError::Cancelled` is a new failure mode of
`statevector`, which is not a documented seam.

## The problem

`statevector` released the GIL around `StatevectorSimulator::run` and called
`py.check_signals()` only once it returned — the single checkpoint. A pending
Ctrl+C was honored when the simulation *finished*, never while it was in flight,
because `polypus-sim` had no hook to check signals against and must stay
Python-free (§2). `MAX_QUBITS` bounds **memory, not time**: cost scales with
gates × `2^n` and nothing bounds the gate count, so a circuit well under the
qubit ceiling could run for minutes with no way to cancel it short of killing
the process — unlike `train`, `qml.train` and `run_quantum_circuit`, which all
have per-generation/per-circuit checkpoints.

## Ambiguous requirements, resolved (§10)

**1. A second trait method, not a changed signature.** `Simulator::run` stays
the required method; `run_cancellable(circuit, Option<&mut dyn FnMut() -> bool>)`
is a provided method whose default delegates to `run` (documented as "ignores
the hook, never returns `Cancelled`"). No existing call site changes —
`native.rs`'s `run_and_sample` and `run_shots_distributed`, the `lib.rs`
doctest, and the four Rust test files all keep calling `run`. Threading an
`Option` through the required method would have touched every one of them to
pass `None`, for no gain; this is §9's "simplest solution that meets the
requirements". `StatevectorSimulator` overrides `run_cancellable` and its `run`
delegates to it with `None`, so there is exactly **one** gate loop, not two to
keep in sync.

**2. Wall-clock throttle, adaptive to the hook's measured cost.** Three nested
throttles, all inside `polypus-sim`:

- **Per gate**: one `Option` test. That is the entire cost of the no-hook path.
- **Clock reads**: one `Instant::now()` per ~64k amplitude updates
  (`stride = 65536 >> n`). Amortizing by *work* rather than by a fixed gate
  count is what makes one constant fit the whole qubit range — at 16+ qubits a
  single gate already costs far more than a clock read, so the stride collapses
  to 1, while a 4-qubit circuit amortizes it over 4096 gates. A circuit shorter
  than its stride never reads the clock at all.
- **Hook calls**: at least 25ms apart, *and* at least 20× the hook's own
  measured duration.

That last term is the non-obvious one. The simulator cannot know what a hook
costs, and this one reacquires the GIL: ~1µs uncontended, but **milliseconds**
when another Python thread is running, since the holder only yields on the
interpreter's 5ms switch interval. On a fixed 25ms cadence that was measurable;
deriving the interval from the observed cost bounds the hook at ~5% of the run
whatever it turns out to cost. A pure gate-count throttle was rejected: gate
cost varies by orders of magnitude with qubit count, so no fixed N is right for
both a 4-qubit and a 25-qubit circuit.

## Not swallowing the real exception

`SimError` cannot carry a `PyErr` (§2), so the hook stashes it and `statevector`
re-raises **that** verbatim when the run comes back `Cancelled`. Mapping it
through `PyValueError::new_err(e.to_string())` like the other variants would
silently downgrade a `KeyboardInterrupt` into a bogus `ValueError` — and
`check_signals()` cannot be re-run to recover it, since raising it already
cleared the pending flag. Same problem `OracleErrorSlot` solves for the
optimizer oracles, minus the `Arc<Mutex<…>>`: `statevector` is single-shot and
the hook runs on the calling thread, so a `&mut` local is enough.

The post-run `check_signals()` stays. `Statevector::new`'s `2^n` allocation is
one `vec![]` with nowhere to put a checkpoint, and near the ceiling it *is* the
run.

## Tests

`crates/polypus-sim/tests/cancellation.rs` — 4 tests, no Python runtime (§3's
Python-free Rust suite), and **no timing assertions**: every circuit ends in a
`NaN` rotation, so the returned error variant alone says whether the loop
reached the end (`Cancelled` = stopped early, `NonFiniteAmplitude` = did not).
That covers stopping at the first "yes", polling until the hook says stop, *not*
cutting a run short when it answers "no" (while proving checkpoints did fire and
that they fired ≪ once per gate), and `run_cancellable(…, None)` being
bit-identical to `run`. Runs in 1.6s debug / 0.08s release, and passes with and
without `--features parallel`.

`test_statevector_responds_to_sigint_mid_simulation` — 20 qubits × 1580 gates
under `RAYON_NUM_THREADS=1`, sized so `Statevector::new`'s allocation is noise
(16 MiB) and essentially all of the ~2.8s is the gate loop. The child times a
**completed** run of the same circuit before printing `READY` (doubling as the
warm-up) and the parent asserts the interrupted elapsed is under half of it.
Both numbers come from the same process on the same machine, so it survives any
CI speed — where a fixed deadline only proves the call returned before a hang
guard, which is precisely the discriminating power
`test_statevector_responds_to_sigint_promptly` lost when the amplitudes started
crossing the seam as a NumPy array.

That older test is **reframed, not replaced**: at 27 qubits with one gate the
cost is the allocation, which has no checkpoint, so that child still guards the
post-run boundary and the two are complementary. Its comment block now says so
instead of claiming there is no mid-run check.

## Performance (§9)

New `benchmarks/bench_statevector.py`, plus a same-binary Rust comparison.

**The isolated measurement** — the pre-#110 loop, `run(None)` and the hooked
loop, interleaved with rotated ordering in one process (the only comparison free
of build/thermal drift) — puts all three **within ±2%** at 11/14/20 qubits, in
both sequential and `parallel` builds, with neither the hook nor the `Option`
test systematically ahead.

**Python, paired baseline↔patched runs minutes apart:**

| case | baseline | patched |
|---|---|---|
| `statevector` 4q, 18 gates | 0.645 µs | 0.708 µs |
| `statevector` 8q, 158 gates | 27.87 µs | 28.73 µs |
| `statevector` 11q, 2111 gates | 2773 µs | 2860 µs |
| `run_quantum_circuit` 4q (no hook) | 9.667 µs | 9.668 µs |

Parity from 8 qubits up. The smallest possible call costs **+0.06 µs** of
per-call hook setup — stated rather than rounded away. The 14q case moves ~+9%,
but the *unhooked* path moves ~+5% alongside it and so does a loop that bypasses
the library entirely, so that is recompilation-layout sensitivity in the
rayon-single-thread dispatch, not the checkpoint.

**Contended case** (one long run, alone vs. against a spinning Python thread;
`C/U`, one sitting): **1.21** with no hook, **1.53** on a fixed 25ms cadence,
**1.25** once the interval adapts — i.e. the adaptive term is what makes the
contended case a non-regression.

`test_statevector_releases_gil_for_other_threads` passes with ratio **0.93**
against its 0.2 threshold, so the checkpoints do not starve the counter thread.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace` (29 suites, including the new doctest on
`run_cancellable`) and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace` are all
clean. `pytest tests/python` → 186 passed, 1 skipped.

`tests/python/test_interrupt.py` cannot run on the author's Windows box — its
`select.select` on a pipe raises `OSError: [WinError 10038]` for all six SIGINT
tests, old and new alike, a pre-existing platform limitation unrelated to this
change. Since this PR *is* signal handling, the new child was verified locally
through a `CTRL_BREAK_EVENT` harness (same CPython interrupt path
`PyErr_CheckSignals` reads) instead of waving the file away:

- patched: `KEYBOARDINTERRUPT 0.316s` against a 3.570s completed run → ratio
  **0.089**
- pre-change build, same child: `2.319s` against `2.637s` → ratio **0.879**

So the new test genuinely discriminates mid-run interruption rather than just
observing that a `KeyboardInterrupt` eventually arrives. The real
`pytest tests/python/test_interrupt.py` run is left to CI on Linux.

## Pre-PR checklist (§10)

- [x] PyO3 boundary respected — `polypus-sim` gains no Python dependency; the
      hook is a plain `FnMut() -> bool`
- [x] GIL still released around the computation; the hook only reacquires it at
      throttled checkpoints
- [x] Simulator correctness untouched — no kernel changes; `run_cancellable(…,
      None)` is bit-identical to `run` (tested)
- [x] Deterministic given a seed — cancellation affects only *whether* a run
      completes, never its result
- [x] No new `unsafe`
- [x] No `unwrap`/`expect`/`panic` on the new error path, including the
      defensive "cancelled with no recorded `PyErr`" arm; `saturating_mul` /
      `saturating_duration_since` keep the throttle arithmetic panic-free
- [x] Public items documented (`run_cancellable`, `SimError::Cancelled`), with a
      doctest
- [x] No `docs/CONTRACTS.md` seam touched
- [x] Ambiguous requirements resolved and justified above