### PR TITLE
chore(lint): tune too-many-arguments-threshold instead of per-fn allows

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -8,6 +8,14 @@
 # just to preserve a frozen public API.
 avoid-breaking-exported-api = false
 
+# The PyO3 entry points in `crates/polypus/src/bindings` mirror their Python
+# kwargs one-for-one, so their arity is set by the API they expose (contract C-1
+# for the execution seam), not by design choice -- `qml_train` is the widest at
+# 16. Tune the threshold once here instead of per-function `#[allow(...)]`: 20
+# clears today's signatures with room for a few more kwargs, while still
+# flagging a genuinely runaway parameter list.
+too-many-arguments-threshold = 20
+
 # Set this to your true Minimum Supported Rust Version so clippy won't suggest
 # APIs newer than you support. Pick the highest floor required by your deps
 # (pyo3 0.24, ndarray 0.16, tokio 1, ...). Uncomment and adjust to a version you

--- a/crates/polypus/src/bindings/logging.rs
+++ b/crates/polypus/src/bindings/logging.rs
@@ -145,7 +145,6 @@ fn warn_logger_already_installed(py: Python<'_>) -> PyResult<()> {
     thread_id = false,
     module_path = false,
 ))]
-#[allow(clippy::too_many_arguments)]
 pub fn init_logger(
     py: Python<'_>,
     level: &str,

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -498,9 +498,6 @@ fn extract_bound_circuit(qc: &Bound<'_, PyAny>) -> PyResult<BoundCircuit> {
 /// Returns a [`RunResult`] carrying the counts plus a manifest (`id`,
 /// effective `seed`, `backend`, `infrastructure`) for logging and replay.
 #[pyfunction(signature=(qc, shots, infrastructure, n_qpus=1, nodes=1, cores_per_qpu=2, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
-// Rich FFI entry point mirroring a many-kwarg Python API; same rationale and
-// convention as `train`/`qml_train` below.
-#[allow(clippy::too_many_arguments)]
 pub fn run_quantum_circuit<'py>(
     qc: Bound<'py, PyAny>,
     shots: u32,
@@ -670,7 +667,6 @@ pub fn run_quantum_circuit<'py>(
 ///     )
 /// ```
 #[pyfunction(signature = (qc, method, shots, n_qpus, dimensions, expectation_function, infrastructure, nodes, cores_per_qpu, id, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
-#[allow(clippy::too_many_arguments)]
 pub fn train<'py>(
     qc: Bound<'py, PyAny>,
     method: Bound<'py, PyAny>,
@@ -903,7 +899,6 @@ pub fn train<'py>(
 ///     )
 /// ```
 #[pyfunction(name = "train", signature = (feature_map, ansatz, x_train, method, shots, n_qpus, dimensions, expectation_function, infrastructure, nodes, cores_per_qpu, id, sim_method="automatic", noise_model=None, backend="aer", seed=None))]
-#[allow(clippy::too_many_arguments)]
 pub fn qml_train<'py>(
     feature_map: Bound<'py, PyAny>,
     ansatz: Bound<'py, PyAny>,

--- a/crates/polypus/src/bindings/pso.rs
+++ b/crates/polypus/src/bindings/pso.rs
@@ -30,9 +30,6 @@ pub struct PSO {
 impl PSO {
     #[new]
     #[pyo3(signature = (generations = 100, population_size = 50, bounds = (-std::f64::consts::PI, std::f64::consts::PI), inertia_weight = 0.5, cognitive_weight = 1.0, social_weight = 1.0, tolerance = 0.01, seed = None))]
-    // Constructor mirrors PSO's full hyper-parameter set as Python kwargs; the
-    // added `seed` pushes it one past the lint threshold.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         generations: u32,
         population_size: u32,


### PR DESCRIPTION
## Summary
- Removes the 5 per-function `#[allow(clippy::too_many_arguments)]` attributes in `crates/polypus/src/bindings/` (`run_quantum_circuit`, `train`, `qml_train`, `PSO::new`, `init_logger`) — they hid the lint instead of tuning it, per CONTRIBUTING.md's "Lint policy".
- Adds `too-many-arguments-threshold = 20` to the workspace `clippy.toml`, with headroom above today's widest signature (`qml_train`, 16 params); these entry points mirror their Python kwargs 1:1 (contract C-1), so arity is set by the API, not by design choice.
- Drops two now-orphaned comments that only existed to justify the removed attributes.
- Pure lint-configuration change, no behavior change.

Closes #119

## Test plan
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo clippy -p polypus --features qmio --all-targets -- -D warnings
- [x] cargo test -p polypus (58 tests, 0 failures)
- [x] Sanity-checked the threshold is honored: temporarily set to 15, clippy correctly failed on qml_train (16/15); restored to 20, clean.