### PR TITLE
feat(circuit): add QFT template and native swap gate

### DIFF
--- a/crates/polypus-circuit/src/circuit.rs
+++ b/crates/polypus-circuit/src/circuit.rs
@@ -183,9 +183,9 @@ impl ParameterizedCircuit {
                 let theta = *theta;
                 self.track_param(&theta);
             }
-            GateInstruction::Cx(q0, q1) | GateInstruction::Cz(q0, q1) => {
-                self.check_pair(*q0, *q1)?
-            }
+            GateInstruction::Cx(q0, q1)
+            | GateInstruction::Cz(q0, q1)
+            | GateInstruction::Swap(q0, q1) => self.check_pair(*q0, *q1)?,
             GateInstruction::Rzz { q0, q1, theta } | GateInstruction::Rxx { q0, q1, theta } => {
                 self.check_pair(*q0, *q1)?;
                 Self::check_finite(theta)?;
@@ -344,6 +344,11 @@ impl ParameterizedCircuit {
     /// Controlled-Z with `control` and `target`.
     pub fn cz(self, control: usize, target: usize) -> Self {
         self.push(GateInstruction::Cz(control, target))
+    }
+
+    /// SWAP: exchange the states of qubits `q0` and `q1`.
+    pub fn swap(self, q0: usize, q1: usize) -> Self {
+        self.push(GateInstruction::Swap(q0, q1))
     }
 
     /// ZZ-interaction rotation on `(q0, q1)`.

--- a/crates/polypus-circuit/src/gate.rs
+++ b/crates/polypus-circuit/src/gate.rs
@@ -88,6 +88,8 @@ pub enum GateInstruction {
     Cx(usize, usize),
     /// Controlled-Z: control, target.
     Cz(usize, usize),
+    /// SWAP: exchange the states of two qubits.
+    Swap(usize, usize),
     /// Two-qubit ZZ-interaction rotation, exp(-i θ/2 Z⊗Z).
     Rzz {
         q0: usize,
@@ -164,6 +166,7 @@ impl GateInstruction {
             | GateInstruction::U { qubit: q, .. } => ActsOn::One(*q),
             GateInstruction::Cx(a, b)
             | GateInstruction::Cz(a, b)
+            | GateInstruction::Swap(a, b)
             | GateInstruction::Rzz { q0: a, q1: b, .. }
             | GateInstruction::Rxx { q0: a, q1: b, .. }
             | GateInstruction::Cp { q0: a, q1: b, .. } => ActsOn::Two(*a, *b),

--- a/crates/polypus-circuit/src/lib.rs
+++ b/crates/polypus-circuit/src/lib.rs
@@ -42,6 +42,7 @@ mod gate;
 mod qasm;
 mod qasm_import;
 mod qir;
+pub mod templates;
 
 pub use circuit::{ConcreteCircuit, ParameterizedCircuit};
 pub use error::CircuitError;

--- a/crates/polypus-circuit/src/qasm.rs
+++ b/crates/polypus-circuit/src/qasm.rs
@@ -84,6 +84,9 @@ pub(crate) fn write_qasm2(
             GateInstruction::Cz(c, t) => {
                 let _ = writeln!(out, "cz q[{c}],q[{t}];");
             }
+            GateInstruction::Swap(q0, q1) => {
+                let _ = writeln!(out, "swap q[{q0}],q[{q1}];");
+            }
             GateInstruction::Rzz { q0, q1, theta } => {
                 let _ = writeln!(out, "rzz({}) q[{q0}],q[{q1}];", angle(theta)?);
             }

--- a/crates/polypus-circuit/src/qasm_import.rs
+++ b/crates/polypus-circuit/src/qasm_import.rs
@@ -792,12 +792,7 @@ impl Parser {
                     self.check_distinct(a, b, line)?;
                     match name {
                         "cz" => self.push_validated(GateInstruction::Cz(a, b), line)?,
-                        // qelib1.inc: swap a,b = cx a,b; cx b,a; cx a,b
-                        "swap" => {
-                            self.push_validated(GateInstruction::Cx(a, b), line)?;
-                            self.push_validated(GateInstruction::Cx(b, a), line)?;
-                            self.push_validated(GateInstruction::Cx(a, b), line)?;
-                        }
+                        "swap" => self.push_validated(GateInstruction::Swap(a, b), line)?,
                         _ => self.push_validated(GateInstruction::Cx(a, b), line)?,
                     }
                 }

--- a/crates/polypus-circuit/src/qir.rs
+++ b/crates/polypus-circuit/src/qir.rs
@@ -188,6 +188,12 @@ pub(crate) fn write_qir(
             GateInstruction::Rz { qubit, theta } => w.rot(RZ, angle(theta)?, *qubit),
             GateInstruction::Cx(c, t) => w.gate2(CNOT, *c, *t),
             GateInstruction::Cz(c, t) => w.gate2(CZ, *c, *t),
+            // swap a,b = cnot a,b; cnot b,a; cnot a,b (no swap intrinsic in QIR base).
+            GateInstruction::Swap(q0, q1) => {
+                w.gate2(CNOT, *q0, *q1);
+                w.gate2(CNOT, *q1, *q0);
+                w.gate2(CNOT, *q0, *q1);
+            }
             // rzz(θ) = cnot · rz(θ) · cnot
             GateInstruction::Rzz { q0, q1, theta } => {
                 let t = angle(theta)?;

--- a/crates/polypus-circuit/src/templates.rs
+++ b/crates/polypus-circuit/src/templates.rs
@@ -1,0 +1,84 @@
+//! Ready-made circuit templates.
+//!
+//! Each template returns a [`ParameterizedCircuit`] so it stays composable: the
+//! caller can keep chaining gates, append `measure_all`, or export it directly.
+//! Templates add no measurements of their own.
+
+use crate::ParameterizedCircuit;
+use std::f64::consts::PI;
+
+/// Quantum Fourier Transform on `num_qubits` qubits.
+///
+/// Follows the Qiskit `QFT` convention: big-endian, with the trailing
+/// qubit-reversal swaps included. Equivalent to
+/// [`qft_with_options(num_qubits, false, true)`](qft_with_options).
+///
+/// The circuit has no free parameters and no measurements.
+///
+/// ```
+/// use polypus_circuit::templates::qft;
+///
+/// let qasm = qft(3).measure_all().to_qasm2_with_params(&[]).unwrap();
+/// assert!(qasm.contains("swap q[0],q[2];"));
+/// ```
+pub fn qft(num_qubits: usize) -> ParameterizedCircuit {
+    qft_with_options(num_qubits, false, true)
+}
+
+/// QFT with explicit control over inversion and the final swap network.
+///
+/// * `inverse` — build the inverse transform (QFT†) instead of the forward one.
+///   It is the exact adjoint of the forward circuit with the same arguments.
+/// * `swaps` — include the qubit-reversal swaps that reconcile the
+///   big-endian convention with standard output order (appended for the forward
+///   transform, prepended for the inverse). Set `false` when the surrounding
+///   circuit already accounts for bit order.
+///
+/// `num_qubits == 0` yields an empty circuit; `num_qubits == 1` is a single
+/// Hadamard (no controlled phases, no swaps).
+pub fn qft_with_options(num_qubits: usize, inverse: bool, swaps: bool) -> ParameterizedCircuit {
+    let mut qc = ParameterizedCircuit::new(num_qubits);
+    if num_qubits == 0 {
+        return qc;
+    }
+
+    // cp(θ) is symmetric in its two qubits; the controlled-phase angle between
+    // qubits j and k is π / 2^(j-k), negated for the inverse.
+    let sign = if inverse { -1.0 } else { 1.0 };
+    let angle = |j: usize, k: usize| sign * PI / 2f64.powi((j - k) as i32);
+
+    let add_swaps = |mut qc: ParameterizedCircuit| {
+        for i in 0..num_qubits / 2 {
+            qc = qc.swap(i, num_qubits - i - 1);
+        }
+        qc
+    };
+
+    if inverse {
+        // Adjoint of the forward circuit: swaps first, then the rotation block
+        // in reverse (each Hadamard last on its qubit, phases with reversed
+        // sign and ascending target index).
+        if swaps {
+            qc = add_swaps(qc);
+        }
+        for j in 0..num_qubits {
+            for k in 0..j {
+                qc = qc.cp(k, j, angle(j, k));
+            }
+            qc = qc.h(j);
+        }
+    } else {
+        // Forward: Hadamard on the most-significant qubit, then the descending
+        // ladder of controlled phases; the swaps close the circuit.
+        for j in (0..num_qubits).rev() {
+            qc = qc.h(j);
+            for k in (0..j).rev() {
+                qc = qc.cp(k, j, angle(j, k));
+            }
+        }
+        if swaps {
+            qc = add_swaps(qc);
+        }
+    }
+    qc
+}

--- a/crates/polypus-circuit/tests/circuit.rs
+++ b/crates/polypus-circuit/tests/circuit.rs
@@ -43,6 +43,29 @@ fn test_parameterized_circuit_gate_param_basic_creation() {
 }
 
 #[test]
+fn test_parameterized_circuit_swap_builder_and_qasm() {
+    let qc = ParameterizedCircuit::new(3).swap(0, 2);
+
+    assert_eq!(qc.gates.len(), 1);
+    assert_eq!(qc.gates[0], GateInstruction::Swap(0, 2));
+
+    let qasm = qc.to_qasm2_with_params(&[]).unwrap();
+    assert!(qasm.contains("swap q[0],q[2];"));
+}
+
+#[test]
+#[should_panic]
+fn test_parameterized_circuit_swap_same_qubit() {
+    let _qc = ParameterizedCircuit::new(2).swap(1, 1);
+}
+
+#[test]
+#[should_panic]
+fn test_parameterized_circuit_swap_qubit_out_of_range() {
+    let _qc = ParameterizedCircuit::new(2).swap(0, 5);
+}
+
+#[test]
 #[should_panic]
 fn test_parameterized_circuit_gate_basic_qubit_out_of_range() {
     let _qc = ParameterizedCircuit::new(2).y(5);

--- a/crates/polypus-circuit/tests/circuit_qir.rs
+++ b/crates/polypus-circuit/tests/circuit_qir.rs
@@ -60,6 +60,25 @@ fn bell_pair_full_module() {
 }
 
 #[test]
+fn swap_is_decomposed_to_three_cnots() {
+    let ir = ParameterizedCircuit::new(2)
+        .swap(0, 1)
+        .to_qir_with_params(&[])
+        .unwrap();
+
+    let q0 = "%Qubit* null";
+    let q1 = "%Qubit* inttoptr (i64 1 to %Qubit*)";
+    assert_eq!(
+        call_lines(&ir),
+        vec![
+            format!("call void @__quantum__qis__cnot__body({q0}, {q1})"),
+            format!("call void @__quantum__qis__cnot__body({q1}, {q0})"),
+            format!("call void @__quantum__qis__cnot__body({q0}, {q1})"),
+        ]
+    );
+}
+
+#[test]
 fn rzz_is_decomposed_to_cnot_rz_cnot() {
     let ir = ParameterizedCircuit::new(2)
         .rzz(0, 1, 0.5)

--- a/crates/polypus-circuit/tests/qasm_import.rs
+++ b/crates/polypus-circuit/tests/qasm_import.rs
@@ -21,6 +21,7 @@ fn full_vocabulary_circuit() -> ParameterizedCircuit {
         .u(0, 0.1, Param(1), 0.3)
         .cx(0, 1)
         .cz(1, 2)
+        .swap(0, 2)
         .rzz(0, 2, Param(0))
         .rxx(1, 2, 2.0)
         .barrier()
@@ -117,8 +118,8 @@ measure q[2] -> meas[2];
     assert_eq!(qc.num_qubits, 3);
     assert_eq!(qc.num_clbits(), 3);
 
-    // swap → 3 cx; id dropped; explicit full barrier → whole-register form;
-    // 3 contiguous measures → MeasureAll.
+    // swap → native Swap; id dropped; explicit full barrier → whole-register
+    // form; 3 contiguous measures → MeasureAll.
     let expected = [
         GateInstruction::H(0),
         GateInstruction::Rzz {
@@ -142,9 +143,7 @@ measure q[2] -> meas[2];
             phi: GateParam::Fixed(0.0),
             lam: GateParam::Fixed(0.5),
         },
-        GateInstruction::Cx(0, 2),
-        GateInstruction::Cx(2, 0),
-        GateInstruction::Cx(0, 2),
+        GateInstruction::Swap(0, 2),
         GateInstruction::Barrier(Vec::new()),
         GateInstruction::MeasureAll,
     ];

--- a/crates/polypus-circuit/tests/templates.rs
+++ b/crates/polypus-circuit/tests/templates.rs
@@ -1,0 +1,89 @@
+//! Integration tests for polypus-circuit circuit templates.
+
+use polypus_circuit::templates::{qft, qft_with_options};
+use polypus_circuit::{GateInstruction, GateParam};
+use std::f64::consts::PI;
+
+/// Controlled-phase angle used by the QFT between target `j` and control `k`.
+fn cp(k: usize, j: usize, sign: f64) -> GateInstruction {
+    GateInstruction::Cp {
+        q0: k,
+        q1: j,
+        theta: GateParam::Fixed(sign * PI / 2f64.powi((j - k) as i32)),
+    }
+}
+
+#[test]
+fn qft_three_qubits_matches_qiskit_convention() {
+    let qc = qft(3);
+
+    // No free parameters, no measurements: directly exportable / composable.
+    assert_eq!(qc.num_qubits, 3);
+    assert_eq!(qc.num_params, 0);
+    assert_eq!(qc.num_clbits(), 0);
+
+    assert_eq!(
+        qc.gates,
+        vec![
+            GateInstruction::H(2),
+            cp(1, 2, 1.0), // π/2
+            cp(0, 2, 1.0), // π/4
+            GateInstruction::H(1),
+            cp(0, 1, 1.0), // π/2
+            GateInstruction::H(0),
+            GateInstruction::Swap(0, 2),
+        ]
+    );
+}
+
+#[test]
+fn qft_inverse_is_the_adjoint_of_the_forward() {
+    let inv = qft_with_options(3, true, true);
+
+    // Reverse of the forward circuit, phases negated, swaps first.
+    assert_eq!(
+        inv.gates,
+        vec![
+            GateInstruction::Swap(0, 2),
+            GateInstruction::H(0),
+            cp(0, 1, -1.0), // −π/2
+            GateInstruction::H(1),
+            cp(0, 2, -1.0), // −π/4
+            cp(1, 2, -1.0), // −π/2
+            GateInstruction::H(2),
+        ]
+    );
+}
+
+#[test]
+fn qft_without_swaps_omits_the_swap_network() {
+    let qc = qft_with_options(3, false, false);
+    assert!(!qc
+        .gates
+        .iter()
+        .any(|g| matches!(g, GateInstruction::Swap(..))));
+    // Same rotation block as the default, just without the trailing swap.
+    assert_eq!(qc.gates.len(), 6);
+}
+
+#[test]
+fn qft_single_qubit_is_a_lone_hadamard() {
+    let qc = qft(1);
+    assert_eq!(qc.gates, vec![GateInstruction::H(0)]);
+}
+
+#[test]
+fn qft_zero_qubits_is_empty() {
+    let qc = qft(0);
+    assert_eq!(qc.num_qubits, 0);
+    assert!(qc.gates.is_empty());
+}
+
+#[test]
+fn qft_exports_to_qasm() {
+    let qasm = qft(3).measure_all().to_qasm2_with_params(&[]).unwrap();
+    assert!(qasm.contains("h q[2];"));
+    assert!(qasm.contains("cp(1.570796326795) q[1],q[2];"));
+    assert!(qasm.contains("swap q[0],q[2];"));
+    assert!(qasm.contains("measure q -> c;"));
+}

--- a/crates/polypus-sim/src/gates.rs
+++ b/crates/polypus-sim/src/gates.rs
@@ -135,3 +135,10 @@ pub(crate) fn cp_diag(theta: f64) -> [C64; 4] {
     let diag = C64::from_polar(1.0, theta);
     [re(1.0), re(1.0), re(1.0), diag]
 }
+
+/// SWAP, in the basis `00, 01, 10, 11`: exchanges `|01>` and `|10>`, leaves the
+/// symmetric states fixed. Symmetric, so the qubit order does not matter.
+pub(crate) fn swap() -> [[C64; 4]; 4] {
+    let (o, z) = (re(1.0), re(0.0));
+    [[o, z, z, z], [z, z, o, z], [z, o, z, z], [z, z, z, o]]
+}

--- a/crates/polypus-sim/src/statevector.rs
+++ b/crates/polypus-sim/src/statevector.rs
@@ -163,6 +163,9 @@ impl Statevector {
             GateInstruction::Cz(c, t) => {
                 kernels::apply_diagonal_2q(&mut self.data, *c, *t, gates::cz_diag(), par);
             }
+            GateInstruction::Swap(q0, q1) => {
+                kernels::apply_2q(&mut self.data, n, *q0, *q1, &gates::swap(), par);
+            }
             GateInstruction::Rzz { q0, q1, theta } => {
                 let diag = gates::rzz_diag(angle(theta)?);
                 kernels::apply_diagonal_2q(&mut self.data, *q0, *q1, diag, par);

--- a/crates/polypus-sim/tests/gate_matrices.rs
+++ b/crates/polypus-sim/tests/gate_matrices.rs
@@ -176,6 +176,26 @@ fn cx_leaves_target_when_control_clear() {
 }
 
 #[test]
+fn swap_exchanges_the_two_qubits() {
+    // |00> --X(0)--> |q1=0,q0=1> (index 1) --SWAP(0,1)--> |q1=1,q0=0> (index 2)
+    let a = after(2, &[G::X(0)], G::Swap(0, 1));
+    assert!(close(a[2], C64::new(1.0, 0.0)));
+    for (i, amp) in a.iter().enumerate() {
+        if i != 2 {
+            assert!(close(*amp, C64::new(0.0, 0.0)));
+        }
+    }
+}
+
+#[test]
+fn swap_is_symmetric_in_its_qubits() {
+    // Same result regardless of argument order.
+    let a = after(2, &[G::X(0)], G::Swap(0, 1));
+    let b = after(2, &[G::X(0)], G::Swap(1, 0));
+    assert!(a.iter().zip(&b).all(|(x, y)| close(*x, *y)));
+}
+
+#[test]
 fn cz_phases_eleven() {
     // |11> -> -|11>
     let a = after(2, &[G::X(0), G::X(1)], G::Cz(0, 1));

--- a/crates/polypus/src/bindings/circuit.rs
+++ b/crates/polypus/src/bindings/circuit.rs
@@ -246,8 +246,8 @@ impl Circuit {
     /// Import an OpenQASM 2.0 program (inverse of [`to_qasm2`](Circuit::to_qasm2)).
     ///
     /// Accepts the QASM this class exports plus Qiskit's `qasm2.dumps` output
-    /// (`u`/`p`/`u1`/`u2` are canonicalised to `u3`, `swap` to 3×`cx`, `id` is
-    /// dropped; multiple registers are flattened in declaration order). The
+    /// (`u`/`p`/`u1`/`u2` are canonicalised to `u3`, `id` is dropped; multiple
+    /// registers are flattened in declaration order). The
     /// result is fully concrete (`num_params == 0`); builder methods can keep
     /// extending it.
     ///
@@ -370,6 +370,11 @@ impl Circuit {
 
     fn cz(slf: PyRefMut<'_, Self>, control: usize, target: usize) -> PyResult<PyRefMut<'_, Self>> {
         push(slf, GateInstruction::Cz(control, target))
+    }
+
+    /// SWAP: exchange the states of qubits `q0` and `q1`.
+    fn swap(slf: PyRefMut<'_, Self>, q0: usize, q1: usize) -> PyResult<PyRefMut<'_, Self>> {
+        push(slf, GateInstruction::Swap(q0, q1))
     }
 
     fn rzz(
@@ -501,5 +506,30 @@ impl Circuit {
             self.inner.num_params,
             self.inner.gates.len()
         )
+    }
+}
+
+/// Quantum Fourier Transform on `num_qubits` qubits, as a `polypus.Circuit`.
+///
+/// Follows the Qiskit `QFT` convention (big-endian, trailing qubit-reversal
+/// swaps). The returned circuit has no free parameters and no measurements, so
+/// it composes like any hand-built circuit — keep chaining gates, add
+/// `measure_all()`, or run it directly.
+///
+/// * `inverse` — build the inverse transform (QFT†), the exact adjoint of the
+///   forward circuit with the same arguments.
+/// * `swaps` — include the qubit-reversal swaps (default `True`); set
+///   `False` when the surrounding circuit already handles bit order.
+///
+/// ```python
+/// import polypus
+/// qft = polypus.circuits.templates.qft(4)
+/// counts = polypus.run_quantum_circuit(qft.measure_all(), shots=1024)
+/// ```
+#[pyfunction]
+#[pyo3(signature = (num_qubits, inverse = false, swaps = true))]
+pub fn qft(num_qubits: usize, inverse: bool, swaps: bool) -> Circuit {
+    Circuit {
+        inner: polypus_circuit::templates::qft_with_options(num_qubits, inverse, swaps),
     }
 }

--- a/crates/polypus/src/bindings/mod.rs
+++ b/crates/polypus/src/bindings/mod.rs
@@ -11,7 +11,7 @@ pub mod observable;
 pub mod pso;
 pub mod qng;
 
-use circuit::{statevector, Circuit, Param};
+use circuit::{qft, statevector, Circuit, Param};
 use de::DE;
 use logging::init_logger;
 use observable::{CachedCost, Ising, Qubo};
@@ -1223,6 +1223,18 @@ pub fn polypus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register in sys.modules so `import polypus.qml` also works
     let sys = PyModule::import(py, "sys")?;
     sys.getattr("modules")?.set_item("polypus.qml", &qml)?;
+
+    // circuits.templates subpackage — exposes polypus.circuits.templates.qft()
+    let circuits = PyModule::new(py, "polypus.circuits")?;
+    let templates = PyModule::new(py, "polypus.circuits.templates")?;
+    templates.add_function(wrap_pyfunction!(qft, &templates)?)?;
+    // Attach under short keys (see the qml note above) and mirror both levels
+    // into sys.modules so `import polypus.circuits.templates` also resolves.
+    circuits.add("templates", &templates)?;
+    m.add("circuits", &circuits)?;
+    let modules = sys.getattr("modules")?;
+    modules.set_item("polypus.circuits", &circuits)?;
+    modules.set_item("polypus.circuits.templates", &templates)?;
 
     Ok(())
 }


### PR DESCRIPTION
Add a `templates` module to polypus-circuit exposing `qft(n)` / `qft_with_options(n, inverse, swaps)`, following the Qiskit QFT convention (big-endian, trailing reversal swaps). The template returns a composable ParameterizedCircuit with no free parameters and no measurements.

QFT needs a SWAP, which the gate set lacked, so add it as a first-class gate across the whole stack:
  - IR: GateInstruction::Swap, builder `.swap()`, validation
  - OpenQASM 2.0: native `swap` emission; the importer now produces Swap instead of decomposing to 3x cx (byte-stable round-trip)
  - QIR: decomposed to 3 CNOTs (no swap intrinsic in the base profile)
  - statevector simulator: 4x4 swap kernel
  - Python: `Circuit.swap()` and `polypus.circuits.templates.qft(...)`

QFT statevector verified identical to Qiskit's QFT for n=1..4.