### PR TITLE
fix(tests): give native SIGINT child DE run enough patience to stay unbounded

### DIFF
--- a/tests/python/test_interrupt.py
+++ b/tests/python/test_interrupt.py
@@ -123,6 +123,12 @@ _INTERRUPT_DEADLINE_S = 5.0  # hard ceiling; real value <1s, full run far longer
 # wind-down (the optimizer's own per-generation bookkeeping, with evaluation
 # short-circuited) stays in the millisecond range. Ctrl+C is captured within
 # one generation; what follows is negligible.
+#
+# This landscape is degenerate too (a fixed circuit with no training data;
+# only 4 of the 16 qubits carry a trainable rotation), so the fitness plateaus
+# and DE's default `patience=20` early-stops it in well under a second — same
+# hazard as `_QML_CHILD` below. `patience` is set far above `generations` so
+# only the interrupt (never convergence) can end the run.
 _NATIVE_CHILD = r"""
 import sys, time
 import polypus
@@ -151,7 +157,9 @@ start = time.time()
 try:
     polypus.train(
         qc,
-        polypus.DE(generations=1500, population_size=8, tolerance=1e-12),
+        polypus.DE(
+            generations=1500, population_size=8, tolerance=1e-12, patience=3000
+        ),
         shots=1024,
         n_qpus=1,
         dimensions=4,


### PR DESCRIPTION
polypus.DE's default patience=20 early-stops the fixed, data-free 16-qubit landscape in ~50-110 generations (0.3-0.6s) instead of running the intended "effectively unbounded" 1500-generation budget, racing the fixed 0.5s delay before SIGINT and making the test intermittently see COMPLETED instead of KeyboardInterrupt. Mirror the patience override _QML_CHILD already uses for the same convergence hazard.